### PR TITLE
macOS keychain support

### DIFF
--- a/.changeset/add-1password-key-provider.md
+++ b/.changeset/add-1password-key-provider.md
@@ -3,30 +3,35 @@
 '@attest-it/cli': minor
 ---
 
-Add 1Password key provider for secure private key storage
+Add 1Password and macOS Keychain key providers for secure private key storage
 
-This release introduces support for storing private signing keys in 1Password, providing a more secure alternative to filesystem storage. Keys are retrieved on-demand via the `op` CLI with Touch ID authentication on macOS.
+This release introduces support for storing private signing keys in 1Password or macOS Keychain, providing more secure alternatives to filesystem storage. Keys are retrieved on-demand with biometric authentication (Touch ID) when available.
 
 **New Features:**
 
 - **KeyProvider abstraction**: Extensible interface for pluggable key storage backends
-- **1Password provider**: Store and retrieve private keys from 1Password vaults
-- **Interactive keygen**: New interactive mode in `keygen` command for selecting storage provider, 1Password account, vault, and item name
+- **1Password provider**: Store and retrieve private keys from 1Password vaults via the `op` CLI
+- **macOS Keychain provider**: Store and retrieve private keys from the macOS login keychain
+- **Interactive keygen**: New interactive mode in `keygen` command for selecting storage provider and configuration
 - **Backward compatible**: Existing filesystem-based key storage continues to work unchanged
 
 **Usage:**
 
 ```bash
-# Interactive key generation (auto-detects 1Password CLI)
+# Interactive key generation (auto-detects available providers)
 attest-it keygen
 
 # Non-interactive with 1Password
 attest-it keygen --provider 1password --vault Private --item-name my-signing-key
+
+# Non-interactive with macOS Keychain
+attest-it keygen --provider macos-keychain --item-name my-signing-key
 ```
 
 **Configuration:**
 
 ```yaml
+# 1Password
 settings:
   publicKeyPath: .attest-it/pubkey.pem
   keyProvider:
@@ -34,10 +39,19 @@ settings:
     options:
       vault: Private
       itemName: attest-it-private-key
-      account: user@example.com # optional, for multi-account setups
+      account: user@example.com  # optional, for multi-account setups
+
+# macOS Keychain
+settings:
+  publicKeyPath: .attest-it/pubkey.pem
+  keyProvider:
+    type: macos-keychain
+    options:
+      itemName: attest-it-private-key
 ```
 
 **Requirements:**
 
-- 1Password CLI (`op`) must be installed and authenticated
+- 1Password: `op` CLI must be installed and authenticated
+- macOS Keychain: Only available on macOS (`process.platform === 'darwin'`)
 - Touch ID or password authentication when signing

--- a/MANUAL_TESTS.md
+++ b/MANUAL_TESTS.md
@@ -5,12 +5,14 @@ This document describes manual testing procedures for key provider integrations 
 ## Prerequisites
 
 ### For 1Password Testing
+
 - [ ] 1Password CLI (`op`) installed: `brew install --cask 1password-cli`
 - [ ] 1Password desktop app installed and running
 - [ ] CLI integration enabled in 1Password settings
 - [ ] Signed in to at least one 1Password account
 
 ### For macOS Keychain Testing
+
 - [ ] Running on macOS
 - [ ] Access to the login keychain
 
@@ -21,16 +23,19 @@ This document describes manual testing procedures for key provider integrations 
 ### Test 1: Detect 1Password CLI Installation
 
 **Steps:**
+
 1. Run `attest-it keygen` in a test project
 2. Verify that "1Password" appears as a storage option
 
 **Expected Result:**
+
 - 1Password should be listed if `op --version` succeeds
 - If not installed, only "Local Filesystem" should appear
 
 ### Test 2: Interactive Key Generation with 1Password
 
 **Steps:**
+
 1. Create a test project with a basic `.attest-it/config.yaml`
 2. Run `attest-it keygen`
 3. Select "1Password" as the storage provider
@@ -40,12 +45,14 @@ This document describes manual testing procedures for key provider integrations 
 7. Verify Touch ID/password prompt appears
 
 **Expected Result:**
+
 - Public key created at `.attest-it/pubkey.pem`
 - Private key stored in 1Password vault as a document
 - Config updated with `keyProvider` settings
 - No private key file on disk
 
 **Verification:**
+
 ```bash
 # Verify public key exists
 ls -la .attest-it/pubkey.pem
@@ -60,6 +67,7 @@ op document get "attest-it-test-key" --vault <your-vault>
 ### Test 3: Non-Interactive Key Generation
 
 **Steps:**
+
 ```bash
 attest-it keygen \
   --provider 1password \
@@ -70,6 +78,7 @@ attest-it keygen \
 ```
 
 **Expected Result:**
+
 - Key generation completes without prompts
 - Touch ID/password prompt for 1Password access
 - Public key created, private key in 1Password
@@ -77,17 +86,20 @@ attest-it keygen \
 ### Test 4: Signing with 1Password Provider
 
 **Steps:**
+
 1. Set up a test project with 1Password key provider configured
 2. Create a simple test suite in config
 3. Run `attest-it run --suite <suite-name> --yes`
 
 **Expected Result:**
+
 - Touch ID/password prompt appears when accessing private key
 - Test runs successfully
 - Attestation created and signed
 - Signature verification passes
 
 **Verification:**
+
 ```bash
 attest-it verify --suite <suite-name>
 ```
@@ -95,10 +107,12 @@ attest-it verify --suite <suite-name>
 ### Test 5: Key Not Found Error
 
 **Steps:**
+
 1. Configure a non-existent key reference in config
 2. Run `attest-it run --suite <suite-name>`
 
 **Expected Result:**
+
 - Clear error message: `Key not found in 1Password: "<key-name>" (vault: <vault>)`
 - No crash or cryptic error
 
@@ -109,26 +123,31 @@ attest-it verify --suite <suite-name>
 ### Test 1: Platform Detection
 
 **Steps:**
+
 1. Run on macOS: `attest-it keygen` should show "macOS Keychain" option
 2. Run on Linux: "macOS Keychain" should NOT appear
 
 **Expected Result:**
+
 - Option only available on macOS (`process.platform === 'darwin'`)
 
 ### Test 2: Interactive Key Generation with Keychain
 
 **Steps:**
+
 1. Create a test project
 2. Run `attest-it keygen`
 3. Select "macOS Keychain" as the storage provider
 4. Enter an item name (e.g., "attest-it-test-key")
 
 **Expected Result:**
+
 - Public key created at `.attest-it/pubkey.pem`
 - Private key stored in login keychain
 - May prompt for keychain access permission
 
 **Verification:**
+
 ```bash
 # Verify key exists in keychain
 security find-generic-password -a "attest-it" -s "attest-it-test-key"
@@ -137,6 +156,7 @@ security find-generic-password -a "attest-it" -s "attest-it-test-key"
 ### Test 3: Non-Interactive Key Generation
 
 **Steps:**
+
 ```bash
 attest-it keygen \
   --provider macos-keychain \
@@ -146,6 +166,7 @@ attest-it keygen \
 ```
 
 **Expected Result:**
+
 - Key generation completes
 - May prompt for keychain access
 - Public key created, private key in keychain
@@ -153,10 +174,12 @@ attest-it keygen \
 ### Test 4: Signing with Keychain Provider
 
 **Steps:**
+
 1. Configure keychain provider in test project
 2. Run `attest-it run --suite <suite-name> --yes`
 
 **Expected Result:**
+
 - May prompt for keychain access
 - Test runs and attestation created
 - Signature verifies correctly
@@ -164,11 +187,13 @@ attest-it keygen \
 ### Test 5: Key Retrieval and Cleanup
 
 **Steps:**
+
 1. Enable debug logging
 2. Run a signing operation
 3. Check that no temp files remain after completion
 
 **Expected Result:**
+
 - Temp file created during signing
 - Temp file deleted after signing completes
 - No key material left on disk
@@ -178,12 +203,14 @@ attest-it keygen \
 ## Cleanup After Testing
 
 ### Remove 1Password Test Keys
+
 ```bash
 op document delete "attest-it-test-key" --vault <your-vault>
 op document delete "attest-it-cli-test" --vault <your-vault>
 ```
 
 ### Remove Keychain Test Keys
+
 ```bash
 security delete-generic-password -a "attest-it" -s "attest-it-test-key"
 security delete-generic-password -a "attest-it" -s "attest-it-cli-test"

--- a/MANUAL_TESTS.md
+++ b/MANUAL_TESTS.md
@@ -1,0 +1,221 @@
+# Manual Testing Guide for Key Providers
+
+This document describes manual testing procedures for key provider integrations that cannot be fully automated in CI due to their interaction with external systems (1Password, macOS Keychain).
+
+## Prerequisites
+
+### For 1Password Testing
+- [ ] 1Password CLI (`op`) installed: `brew install --cask 1password-cli`
+- [ ] 1Password desktop app installed and running
+- [ ] CLI integration enabled in 1Password settings
+- [ ] Signed in to at least one 1Password account
+
+### For macOS Keychain Testing
+- [ ] Running on macOS
+- [ ] Access to the login keychain
+
+---
+
+## 1Password Key Provider Tests
+
+### Test 1: Detect 1Password CLI Installation
+
+**Steps:**
+1. Run `attest-it keygen` in a test project
+2. Verify that "1Password" appears as a storage option
+
+**Expected Result:**
+- 1Password should be listed if `op --version` succeeds
+- If not installed, only "Local Filesystem" should appear
+
+### Test 2: Interactive Key Generation with 1Password
+
+**Steps:**
+1. Create a test project with a basic `.attest-it/config.yaml`
+2. Run `attest-it keygen`
+3. Select "1Password" as the storage provider
+4. Select an account (if multiple)
+5. Select a vault
+6. Enter an item name (e.g., "attest-it-test-key")
+7. Verify Touch ID/password prompt appears
+
+**Expected Result:**
+- Public key created at `.attest-it/pubkey.pem`
+- Private key stored in 1Password vault as a document
+- Config updated with `keyProvider` settings
+- No private key file on disk
+
+**Verification:**
+```bash
+# Verify public key exists
+ls -la .attest-it/pubkey.pem
+
+# Verify no private key on disk
+ls -la ~/.config/attest-it/private.pem  # Should not exist
+
+# Verify key in 1Password
+op document get "attest-it-test-key" --vault <your-vault>
+```
+
+### Test 3: Non-Interactive Key Generation
+
+**Steps:**
+```bash
+attest-it keygen \
+  --provider 1password \
+  --vault "Private" \
+  --item-name "attest-it-cli-test" \
+  --output .attest-it/pubkey.pem \
+  --force
+```
+
+**Expected Result:**
+- Key generation completes without prompts
+- Touch ID/password prompt for 1Password access
+- Public key created, private key in 1Password
+
+### Test 4: Signing with 1Password Provider
+
+**Steps:**
+1. Set up a test project with 1Password key provider configured
+2. Create a simple test suite in config
+3. Run `attest-it run --suite <suite-name> --yes`
+
+**Expected Result:**
+- Touch ID/password prompt appears when accessing private key
+- Test runs successfully
+- Attestation created and signed
+- Signature verification passes
+
+**Verification:**
+```bash
+attest-it verify --suite <suite-name>
+```
+
+### Test 5: Key Not Found Error
+
+**Steps:**
+1. Configure a non-existent key reference in config
+2. Run `attest-it run --suite <suite-name>`
+
+**Expected Result:**
+- Clear error message: `Key not found in 1Password: "<key-name>" (vault: <vault>)`
+- No crash or cryptic error
+
+---
+
+## macOS Keychain Key Provider Tests
+
+### Test 1: Platform Detection
+
+**Steps:**
+1. Run on macOS: `attest-it keygen` should show "macOS Keychain" option
+2. Run on Linux: "macOS Keychain" should NOT appear
+
+**Expected Result:**
+- Option only available on macOS (`process.platform === 'darwin'`)
+
+### Test 2: Interactive Key Generation with Keychain
+
+**Steps:**
+1. Create a test project
+2. Run `attest-it keygen`
+3. Select "macOS Keychain" as the storage provider
+4. Enter an item name (e.g., "attest-it-test-key")
+
+**Expected Result:**
+- Public key created at `.attest-it/pubkey.pem`
+- Private key stored in login keychain
+- May prompt for keychain access permission
+
+**Verification:**
+```bash
+# Verify key exists in keychain
+security find-generic-password -a "attest-it" -s "attest-it-test-key"
+```
+
+### Test 3: Non-Interactive Key Generation
+
+**Steps:**
+```bash
+attest-it keygen \
+  --provider macos-keychain \
+  --item-name "attest-it-cli-test" \
+  --output .attest-it/pubkey.pem \
+  --force
+```
+
+**Expected Result:**
+- Key generation completes
+- May prompt for keychain access
+- Public key created, private key in keychain
+
+### Test 4: Signing with Keychain Provider
+
+**Steps:**
+1. Configure keychain provider in test project
+2. Run `attest-it run --suite <suite-name> --yes`
+
+**Expected Result:**
+- May prompt for keychain access
+- Test runs and attestation created
+- Signature verifies correctly
+
+### Test 5: Key Retrieval and Cleanup
+
+**Steps:**
+1. Enable debug logging
+2. Run a signing operation
+3. Check that no temp files remain after completion
+
+**Expected Result:**
+- Temp file created during signing
+- Temp file deleted after signing completes
+- No key material left on disk
+
+---
+
+## Cleanup After Testing
+
+### Remove 1Password Test Keys
+```bash
+op document delete "attest-it-test-key" --vault <your-vault>
+op document delete "attest-it-cli-test" --vault <your-vault>
+```
+
+### Remove Keychain Test Keys
+```bash
+security delete-generic-password -a "attest-it" -s "attest-it-test-key"
+security delete-generic-password -a "attest-it" -s "attest-it-cli-test"
+```
+
+---
+
+## When to Re-run Manual Tests
+
+Manual tests should be re-run when:
+
+1. **Code changes** to any of these files:
+   - `packages/core/src/key-provider/one-password-provider.ts`
+   - `packages/core/src/key-provider/macos-keychain-provider.ts`
+   - `packages/cli/src/commands/keygen.ts`
+   - `packages/cli/src/commands/keygen-interactive.tsx`
+
+2. **Dependency updates** affecting:
+   - Node.js version
+   - 1Password CLI version
+   - macOS version
+
+3. **Before releases** that include key provider changes
+
+---
+
+## Reporting Issues
+
+If manual tests fail, please file an issue with:
+
+1. Operating system and version
+2. 1Password CLI version (if applicable): `op --version`
+3. Node.js version: `node --version`
+4. Full error message and stack trace
+5. Steps to reproduce

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,56 @@
+# PR: feat: add 1Password and macOS Keychain key providers
+
+## Summary
+
+This PR adds support for storing private signing keys in 1Password and macOS Keychain, providing more secure alternatives to filesystem storage.
+
+**New Features:**
+
+- **KeyProvider abstraction**: Extensible interface for pluggable key storage backends
+- **1Password provider**: Store and retrieve private keys from 1Password vaults via the `op` CLI
+- **macOS Keychain provider**: Store and retrieve private keys from the macOS login keychain
+- **Interactive keygen**: New interactive mode in `keygen` command for selecting storage provider and configuration
+- **Backward compatible**: Existing filesystem-based key storage continues to work unchanged
+
+## Usage
+
+```bash
+# Interactive key generation (auto-detects available providers)
+attest-it keygen
+
+# Non-interactive with 1Password
+attest-it keygen --provider 1password --vault Private --item-name my-signing-key
+
+# Non-interactive with macOS Keychain
+attest-it keygen --provider macos-keychain --item-name my-signing-key
+```
+
+## Configuration
+
+```yaml
+# 1Password
+settings:
+  publicKeyPath: .attest-it/pubkey.pem
+  keyProvider:
+    type: 1password
+    options:
+      vault: Private
+      itemName: attest-it-private-key
+      account: user@example.com  # optional
+
+# macOS Keychain
+settings:
+  publicKeyPath: .attest-it/pubkey.pem
+  keyProvider:
+    type: macos-keychain
+    options:
+      itemName: attest-it-private-key
+```
+
+## Test plan
+
+- [x] Unit tests for 1Password provider (31 tests)
+- [x] Unit tests for macOS Keychain provider (26 tests)
+- [x] Interactive keygen tests updated
+- [x] Config schema updated
+- [ ] Manual testing per MANUAL_TESTS.md

--- a/packages/cli/src/commands/keygen-interactive.tsx
+++ b/packages/cli/src/commands/keygen-interactive.tsx
@@ -118,14 +118,9 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
         setOpAvailable(false)
       }
 
-      // Check macOS Keychain
-      try {
-        const isAvailable = await MacOSKeychainKeyProvider.isAvailable()
-        setKeychainAvailable(isAvailable)
-      } catch {
-        // macOS Keychain not available
-        setKeychainAvailable(false)
-      }
+      // Check macOS Keychain (synchronous check)
+      const isKeychainAvailable = MacOSKeychainKeyProvider.isAvailable()
+      setKeychainAvailable(isKeychainAvailable)
 
       setStep('select-provider')
     }
@@ -260,8 +255,8 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
         }
 
         onComplete(completionResult)
-      } else if (provider === 'macos-keychain') {
-        // macOS Keychain provider
+      } else {
+        // macOS Keychain provider (provider === 'macos-keychain')
         if (!keychainItemName) {
           throw new Error('Item name is required for macOS Keychain')
         }

--- a/packages/cli/src/commands/keygen-interactive.tsx
+++ b/packages/cli/src/commands/keygen-interactive.tsx
@@ -14,6 +14,7 @@ import { Select, TextInput, Spinner } from '@inkjs/ui'
 import {
   OnePasswordKeyProvider,
   FilesystemKeyProvider,
+  MacOSKeychainKeyProvider,
   getDefaultPrivateKeyPath,
   getDefaultPublicKeyPath,
   type OnePasswordAccount,
@@ -26,7 +27,7 @@ import {
  */
 export interface KeygenResult {
   /** Provider type used */
-  provider: 'filesystem' | '1password'
+  provider: 'filesystem' | '1password' | 'macos-keychain'
   /** Path to the public key file */
   publicKeyPath: string
   /** Reference to the private key (path or 1Password item name) */
@@ -37,7 +38,7 @@ export interface KeygenResult {
   account?: string
   /** For 1Password: vault name */
   vault?: string
-  /** For 1Password: item name */
+  /** For 1Password/macOS Keychain: item name */
   itemName?: string
 }
 
@@ -63,11 +64,12 @@ export interface KeygenInteractiveProps {
  * @internal
  */
 type Step =
-  | 'checking-1password'
+  | 'checking-providers'
   | 'select-provider'
   | 'select-account'
   | 'select-vault'
   | 'enter-item-name'
+  | 'enter-keychain-item-name'
   | 'generating'
   | 'done'
 
@@ -86,20 +88,23 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
   const { onComplete, onError } = props
 
   // State management
-  const [step, setStep] = useState<Step>('checking-1password')
+  const [step, setStep] = useState<Step>('checking-providers')
   const [opAvailable, setOpAvailable] = useState(false)
+  const [keychainAvailable, setKeychainAvailable] = useState(false)
   const [accounts, setAccounts] = useState<OnePasswordAccount[]>([])
   const [vaults, setVaults] = useState<OnePasswordVault[]>([])
   const [_selectedProvider, setSelectedProvider] = useState<
-    'filesystem' | '1password' | undefined
+    'filesystem' | '1password' | 'macos-keychain' | undefined
   >()
   const [selectedAccount, setSelectedAccount] = useState<string | undefined>()
   const [selectedVault, setSelectedVault] = useState<string | undefined>()
   const [itemName, setItemName] = useState('attest-it-private-key')
+  const [keychainItemName, setKeychainItemName] = useState('attest-it-private-key')
 
-  // Check 1Password availability on mount
+  // Check provider availability on mount
   useEffect(() => {
-    const checkOnePassword = async (): Promise<void> => {
+    const checkProviders = async (): Promise<void> => {
+      // Check 1Password
       try {
         const isInstalled = await OnePasswordKeyProvider.isInstalled()
         setOpAvailable(isInstalled)
@@ -109,14 +114,23 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
           setAccounts(accountList)
         }
       } catch {
-        // 1Password not available, continue with filesystem only
+        // 1Password not available
         setOpAvailable(false)
+      }
+
+      // Check macOS Keychain
+      try {
+        const isAvailable = await MacOSKeychainKeyProvider.isAvailable()
+        setKeychainAvailable(isAvailable)
+      } catch {
+        // macOS Keychain not available
+        setKeychainAvailable(false)
       }
 
       setStep('select-provider')
     }
 
-    void checkOnePassword()
+    void checkProviders()
   }, [])
 
   // Fetch vaults when account is selected
@@ -150,6 +164,10 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
       } else {
         setStep('select-account')
       }
+    } else if (value === 'macos-keychain') {
+      setSelectedProvider('macos-keychain')
+      // Move to item name entry for keychain
+      setStep('enter-keychain-item-name')
     }
   }
 
@@ -165,14 +183,22 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
     setStep('enter-item-name')
   }
 
-  // Handle item name submission
+  // Handle item name submission (1Password)
   const handleItemNameSubmit = (value: string): void => {
     setItemName(value)
     void generateKeys('1password')
   }
 
+  // Handle keychain item name submission
+  const handleKeychainItemNameSubmit = (value: string): void => {
+    setKeychainItemName(value)
+    void generateKeys('macos-keychain')
+  }
+
   // Generate the keypair
-  const generateKeys = async (provider: 'filesystem' | '1password'): Promise<void> => {
+  const generateKeys = async (
+    provider: 'filesystem' | '1password' | 'macos-keychain',
+  ): Promise<void> => {
     setStep('generating')
 
     try {
@@ -195,8 +221,8 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
           privateKeyRef: result.privateKeyRef,
           storageDescription: result.storageDescription,
         })
-      } else {
-        // Must be 1password at this point
+      } else if (provider === '1password') {
+        // 1Password provider
         if (!selectedVault || !itemName) {
           throw new Error('Vault and item name are required for 1Password')
         }
@@ -234,6 +260,31 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
         }
 
         onComplete(completionResult)
+      } else if (provider === 'macos-keychain') {
+        // macOS Keychain provider
+        if (!keychainItemName) {
+          throw new Error('Item name is required for macOS Keychain')
+        }
+
+        const keychainProvider = new MacOSKeychainKeyProvider({
+          itemName: keychainItemName,
+        })
+
+        // Build generation options, only including force if defined
+        const genOptions: { publicKeyPath: string; force?: boolean } = { publicKeyPath }
+        if (props.force !== undefined) {
+          genOptions.force = props.force
+        }
+
+        const result = await keychainProvider.generateKeyPair(genOptions)
+
+        onComplete({
+          provider: 'macos-keychain',
+          publicKeyPath: result.publicKeyPath,
+          privateKeyRef: result.privateKeyRef,
+          storageDescription: result.storageDescription,
+          itemName: keychainItemName,
+        })
       }
 
       setStep('done')
@@ -243,12 +294,12 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
   }
 
   // Render different steps
-  if (step === 'checking-1password') {
+  if (step === 'checking-providers') {
     return (
       <Box flexDirection="column">
         <Box flexDirection="row" gap={1}>
           <Spinner />
-          <Text>Checking for 1Password CLI...</Text>
+          <Text>Checking available key storage providers...</Text>
         </Box>
       </Box>
     )
@@ -261,6 +312,13 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
         value: 'filesystem',
       },
     ]
+
+    if (keychainAvailable) {
+      options.push({
+        label: 'macOS Keychain',
+        value: 'macos-keychain',
+      })
+    }
 
     if (opAvailable) {
       options.push({
@@ -326,6 +384,17 @@ export function KeygenInteractive(props: KeygenInteractiveProps): React.ReactEle
         <Text dimColor>(This will be visible in your 1Password vault)</Text>
         <Text dimColor>{''}</Text>
         <TextInput defaultValue={itemName} onSubmit={handleItemNameSubmit} />
+      </Box>
+    )
+  }
+
+  if (step === 'enter-keychain-item-name') {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Enter name for the keychain item:</Text>
+        <Text dimColor>(This will be the service name in your macOS Keychain)</Text>
+        <Text dimColor>{''}</Text>
+        <TextInput defaultValue={keychainItemName} onSubmit={handleKeychainItemNameSubmit} />
       </Box>
     )
   }

--- a/packages/cli/src/commands/keygen.ts
+++ b/packages/cli/src/commands/keygen.ts
@@ -189,8 +189,8 @@ async function runNonInteractiveKeygen(options: KeygenOptions): Promise<void> {
       throw new Error('--item-name is required for macos-keychain provider')
     }
 
-    // Check if macOS Keychain is available
-    const isAvailable = await MacOSKeychainKeyProvider.isAvailable()
+    // Check if macOS Keychain is available (synchronous check)
+    const isAvailable = MacOSKeychainKeyProvider.isAvailable()
     if (!isAvailable) {
       throw new Error('macOS Keychain is not available on this platform')
     }

--- a/packages/cli/src/commands/keygen.ts
+++ b/packages/cli/src/commands/keygen.ts
@@ -7,6 +7,7 @@ import {
   getDefaultPublicKeyPath,
   setKeyPermissions,
   OnePasswordKeyProvider,
+  MacOSKeychainKeyProvider,
 } from '@attest-it/core'
 import { log, success, error, warn, info } from '../utils/output.js'
 import { confirmAction } from '../utils/prompts.js'
@@ -17,9 +18,12 @@ export const keygenCommand = new Command('keygen')
   .description('Generate a new RSA keypair for signing attestations')
   .option('-o, --output <path>', 'Public key output path')
   .option('-p, --private <path>', 'Private key output path (filesystem only)')
-  .option('--provider <type>', 'Key provider: filesystem or 1password (skips interactive)')
+  .option(
+    '--provider <type>',
+    'Key provider: filesystem, 1password, or macos-keychain (skips interactive)',
+  )
   .option('--vault <name>', '1Password vault name')
-  .option('--item-name <name>', '1Password item name')
+  .option('--item-name <name>', '1Password/macOS Keychain item name')
   .option('--account <email>', '1Password account')
   .option('-f, --force', 'Overwrite existing keys')
   .option('--no-interactive', 'Disable interactive mode')
@@ -97,11 +101,21 @@ async function runKeygen(options: KeygenOptions): Promise<void> {
         log(`      vault: ${result.vault ?? ''}`)
         log(`      itemName: ${result.itemName ?? ''}`)
         log('')
+      } else if (result.provider === 'macos-keychain') {
+        log('Add to your .attest-it/config.yaml:')
+        log('')
+        log('settings:')
+        log(`  publicKeyPath: ${result.publicKeyPath}`)
+        log('  keyProvider:')
+        log('    type: macos-keychain')
+        log('    options:')
+        log(`      itemName: ${result.itemName ?? ''}`)
+        log('')
       }
 
       log('Next steps:')
       log(`  1. git add ${result.publicKeyPath}`)
-      if (result.provider === '1password') {
+      if (result.provider === '1password' || result.provider === 'macos-keychain') {
         log('  2. Update .attest-it/config.yaml with keyProvider settings')
       } else {
         log('  2. Update .attest-it/config.yaml publicKeyPath if needed')
@@ -152,6 +166,40 @@ async function runNonInteractiveKeygen(options: KeygenOptions): Promise<void> {
 
     log(`Generating keypair with 1Password storage...`)
     log(`Vault: ${options.vault}`)
+    log(`Item: ${options.itemName}`)
+
+    // Build generation options, only including force if defined
+    const genOptions: { publicKeyPath: string; force?: boolean } = { publicKeyPath: publicPath }
+    if (options.force !== undefined) {
+      genOptions.force = options.force
+    }
+
+    const result = await provider.generateKeyPair(genOptions)
+
+    success('Keypair generated successfully!')
+    log('')
+    log('Private key stored in:')
+    log(`  ${result.storageDescription}`)
+    log('')
+    log('Public key (commit to repo):')
+    log(`  ${result.publicKeyPath}`)
+  } else if (options.provider === 'macos-keychain') {
+    // macOS Keychain provider mode
+    if (!options.itemName) {
+      throw new Error('--item-name is required for macos-keychain provider')
+    }
+
+    // Check if macOS Keychain is available
+    const isAvailable = await MacOSKeychainKeyProvider.isAvailable()
+    if (!isAvailable) {
+      throw new Error('macOS Keychain is not available on this platform')
+    }
+
+    const provider = new MacOSKeychainKeyProvider({
+      itemName: options.itemName,
+    })
+
+    log(`Generating keypair with macOS Keychain storage...`)
     log(`Item: ${options.itemName}`)
 
     // Build generation options, only including force if defined

--- a/packages/cli/test/helpers/fixture-factory.ts
+++ b/packages/cli/test/helpers/fixture-factory.ts
@@ -99,9 +99,12 @@ export async function createProjectFixture(options: ProjectFixtureOptions = {}):
   const attestationsPath = join(project.baseDir, '.attest-it', 'attestations.json')
 
   yamlLines.push('settings:')
-  yamlLines.push(`  privateKeyPath: ${privateKeyPath}`)
   yamlLines.push(`  publicKeyPath: ${publicKeyPath}`)
   yamlLines.push(`  attestationsPath: ${attestationsPath}`)
+  yamlLines.push('  keyProvider:')
+  yamlLines.push('    type: filesystem')
+  yamlLines.push('    options:')
+  yamlLines.push(`      privateKeyPath: ${privateKeyPath}`)
 
   // Add default max age if any suite has one
   const maxAges = suites.map((s) => s.maxAge).filter((age): age is string => age !== undefined)

--- a/packages/cli/test/interactive-cli-integration.test.ts
+++ b/packages/cli/test/interactive-cli-integration.test.ts
@@ -350,6 +350,25 @@ describe('Interactive CLI Integration Tests', () => {
       project = await createAllMissingFixture()
       await setupProject(project)
 
+      // Verify working tree is clean before running (CI stability)
+      const gitStatus = await checkGitStatus(project.baseDir)
+      if (gitStatus !== '') {
+        // If there are uncommitted changes, commit them first
+        // This handles race conditions in CI where files might not be fully synced
+        if (process.env.CI) {
+          console.log(`Unexpected uncommitted changes before run: ${gitStatus}`)
+        }
+        await execa('git', ['add', '.'], { cwd: project.baseDir })
+        await execa('git', ['commit', '-m', 'Sync uncommitted changes', '--allow-empty'], {
+          cwd: project.baseDir,
+        })
+      }
+
+      // Small delay for CI file system stability
+      if (process.env.CI) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+
       // Run a specific suite and attest it (suite-1 from createAllMissingFixture)
       const result = await execa('node', [CLI_PATH, 'run', '--suite', 'suite-1'], {
         cwd: project.baseDir,
@@ -357,6 +376,15 @@ describe('Interactive CLI Integration Tests', () => {
         timeout: 30000, // Increased for CI stability
         input: 'y\n',
       })
+
+      // Debug output for CI failures
+      if (result.exitCode !== 0 && process.env.CI) {
+        console.log(`Test failed with exit code: ${result.exitCode}`)
+        console.log(`stdout: ${result.stdout}`)
+        console.log(`stderr: ${result.stderr}`)
+        const finalStatus = await checkGitStatus(project.baseDir)
+        console.log(`Git status after failure: ${finalStatus}`)
+      }
 
       // Should succeed
       expect(result.exitCode).toBe(0)
@@ -372,7 +400,7 @@ describe('Interactive CLI Integration Tests', () => {
       await execa('git', ['commit', '-m', 'Add attestation', '--allow-empty'], {
         cwd: project.baseDir,
       })
-    })
+    }, 20000)
   })
 
   describe('User workflow: Out-of-date attestations', () => {

--- a/packages/cli/test/keygen-interactive.test.tsx
+++ b/packages/cli/test/keygen-interactive.test.tsx
@@ -22,6 +22,9 @@ vi.mock('@attest-it/core', async () => {
       listAccounts: vi.fn(),
       listVaults: vi.fn(),
     },
+    MacOSKeychainKeyProvider: {
+      isAvailable: vi.fn().mockResolvedValue(false),
+    },
     FilesystemKeyProvider: vi.fn(),
   }
 })
@@ -49,7 +52,7 @@ describe('KeygenInteractive', () => {
         <KeygenInteractive onComplete={vi.fn()} onCancel={vi.fn()} onError={vi.fn()} />,
       )
 
-      expect(lastFrame()).toContain('Checking for 1Password CLI')
+      expect(lastFrame()).toContain('Checking available key storage providers')
     })
 
     it('should show filesystem option when 1Password not installed', async () => {

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -212,6 +212,26 @@ export function loadConfig(configPath?: string): Promise<Config>;
 export function loadConfigSync(configPath?: string): Config;
 
 // @public
+export class MacOSKeychainKeyProvider implements KeyProvider {
+    constructor(options: MacOSKeychainKeyProviderOptions);
+    // (undocumented)
+    readonly displayName = "macOS Keychain";
+    generateKeyPair(options: KeygenProviderOptions): Promise<KeyGenerationResult>;
+    getConfig(): KeyProviderConfig;
+    getPrivateKey(keyRef: string): Promise<KeyRetrievalResult>;
+    static isAvailable(): boolean;
+    isAvailable(): Promise<boolean>;
+    keyExists(keyRef: string): Promise<boolean>;
+    // (undocumented)
+    readonly type = "macos-keychain";
+}
+
+// @public
+export interface MacOSKeychainKeyProviderOptions {
+    itemName: string;
+}
+
+// @public
 export interface OnePasswordAccount {
     account_uuid: string;
     email: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,7 @@ export type { VerifyOptions, VerifyResult } from './verify.js'
 export {
   FilesystemKeyProvider,
   OnePasswordKeyProvider,
+  MacOSKeychainKeyProvider,
   KeyProviderRegistry,
   type KeyProvider,
   type KeyProviderConfig,
@@ -94,5 +95,6 @@ export {
   type OnePasswordKeyProviderOptions,
   type OnePasswordAccount,
   type OnePasswordVault,
+  type MacOSKeychainKeyProviderOptions,
   type KeyProviderFactory,
 } from './key-provider/index.js'

--- a/packages/core/src/key-provider/index.ts
+++ b/packages/core/src/key-provider/index.ts
@@ -30,6 +30,10 @@ export type {
   OnePasswordVault,
 } from './one-password-provider.js'
 
+// macOS Keychain provider
+export { MacOSKeychainKeyProvider } from './macos-keychain-provider.js'
+export type { MacOSKeychainKeyProviderOptions } from './macos-keychain-provider.js'
+
 // Registry
 export { KeyProviderRegistry } from './registry.js'
 export type { KeyProviderFactory } from './registry.js'

--- a/packages/core/src/key-provider/macos-keychain-provider.ts
+++ b/packages/core/src/key-provider/macos-keychain-provider.ts
@@ -1,0 +1,258 @@
+/**
+ * macOS Keychain-based key provider implementation.
+ *
+ * @remarks
+ * This provider stores private keys in the macOS Keychain and retrieves them via the
+ * `security` CLI tool. Keys are stored as base64-encoded strings and downloaded to
+ * temporary files for signing operations, then securely deleted after use.
+ *
+ * @packageDocumentation
+ */
+
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { spawn } from 'node:child_process'
+import {
+  generateKeyPair as cryptoGenerateKeyPair,
+  setKeyPermissions,
+} from '../crypto.js'
+import type {
+  KeyProvider,
+  KeyProviderConfig,
+  KeyRetrievalResult,
+  KeyGenerationResult,
+  KeygenProviderOptions,
+} from './types.js'
+
+/**
+ * Options for creating a MacOSKeychainKeyProvider.
+ * @public
+ */
+export interface MacOSKeychainKeyProviderOptions {
+  /** Item name in keychain (e.g., "attest-it-private-key") */
+  itemName: string
+}
+
+/**
+ * Key provider that stores private keys in macOS Keychain.
+ *
+ * @remarks
+ * This provider requires macOS and uses the `security` CLI tool.
+ * Private keys are stored as base64-encoded strings in the keychain and decoded
+ * to temporary files for signing operations.
+ *
+ * @public
+ */
+export class MacOSKeychainKeyProvider implements KeyProvider {
+  readonly type = 'macos-keychain'
+  readonly displayName = 'macOS Keychain'
+
+  private readonly itemName: string
+  private static readonly ACCOUNT = 'attest-it'
+
+  /**
+   * Create a new MacOSKeychainKeyProvider.
+   * @param options - Provider options
+   */
+  constructor(options: MacOSKeychainKeyProviderOptions) {
+    this.itemName = options.itemName
+  }
+
+  /**
+   * Check if this provider is available.
+   * Only available on macOS platforms.
+   */
+  static isAvailable(): boolean {
+    return process.platform === 'darwin'
+  }
+
+  /**
+   * Check if this provider is available on the current system.
+   */
+  isAvailable(): Promise<boolean> {
+    return Promise.resolve(MacOSKeychainKeyProvider.isAvailable())
+  }
+
+  /**
+   * Check if a key exists in the keychain.
+   * @param keyRef - Item name in keychain
+   */
+  async keyExists(keyRef: string): Promise<boolean> {
+    try {
+      await execCommand('security', [
+        'find-generic-password',
+        '-a',
+        MacOSKeychainKeyProvider.ACCOUNT,
+        '-s',
+        keyRef,
+      ])
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Get the private key from keychain for signing.
+   * Downloads to a temporary file and returns a cleanup function.
+   * @param keyRef - Item name in keychain
+   * @throws Error if the key does not exist in keychain
+   */
+  async getPrivateKey(keyRef: string): Promise<KeyRetrievalResult> {
+    // Check if key exists first for better error messages
+    if (!(await this.keyExists(keyRef))) {
+      throw new Error(
+        `Key not found in macOS Keychain: "${keyRef}" (account: ${MacOSKeychainKeyProvider.ACCOUNT})`,
+      )
+    }
+
+    // Create a temporary file
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-'))
+    const tempKeyPath = path.join(tempDir, 'private.pem')
+
+    try {
+      // Retrieve the base64-encoded key from keychain
+      const base64Key = await execCommand('security', [
+        'find-generic-password',
+        '-a',
+        MacOSKeychainKeyProvider.ACCOUNT,
+        '-s',
+        keyRef,
+        '-w',
+      ])
+
+      // Decode from base64 and write to temp file
+      const keyContent = Buffer.from(base64Key, 'base64').toString('utf8')
+      await fs.writeFile(tempKeyPath, keyContent, { mode: 0o600 })
+
+      // Set proper permissions
+      await setKeyPermissions(tempKeyPath)
+
+      return {
+        keyPath: tempKeyPath,
+        cleanup: async () => {
+          // Securely delete the temporary file and directory
+          try {
+            await fs.unlink(tempKeyPath)
+            await fs.rmdir(tempDir)
+          } catch {
+            // Best effort cleanup
+          }
+        },
+      }
+    } catch (error) {
+      // Clean up temp directory on error
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true })
+      } catch {
+        // Best effort cleanup
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Generate a new keypair and store private key in keychain.
+   * Public key is written to filesystem for repository commit.
+   * @param options - Key generation options
+   */
+  async generateKeyPair(options: KeygenProviderOptions): Promise<KeyGenerationResult> {
+    const { publicKeyPath, force = false } = options
+
+    // Create a temporary directory for key generation
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-keygen-'))
+    const tempPrivateKeyPath = path.join(tempDir, 'private.pem')
+
+    try {
+      // Generate the keypair to temporary location
+      await cryptoGenerateKeyPair({
+        privatePath: tempPrivateKeyPath,
+        publicPath: publicKeyPath,
+        force,
+      })
+
+      // Read the private key and encode as base64
+      const privateKeyContent = await fs.readFile(tempPrivateKeyPath, 'utf8')
+      const base64Key = Buffer.from(privateKeyContent, 'utf8').toString('base64')
+
+      // Store in keychain
+      // The -T "" flag allows all applications to access the key
+      // The -U flag updates if the item already exists
+      await execCommand('security', [
+        'add-generic-password',
+        '-a',
+        MacOSKeychainKeyProvider.ACCOUNT,
+        '-s',
+        this.itemName,
+        '-w',
+        base64Key,
+        '-T',
+        '',
+        '-U',
+      ])
+
+      // Clean up temporary private key
+      await fs.unlink(tempPrivateKeyPath)
+      await fs.rmdir(tempDir)
+
+      return {
+        privateKeyRef: this.itemName,
+        publicKeyPath,
+        storageDescription: `macOS Keychain: ${this.itemName}`,
+      }
+    } catch (error) {
+      // Clean up on error
+      try {
+        await fs.rm(tempDir, { recursive: true, force: true })
+      } catch {
+        // Best effort cleanup
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig(): KeyProviderConfig {
+    return {
+      type: this.type,
+      options: {
+        itemName: this.itemName,
+      },
+    }
+  }
+}
+
+/**
+ * Execute a command and return stdout.
+ * @internal
+ */
+async function execCommand(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString()
+    })
+
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString()
+    })
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout.trim())
+      } else {
+        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`))
+      }
+    })
+
+    proc.on('error', (error) => {
+      reject(error)
+    })
+  })
+}

--- a/packages/core/src/key-provider/macos-keychain-provider.ts
+++ b/packages/core/src/key-provider/macos-keychain-provider.ts
@@ -13,10 +13,7 @@ import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { spawn } from 'node:child_process'
-import {
-  generateKeyPair as cryptoGenerateKeyPair,
-  setKeyPermissions,
-} from '../crypto.js'
+import { generateKeyPair as cryptoGenerateKeyPair, setKeyPermissions } from '../crypto.js'
 import type {
   KeyProvider,
   KeyProviderConfig,

--- a/packages/core/src/key-provider/registry.ts
+++ b/packages/core/src/key-provider/registry.ts
@@ -11,6 +11,7 @@
 import type { KeyProvider, KeyProviderConfig } from './types.js'
 import { FilesystemKeyProvider } from './filesystem-provider.js'
 import { OnePasswordKeyProvider } from './one-password-provider.js'
+import { MacOSKeychainKeyProvider } from './macos-keychain-provider.js'
 
 /**
  * Type for a key provider factory function.
@@ -95,4 +96,16 @@ KeyProviderRegistry.register('1password', (config) => {
     return new OnePasswordKeyProvider({ account, vault, itemName })
   }
   return new OnePasswordKeyProvider({ vault, itemName })
+})
+
+// Register the macOS Keychain provider
+KeyProviderRegistry.register('macos-keychain', (config) => {
+  const { options } = config
+  const itemName = typeof options.itemName === 'string' ? options.itemName : ''
+
+  if (!itemName) {
+    throw new Error('macOS Keychain provider requires itemName option')
+  }
+
+  return new MacOSKeychainKeyProvider({ itemName })
 })

--- a/packages/core/test/key-provider/macos-keychain-provider.test.ts
+++ b/packages/core/test/key-provider/macos-keychain-provider.test.ts
@@ -1,0 +1,796 @@
+/**
+ * Tests for MacOSKeychainKeyProvider.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { MacOSKeychainKeyProvider } from '../../src/key-provider/macos-keychain-provider.js'
+import * as crypto from '../../src/crypto.js'
+
+// Mock child_process.spawn
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}))
+
+// Mock crypto.generateKeyPair
+vi.mock('../../src/crypto.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof crypto>()
+  return {
+    ...actual,
+    generateKeyPair: vi.fn(),
+    setKeyPermissions: vi.fn(),
+  }
+})
+
+/**
+ * Helper to create a mock spawn result for successful command
+ */
+function mockSpawnSuccess(stdout: string): ReturnType<typeof spawn> {
+  const mockProcess = {
+    stdout: {
+      on: vi.fn((event, handler) => {
+        if (event === 'data') {
+          setImmediate(() => {
+            handler(Buffer.from(stdout))
+          })
+        }
+      }),
+    },
+    stderr: {
+      on: vi.fn(),
+    },
+    on: vi.fn((event, handler) => {
+      if (event === 'close') {
+        setImmediate(() => {
+          handler(0)
+        })
+      }
+    }),
+  }
+  return mockProcess as unknown as ReturnType<typeof spawn>
+}
+
+/**
+ * Helper to create a mock spawn result for failed command
+ */
+function mockSpawnFailure(stderr: string, exitCode = 1): ReturnType<typeof spawn> {
+  const mockProcess = {
+    stdout: {
+      on: vi.fn(),
+    },
+    stderr: {
+      on: vi.fn((event, handler) => {
+        if (event === 'data') {
+          setImmediate(() => {
+            handler(Buffer.from(stderr))
+          })
+        }
+      }),
+    },
+    on: vi.fn((event, handler) => {
+      if (event === 'close') {
+        setImmediate(() => {
+          handler(exitCode)
+        })
+      }
+    }),
+  }
+  return mockProcess as unknown as ReturnType<typeof spawn>
+}
+
+/**
+ * Helper to create a mock spawn that throws error
+ */
+function mockSpawnError(error: Error): ReturnType<typeof spawn> {
+  const mockProcess = {
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn((event, handler) => {
+      if (event === 'error') {
+        setImmediate(() => {
+          handler(error)
+        })
+      }
+    }),
+  }
+  return mockProcess as unknown as ReturnType<typeof spawn>
+}
+
+describe('MacOSKeychainKeyProvider', () => {
+  let tmpDir: string
+  let originalPlatform: NodeJS.Platform
+
+  beforeEach(async () => {
+    // Create a real temp directory for tests
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'macos-keychain-test-'))
+    vi.clearAllMocks()
+
+    // Save original platform
+    originalPlatform = process.platform
+  })
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {
+      // Ignore cleanup errors
+    })
+
+    // Restore platform
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  describe('constructor', () => {
+    it('should create provider with required options', () => {
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      expect(provider.type).toBe('macos-keychain')
+      expect(provider.displayName).toBe('macOS Keychain')
+    })
+  })
+
+  describe('isAvailable (static)', () => {
+    it('should return true on macOS', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        writable: true,
+        configurable: true,
+      })
+
+      expect(MacOSKeychainKeyProvider.isAvailable()).toBe(true)
+    })
+
+    it('should return false on non-macOS platforms', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        writable: true,
+        configurable: true,
+      })
+
+      expect(MacOSKeychainKeyProvider.isAvailable()).toBe(false)
+    })
+
+    it('should return false on Windows', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        writable: true,
+        configurable: true,
+      })
+
+      expect(MacOSKeychainKeyProvider.isAvailable()).toBe(false)
+    })
+  })
+
+  describe('isAvailable (instance)', () => {
+    it('should return true on macOS', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        writable: true,
+        configurable: true,
+      })
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.isAvailable()
+      expect(result).toBe(true)
+    })
+
+    it('should return false on non-macOS platforms', async () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        writable: true,
+        configurable: true,
+      })
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.isAvailable()
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('keyExists', () => {
+    it('should return true when item exists in keychain', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(mockSpawnSuccess(''))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.keyExists('test-key')
+
+      expect(result).toBe(true)
+      expect(mockSpawnFn).toHaveBeenCalledWith(
+        'security',
+        ['find-generic-password', '-a', 'attest-it', '-s', 'test-key'],
+        expect.any(Object),
+      )
+    })
+
+    it('should return false when item does not exist', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(
+        mockSpawnFailure('security: The specified item could not be found in the keychain.'),
+      )
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.keyExists('nonexistent-key')
+
+      expect(result).toBe(false)
+    })
+
+    it('should return false on spawn error', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(mockSpawnError(new Error('command not found')))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.keyExists('test-key')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getPrivateKey', () => {
+    it('should retrieve base64 key, decode, and write to temp file', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockSetKeyPermissions = vi.mocked(crypto.setKeyPermissions)
+
+      const originalKeyContent = '-----BEGIN PRIVATE KEY-----\nmock-key-content\n-----END PRIVATE KEY-----'
+      const base64Key = Buffer.from(originalKeyContent, 'utf8').toString('base64')
+
+      let callCount = 0
+      mockSpawnFn.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          // keyExists check
+          return mockSpawnSuccess('')
+        } else {
+          // find-generic-password -w to get the key
+          return mockSpawnSuccess(base64Key)
+        }
+      })
+
+      mockSetKeyPermissions.mockResolvedValue()
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.getPrivateKey('test-key')
+
+      // Check that we got a valid result
+      expect(result.keyPath).toContain('attest-it-')
+      expect(result.keyPath).toContain('private.pem')
+      expect(typeof result.cleanup).toBe('function')
+
+      // Verify spawn was called correctly
+      expect(mockSpawnFn).toHaveBeenCalledTimes(2)
+
+      // First call: keyExists
+      expect(mockSpawnFn).toHaveBeenNthCalledWith(
+        1,
+        'security',
+        ['find-generic-password', '-a', 'attest-it', '-s', 'test-key'],
+        expect.any(Object),
+      )
+
+      // Second call: retrieve with -w flag
+      expect(mockSpawnFn).toHaveBeenNthCalledWith(
+        2,
+        'security',
+        ['find-generic-password', '-a', 'attest-it', '-s', 'test-key', '-w'],
+        expect.any(Object),
+      )
+
+      // Verify permissions were set
+      expect(mockSetKeyPermissions).toHaveBeenCalled()
+
+      // Verify file content is correctly decoded
+      const retrievedContent = await fs.readFile(result.keyPath, 'utf8')
+      expect(retrievedContent).toBe(originalKeyContent)
+
+      // Test cleanup
+      await result.cleanup()
+
+      // Verify file was deleted
+      await expect(fs.stat(result.keyPath)).rejects.toThrow()
+    })
+
+    it('should throw error when key does not exist', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(
+        mockSpawnFailure('security: The specified item could not be found in the keychain.'),
+      )
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(provider.getPrivateKey('nonexistent-key')).rejects.toThrow(
+        /Key not found in macOS Keychain/,
+      )
+    })
+
+    it('should throw error when key retrieval fails after keyExists succeeds', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      let callCount = 0
+      mockSpawnFn.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          // keyExists succeeds
+          return mockSpawnSuccess('')
+        } else {
+          // key retrieval fails
+          return mockSpawnFailure('security: error retrieving password')
+        }
+      })
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(provider.getPrivateKey('test-key')).rejects.toThrow('Command failed')
+    })
+
+    it('should clean up temp directory on error', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(mockSpawnFailure('error'))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(provider.getPrivateKey('test-key')).rejects.toThrow()
+
+      // Note: Cleanup verification is best-effort due to async timing
+    })
+
+    it('should handle spawn error event during retrieval', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      let callCount = 0
+      mockSpawnFn.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          // keyExists succeeds
+          return mockSpawnSuccess('')
+        } else {
+          // retrieval emits error
+          return mockSpawnError(new Error('EACCES'))
+        }
+      })
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(provider.getPrivateKey('test-key')).rejects.toThrow('EACCES')
+    })
+  })
+
+  describe('generateKeyPair', () => {
+    it('should generate keypair, encode to base64, and store in keychain', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockGenerateKeyPair = vi.mocked(crypto.generateKeyPair)
+
+      const publicPath = path.join(tmpDir, 'public.pem')
+      const privateKeyContent = '-----BEGIN PRIVATE KEY-----\nmock\n-----END PRIVATE KEY-----'
+
+      // Mock successful key generation
+      mockGenerateKeyPair.mockImplementation(async (opts) => {
+        const tempPrivatePath = opts.privatePath
+        await fs.mkdir(path.dirname(tempPrivatePath), { recursive: true })
+        await fs.writeFile(tempPrivatePath, privateKeyContent)
+        return {
+          privatePath: tempPrivatePath,
+          publicPath: opts.publicPath,
+        }
+      })
+
+      // Mock successful keychain storage
+      mockSpawnFn.mockReturnValue(mockSpawnSuccess(''))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.generateKeyPair({
+        publicKeyPath: publicPath,
+        force: false,
+      })
+
+      expect(result.privateKeyRef).toBe('test-key')
+      expect(result.publicKeyPath).toBe(publicPath)
+      expect(result.storageDescription).toBe('macOS Keychain: test-key')
+
+      // Verify spawn was called to store in keychain
+      expect(mockSpawnFn).toHaveBeenCalledWith(
+        'security',
+        [
+          'add-generic-password',
+          '-a',
+          'attest-it',
+          '-s',
+          'test-key',
+          '-w',
+          Buffer.from(privateKeyContent, 'utf8').toString('base64'),
+          '-T',
+          '',
+          '-U',
+        ],
+        expect.any(Object),
+      )
+    })
+
+    it('should throw error when keychain storage fails', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockGenerateKeyPair = vi.mocked(crypto.generateKeyPair)
+
+      const publicPath = path.join(tmpDir, 'public.pem')
+
+      mockGenerateKeyPair.mockImplementation(async (opts) => {
+        const tempPrivatePath = opts.privatePath
+        await fs.mkdir(path.dirname(tempPrivatePath), { recursive: true })
+        await fs.writeFile(tempPrivatePath, 'private key contents')
+        return {
+          privatePath: tempPrivatePath,
+          publicPath: opts.publicPath,
+        }
+      })
+
+      // Mock failed storage
+      mockSpawnFn.mockReturnValue(mockSpawnFailure('security: error adding to keychain'))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(
+        provider.generateKeyPair({
+          publicKeyPath: publicPath,
+        }),
+      ).rejects.toThrow('Command failed')
+    })
+
+    it('should clean up temp files after generation', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockGenerateKeyPair = vi.mocked(crypto.generateKeyPair)
+
+      const publicPath = path.join(tmpDir, 'public.pem')
+      let capturedPrivatePath: string | undefined
+
+      mockGenerateKeyPair.mockImplementation(async (opts) => {
+        const tempPrivatePath = opts.privatePath
+        capturedPrivatePath = tempPrivatePath
+        await fs.mkdir(path.dirname(tempPrivatePath), { recursive: true })
+        await fs.writeFile(tempPrivatePath, 'private key contents')
+        return {
+          privatePath: tempPrivatePath,
+          publicPath: opts.publicPath,
+        }
+      })
+
+      mockSpawnFn.mockReturnValue(mockSpawnSuccess(''))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await provider.generateKeyPair({
+        publicKeyPath: publicPath,
+      })
+
+      // Verify temp private key was deleted
+      expect(capturedPrivatePath).toBeDefined()
+      if (capturedPrivatePath) {
+        await expect(fs.stat(capturedPrivatePath)).rejects.toThrow()
+      }
+    })
+
+    it('should handle force flag correctly', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockGenerateKeyPair = vi.mocked(crypto.generateKeyPair)
+
+      const publicPath = path.join(tmpDir, 'public.pem')
+      const privateKeyContent = 'private key contents'
+
+      mockGenerateKeyPair.mockImplementation(async (opts) => {
+        const tempPrivatePath = opts.privatePath
+        await fs.mkdir(path.dirname(tempPrivatePath), { recursive: true })
+        await fs.writeFile(tempPrivatePath, privateKeyContent)
+        return {
+          privatePath: tempPrivatePath,
+          publicPath: opts.publicPath,
+        }
+      })
+
+      mockSpawnFn.mockReturnValue(mockSpawnSuccess(''))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await provider.generateKeyPair({
+        publicKeyPath: publicPath,
+        force: true,
+      })
+
+      // Verify generateKeyPair was called with force flag
+      expect(mockGenerateKeyPair).toHaveBeenCalledWith(
+        expect.objectContaining({
+          force: true,
+        }),
+      )
+    })
+  })
+
+  describe('getConfig', () => {
+    it('should return config with itemName', () => {
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const config = provider.getConfig()
+
+      expect(config).toEqual({
+        type: 'macos-keychain',
+        options: {
+          itemName: 'test-key',
+        },
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle base64 decoding of complex key content', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockSetKeyPermissions = vi.mocked(crypto.setKeyPermissions)
+
+      const complexKeyContent =
+        '-----BEGIN PRIVATE KEY-----\n' +
+        'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7VJTUt9Us8cKj\n' +
+        'MzEfYyjiWA4R4/M2bS1+fWIcPm15A8vMpmcdgU7U3axvfiIVQ6Z5RIQBVhC8NvO6\n' +
+        '-----END PRIVATE KEY-----\n'
+      const base64Key = Buffer.from(complexKeyContent, 'utf8').toString('base64')
+
+      let callCount = 0
+      mockSpawnFn.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return mockSpawnSuccess('')
+        } else {
+          return mockSpawnSuccess(base64Key)
+        }
+      })
+
+      mockSetKeyPermissions.mockResolvedValue()
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.getPrivateKey('test-key')
+
+      const retrievedContent = await fs.readFile(result.keyPath, 'utf8')
+      expect(retrievedContent).toBe(complexKeyContent)
+
+      await result.cleanup()
+    })
+
+    it('should handle spawn error during keyExists check', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(mockSpawnError(new Error('ENOENT')))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(provider.getPrivateKey('test-key')).rejects.toThrow(/Key not found in macOS Keychain/)
+    })
+
+    it('should handle empty base64 string from keychain', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockSetKeyPermissions = vi.mocked(crypto.setKeyPermissions)
+
+      let callCount = 0
+      mockSpawnFn.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          return mockSpawnSuccess('')
+        } else {
+          // Empty base64 decodes to empty string
+          return mockSpawnSuccess('')
+        }
+      })
+
+      mockSetKeyPermissions.mockResolvedValue()
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      const result = await provider.getPrivateKey('test-key')
+
+      const retrievedContent = await fs.readFile(result.keyPath, 'utf8')
+      expect(retrievedContent).toBe('')
+
+      await result.cleanup()
+    })
+  })
+
+  describe('integration: provider workflow validation', () => {
+    it('should complete the full getPrivateKey workflow with mocked security CLI', async () => {
+      // This test validates the complete provider workflow:
+      // 1. keyExists check
+      // 2. Key retrieval with base64 decoding
+      // 3. Proper cleanup after use
+
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockSetKeyPermissions = vi.mocked(crypto.setKeyPermissions)
+
+      const mockPrivateKeyContent = '-----BEGIN PRIVATE KEY-----\nmock-key-content\n-----END PRIVATE KEY-----'
+      const base64Key = Buffer.from(mockPrivateKeyContent, 'utf8').toString('base64')
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'integration-test-key',
+      })
+
+      // Mock the security CLI calls
+      let callCount = 0
+      mockSpawnFn.mockImplementation(() => {
+        callCount++
+        if (callCount === 1) {
+          // keyExists check
+          return mockSpawnSuccess('')
+        } else {
+          // key retrieval with -w flag
+          return mockSpawnSuccess(base64Key)
+        }
+      })
+
+      mockSetKeyPermissions.mockResolvedValue()
+
+      // Get the private key through the provider
+      const keyResult = await provider.getPrivateKey('integration-test-key')
+
+      // Verify the workflow completed correctly
+      expect(keyResult.keyPath).toContain('attest-it-')
+      expect(keyResult.keyPath).toContain('private.pem')
+      expect(typeof keyResult.cleanup).toBe('function')
+
+      // Verify the key file exists and has correct content
+      const retrievedContent = await fs.readFile(keyResult.keyPath, 'utf8')
+      expect(retrievedContent).toBe(mockPrivateKeyContent)
+
+      // Verify security CLI was called correctly
+      expect(mockSpawnFn).toHaveBeenCalledTimes(2)
+
+      // First call: keyExists check
+      expect(mockSpawnFn).toHaveBeenNthCalledWith(
+        1,
+        'security',
+        ['find-generic-password', '-a', 'attest-it', '-s', 'integration-test-key'],
+        expect.any(Object),
+      )
+
+      // Second call: key retrieval
+      expect(mockSpawnFn).toHaveBeenNthCalledWith(
+        2,
+        'security',
+        ['find-generic-password', '-a', 'attest-it', '-s', 'integration-test-key', '-w'],
+        expect.any(Object),
+      )
+
+      // Verify setKeyPermissions was called on the temp file
+      expect(mockSetKeyPermissions).toHaveBeenCalledWith(keyResult.keyPath)
+
+      // Test cleanup
+      await keyResult.cleanup()
+
+      // Verify file was deleted
+      await expect(fs.stat(keyResult.keyPath)).rejects.toThrow()
+    })
+
+    it('should complete the full generateKeyPair workflow', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      const mockGenerateKeyPair = vi.mocked(crypto.generateKeyPair)
+
+      const publicPath = path.join(tmpDir, 'integration-public.pem')
+      const privateKeyContent = '-----BEGIN PRIVATE KEY-----\nintegration-test\n-----END PRIVATE KEY-----'
+
+      mockGenerateKeyPair.mockImplementation(async (opts) => {
+        const tempPrivatePath = opts.privatePath
+        await fs.mkdir(path.dirname(tempPrivatePath), { recursive: true })
+        await fs.writeFile(tempPrivatePath, privateKeyContent)
+        return {
+          privatePath: tempPrivatePath,
+          publicPath: opts.publicPath,
+        }
+      })
+
+      mockSpawnFn.mockReturnValue(mockSpawnSuccess(''))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'integration-generated-key',
+      })
+
+      const result = await provider.generateKeyPair({
+        publicKeyPath: publicPath,
+        force: false,
+      })
+
+      // Verify result
+      expect(result.privateKeyRef).toBe('integration-generated-key')
+      expect(result.publicKeyPath).toBe(publicPath)
+      expect(result.storageDescription).toBe('macOS Keychain: integration-generated-key')
+
+      // Verify the key was stored with correct base64 encoding
+      const expectedBase64 = Buffer.from(privateKeyContent, 'utf8').toString('base64')
+      expect(mockSpawnFn).toHaveBeenCalledWith(
+        'security',
+        [
+          'add-generic-password',
+          '-a',
+          'attest-it',
+          '-s',
+          'integration-generated-key',
+          '-w',
+          expectedBase64,
+          '-T',
+          '',
+          '-U',
+        ],
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('getPrivateKey error handling', () => {
+    it('should throw descriptive error when key does not exist', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(
+        mockSpawnFailure('security: The specified item could not be found in the keychain.'),
+      )
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(provider.getPrivateKey('nonexistent-key')).rejects.toThrow(
+        /Key not found in macOS Keychain.*nonexistent-key.*account: attest-it/,
+      )
+    })
+
+    it('should include proper context in error messages', async () => {
+      const mockSpawnFn = vi.mocked(spawn)
+      mockSpawnFn.mockReturnValue(mockSpawnFailure('access denied'))
+
+      const provider = new MacOSKeychainKeyProvider({
+        itemName: 'test-key',
+      })
+
+      await expect(provider.getPrivateKey('test-key')).rejects.toThrow(/Key not found in macOS Keychain/)
+    })
+  })
+})

--- a/packages/core/test/key-provider/macos-keychain-provider.test.ts
+++ b/packages/core/test/key-provider/macos-keychain-provider.test.ts
@@ -257,7 +257,8 @@ describe('MacOSKeychainKeyProvider', () => {
       const mockSpawnFn = vi.mocked(spawn)
       const mockSetKeyPermissions = vi.mocked(crypto.setKeyPermissions)
 
-      const originalKeyContent = '-----BEGIN PRIVATE KEY-----\nmock-key-content\n-----END PRIVATE KEY-----'
+      const originalKeyContent =
+        '-----BEGIN PRIVATE KEY-----\nmock-key-content\n-----END PRIVATE KEY-----'
       const base64Key = Buffer.from(originalKeyContent, 'utf8').toString('base64')
 
       let callCount = 0
@@ -606,7 +607,9 @@ describe('MacOSKeychainKeyProvider', () => {
         itemName: 'test-key',
       })
 
-      await expect(provider.getPrivateKey('test-key')).rejects.toThrow(/Key not found in macOS Keychain/)
+      await expect(provider.getPrivateKey('test-key')).rejects.toThrow(
+        /Key not found in macOS Keychain/,
+      )
     })
 
     it('should handle empty base64 string from keychain', async () => {
@@ -649,7 +652,8 @@ describe('MacOSKeychainKeyProvider', () => {
       const mockSpawnFn = vi.mocked(spawn)
       const mockSetKeyPermissions = vi.mocked(crypto.setKeyPermissions)
 
-      const mockPrivateKeyContent = '-----BEGIN PRIVATE KEY-----\nmock-key-content\n-----END PRIVATE KEY-----'
+      const mockPrivateKeyContent =
+        '-----BEGIN PRIVATE KEY-----\nmock-key-content\n-----END PRIVATE KEY-----'
       const base64Key = Buffer.from(mockPrivateKeyContent, 'utf8').toString('base64')
 
       const provider = new MacOSKeychainKeyProvider({
@@ -717,7 +721,8 @@ describe('MacOSKeychainKeyProvider', () => {
       const mockGenerateKeyPair = vi.mocked(crypto.generateKeyPair)
 
       const publicPath = path.join(tmpDir, 'integration-public.pem')
-      const privateKeyContent = '-----BEGIN PRIVATE KEY-----\nintegration-test\n-----END PRIVATE KEY-----'
+      const privateKeyContent =
+        '-----BEGIN PRIVATE KEY-----\nintegration-test\n-----END PRIVATE KEY-----'
 
       mockGenerateKeyPair.mockImplementation(async (opts) => {
         const tempPrivatePath = opts.privatePath
@@ -790,7 +795,9 @@ describe('MacOSKeychainKeyProvider', () => {
         itemName: 'test-key',
       })
 
-      await expect(provider.getPrivateKey('test-key')).rejects.toThrow(/Key not found in macOS Keychain/)
+      await expect(provider.getPrivateKey('test-key')).rejects.toThrow(
+        /Key not found in macOS Keychain/,
+      )
     })
   })
 })

--- a/packages/core/test/key-provider/one-password-provider.test.ts
+++ b/packages/core/test/key-provider/one-password-provider.test.ts
@@ -713,9 +713,10 @@ describe('OnePasswordKeyProvider', () => {
             const targetPath = (args as string[])[outFileIndex + 1]
             // Synchronously schedule the file write (simulates op writing the file)
             setImmediate(() => {
-              void fs
-                .mkdir(path.dirname(targetPath), { recursive: true })
-                .then(() => fs.writeFile(targetPath, mockPrivateKeyContent))
+              void (async () => {
+                await fs.mkdir(path.dirname(targetPath), { recursive: true })
+                await fs.writeFile(targetPath, mockPrivateKeyContent)
+              })()
             })
           }
           return mockSpawnSuccess('')
@@ -802,9 +803,10 @@ describe('OnePasswordKeyProvider', () => {
           if (outFileIndex !== -1) {
             const targetPath = (args as string[])[outFileIndex + 1]
             setImmediate(() => {
-              void fs
-                .mkdir(path.dirname(targetPath), { recursive: true })
-                .then(() => fs.writeFile(targetPath, mockPrivateKeyContent))
+              void (async () => {
+                await fs.mkdir(path.dirname(targetPath), { recursive: true })
+                await fs.writeFile(targetPath, mockPrivateKeyContent)
+              })()
             })
           }
           return mockSpawnSuccess('')

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -18269,7 +18269,7 @@ var require_summary = __commonJS({
     exports2.summary = exports2.markdownSummary = exports2.SUMMARY_DOCS_URL = exports2.SUMMARY_ENV_VAR = void 0;
     var os_1 = require("os");
     var fs_1 = require("fs");
-    var { access: access3, appendFile, writeFile: writeFile2 } = fs_1.promises;
+    var { access: access3, appendFile, writeFile: writeFile3 } = fs_1.promises;
     exports2.SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
     exports2.SUMMARY_DOCS_URL = "https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary";
     var Summary = class {
@@ -18327,7 +18327,7 @@ var require_summary = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           const overwrite = !!(options === null || options === void 0 ? void 0 : options.overwrite);
           const filePath = yield this.filePath();
-          const writeFunc = overwrite ? writeFile2 : appendFile;
+          const writeFunc = overwrite ? writeFile3 : appendFile;
           yield writeFunc(filePath, this._buffer, { encoding: "utf8" });
           return this.emptyBuffer();
         });
@@ -19944,7 +19944,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
   }
 });
 
-// ../core/dist/chunk-MWVVZIGH.js
+// ../core/dist/chunk-VC3BBBBO.js
 async function runOpenSSL(args, stdin) {
   return new Promise((resolve4, reject) => {
     const child = (0, import_child_process.spawn)("openssl", args, {
@@ -20101,15 +20101,7 @@ async function sign(options) {
     const sigFile = path.join(tmpDir, "sig.bin");
     try {
       await fs.writeFile(dataFile, processBuffer);
-      const signArgs = [
-        "dgst",
-        "-sha256",
-        "-sign",
-        effectiveKeyPath,
-        "-out",
-        sigFile,
-        dataFile
-      ];
+      const signArgs = ["dgst", "-sha256", "-sign", effectiveKeyPath, "-out", sigFile, dataFile];
       const result = await runOpenSSL(signArgs);
       if (result.exitCode !== 0) {
         throw new Error(`Failed to sign data: ${result.stderr}`);
@@ -20169,8 +20161,8 @@ async function setKeyPermissions(keyPath) {
   }
 }
 var import_child_process, fs, path, os, openSSLChecked;
-var init_chunk_MWVVZIGH = __esm({
-  "../core/dist/chunk-MWVVZIGH.js"() {
+var init_chunk_VC3BBBBO = __esm({
+  "../core/dist/chunk-VC3BBBBO.js"() {
     "use strict";
     init_cjs_shims();
     import_child_process = require("child_process");
@@ -29104,9 +29096,9 @@ var require_canonicalize = __commonJS({
   }
 });
 
-// ../core/dist/crypto-I4ZGDVZL.js
-var crypto_I4ZGDVZL_exports = {};
-__export(crypto_I4ZGDVZL_exports, {
+// ../core/dist/crypto-CE2YISRD.js
+var crypto_CE2YISRD_exports = {};
+__export(crypto_CE2YISRD_exports, {
   checkOpenSSL: () => checkOpenSSL,
   generateKeyPair: () => generateKeyPair,
   getDefaultPrivateKeyPath: () => getDefaultPrivateKeyPath,
@@ -29115,11 +29107,11 @@ __export(crypto_I4ZGDVZL_exports, {
   sign: () => sign,
   verify: () => verify
 });
-var init_crypto_I4ZGDVZL = __esm({
-  "../core/dist/crypto-I4ZGDVZL.js"() {
+var init_crypto_CE2YISRD = __esm({
+  "../core/dist/crypto-CE2YISRD.js"() {
     "use strict";
     init_cjs_shims();
-    init_chunk_MWVVZIGH();
+    init_chunk_VC3BBBBO();
   }
 });
 
@@ -29134,11 +29126,11 @@ var core = __toESM(require_core(), 1);
 
 // ../core/dist/index.js
 init_cjs_shims();
-init_chunk_MWVVZIGH();
-init_chunk_MWVVZIGH();
+init_chunk_VC3BBBBO();
+init_chunk_VC3BBBBO();
 var fs2 = __toESM(require("fs"), 1);
 var import_fs2 = require("fs");
-var fs5 = __toESM(require("fs/promises"), 1);
+var fs6 = __toESM(require("fs/promises"), 1);
 var import_promises = require("fs/promises");
 var path3 = __toESM(require("path"), 1);
 var import_path3 = require("path");
@@ -34301,7 +34293,7 @@ function canonicalizeAttestations(attestations) {
   return canonical;
 }
 async function readAndVerifyAttestations(options) {
-  const { verify: verify2 } = await Promise.resolve().then(() => (init_crypto_I4ZGDVZL(), crypto_I4ZGDVZL_exports));
+  const { verify: verify2 } = await Promise.resolve().then(() => (init_crypto_CE2YISRD(), crypto_CE2YISRD_exports));
   const file = await readAttestations(options.filePath);
   if (!file) {
     throw new Error(`Attestations file not found: ${options.filePath}`);
@@ -34469,7 +34461,7 @@ var FilesystemKeyProvider = class {
    */
   async keyExists(keyRef) {
     try {
-      await fs5.access(keyRef);
+      await fs6.access(keyRef);
       return true;
     } catch {
       return false;
@@ -34627,18 +34619,10 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
         `Key not found in 1Password: "${keyRef}" (vault: ${this.vault})` + (this.account ? ` (account: ${this.account})` : "")
       );
     }
-    const tempDir = await fs5.mkdtemp(path3.join(os2.tmpdir(), "attest-it-"));
+    const tempDir = await fs6.mkdtemp(path3.join(os2.tmpdir(), "attest-it-"));
     const tempKeyPath = path3.join(tempDir, "private.pem");
     try {
-      const args = [
-        "document",
-        "get",
-        keyRef,
-        "--vault",
-        this.vault,
-        "--out-file",
-        tempKeyPath
-      ];
+      const args = ["document", "get", keyRef, "--vault", this.vault, "--out-file", tempKeyPath];
       if (this.account) {
         args.push("--account", this.account);
       }
@@ -34648,15 +34632,15 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
         keyPath: tempKeyPath,
         cleanup: async () => {
           try {
-            await fs5.unlink(tempKeyPath);
-            await fs5.rmdir(tempDir);
+            await fs6.unlink(tempKeyPath);
+            await fs6.rmdir(tempDir);
           } catch {
           }
         }
       };
     } catch (error2) {
       try {
-        await fs5.rm(tempDir, { recursive: true, force: true });
+        await fs6.rm(tempDir, { recursive: true, force: true });
       } catch {
       }
       throw error2;
@@ -34669,7 +34653,7 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
    */
   async generateKeyPair(options) {
     const { publicKeyPath, force = false } = options;
-    const tempDir = await fs5.mkdtemp(path3.join(os2.tmpdir(), "attest-it-keygen-"));
+    const tempDir = await fs6.mkdtemp(path3.join(os2.tmpdir(), "attest-it-keygen-"));
     const tempPrivateKeyPath = path3.join(tempDir, "private.pem");
     try {
       await generateKeyPair({
@@ -34690,8 +34674,8 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
         args.push("--account", this.account);
       }
       await execCommand("op", args);
-      await fs5.unlink(tempPrivateKeyPath);
-      await fs5.rmdir(tempDir);
+      await fs6.unlink(tempPrivateKeyPath);
+      await fs6.rmdir(tempDir);
       return {
         privateKeyRef: this.itemName,
         publicKeyPath,
@@ -34699,7 +34683,7 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
       };
     } catch (error2) {
       try {
-        await fs5.rm(tempDir, { recursive: true, force: true });
+        await fs6.rm(tempDir, { recursive: true, force: true });
       } catch {
       }
       throw error2;
@@ -34720,6 +34704,172 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
   }
 };
 async function execCommand(command, args) {
+  return new Promise((resolve32, reject) => {
+    const proc = (0, import_child_process2.spawn)(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve32(stdout.trim());
+      } else {
+        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
+      }
+    });
+    proc.on("error", (error2) => {
+      reject(error2);
+    });
+  });
+}
+var MacOSKeychainKeyProvider = class _MacOSKeychainKeyProvider {
+  type = "macos-keychain";
+  displayName = "macOS Keychain";
+  itemName;
+  static ACCOUNT = "attest-it";
+  /**
+   * Create a new MacOSKeychainKeyProvider.
+   * @param options - Provider options
+   */
+  constructor(options) {
+    this.itemName = options.itemName;
+  }
+  /**
+   * Check if this provider is available.
+   * Only available on macOS platforms.
+   */
+  static isAvailable() {
+    return process.platform === "darwin";
+  }
+  /**
+   * Check if this provider is available on the current system.
+   */
+  isAvailable() {
+    return Promise.resolve(_MacOSKeychainKeyProvider.isAvailable());
+  }
+  /**
+   * Check if a key exists in the keychain.
+   * @param keyRef - Item name in keychain
+   */
+  async keyExists(keyRef) {
+    try {
+      await execCommand2("security", [
+        "find-generic-password",
+        "-a",
+        _MacOSKeychainKeyProvider.ACCOUNT,
+        "-s",
+        keyRef
+      ]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  /**
+   * Get the private key from keychain for signing.
+   * Downloads to a temporary file and returns a cleanup function.
+   * @param keyRef - Item name in keychain
+   * @throws Error if the key does not exist in keychain
+   */
+  async getPrivateKey(keyRef) {
+    if (!await this.keyExists(keyRef)) {
+      throw new Error(
+        `Key not found in macOS Keychain: "${keyRef}" (account: ${_MacOSKeychainKeyProvider.ACCOUNT})`
+      );
+    }
+    const tempDir = await fs6.mkdtemp(path3.join(os2.tmpdir(), "attest-it-"));
+    const tempKeyPath = path3.join(tempDir, "private.pem");
+    try {
+      const base64Key = await execCommand2("security", [
+        "find-generic-password",
+        "-a",
+        _MacOSKeychainKeyProvider.ACCOUNT,
+        "-s",
+        keyRef,
+        "-w"
+      ]);
+      const keyContent = Buffer.from(base64Key, "base64").toString("utf8");
+      await fs6.writeFile(tempKeyPath, keyContent, { mode: 384 });
+      await setKeyPermissions(tempKeyPath);
+      return {
+        keyPath: tempKeyPath,
+        cleanup: async () => {
+          try {
+            await fs6.unlink(tempKeyPath);
+            await fs6.rmdir(tempDir);
+          } catch {
+          }
+        }
+      };
+    } catch (error2) {
+      try {
+        await fs6.rm(tempDir, { recursive: true, force: true });
+      } catch {
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Generate a new keypair and store private key in keychain.
+   * Public key is written to filesystem for repository commit.
+   * @param options - Key generation options
+   */
+  async generateKeyPair(options) {
+    const { publicKeyPath, force = false } = options;
+    const tempDir = await fs6.mkdtemp(path3.join(os2.tmpdir(), "attest-it-keygen-"));
+    const tempPrivateKeyPath = path3.join(tempDir, "private.pem");
+    try {
+      await generateKeyPair({
+        privatePath: tempPrivateKeyPath,
+        publicPath: publicKeyPath,
+        force
+      });
+      const privateKeyContent = await fs6.readFile(tempPrivateKeyPath, "utf8");
+      const base64Key = Buffer.from(privateKeyContent, "utf8").toString("base64");
+      await execCommand2("security", [
+        "add-generic-password",
+        "-a",
+        _MacOSKeychainKeyProvider.ACCOUNT,
+        "-s",
+        this.itemName,
+        "-w",
+        base64Key,
+        "-T",
+        "",
+        "-U"
+      ]);
+      await fs6.unlink(tempPrivateKeyPath);
+      await fs6.rmdir(tempDir);
+      return {
+        privateKeyRef: this.itemName,
+        publicKeyPath,
+        storageDescription: `macOS Keychain: ${this.itemName}`
+      };
+    } catch (error2) {
+      try {
+        await fs6.rm(tempDir, { recursive: true, force: true });
+      } catch {
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return {
+      type: this.type,
+      options: {
+        itemName: this.itemName
+      }
+    };
+  }
+};
+async function execCommand2(command, args) {
   return new Promise((resolve32, reject) => {
     const proc = (0, import_child_process2.spawn)(command, args, { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
@@ -34794,6 +34944,14 @@ KeyProviderRegistry.register("1password", (config) => {
     return new OnePasswordKeyProvider({ account, vault, itemName });
   }
   return new OnePasswordKeyProvider({ vault, itemName });
+});
+KeyProviderRegistry.register("macos-keychain", (config) => {
+  const { options } = config;
+  const itemName = typeof options.itemName === "string" ? options.itemName : "";
+  if (!itemName) {
+    throw new Error("macOS Keychain provider requires itemName option");
+  }
+  return new MacOSKeychainKeyProvider({ itemName });
 });
 
 // src/index.ts

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -18272,7 +18272,7 @@ var require_summary = __commonJS({
     exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
     var os_1 = __require("os");
     var fs_1 = __require("fs");
-    var { access: access3, appendFile, writeFile: writeFile2 } = fs_1.promises;
+    var { access: access3, appendFile, writeFile: writeFile3 } = fs_1.promises;
     exports.SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
     exports.SUMMARY_DOCS_URL = "https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary";
     var Summary = class {
@@ -18330,7 +18330,7 @@ var require_summary = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           const overwrite = !!(options === null || options === void 0 ? void 0 : options.overwrite);
           const filePath = yield this.filePath();
-          const writeFunc = overwrite ? writeFile2 : appendFile;
+          const writeFunc = overwrite ? writeFile3 : appendFile;
           yield writeFunc(filePath, this._buffer, { encoding: "utf8" });
           return this.emptyBuffer();
         });
@@ -19947,7 +19947,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
   }
 });
 
-// ../core/dist/chunk-MWVVZIGH.js
+// ../core/dist/chunk-VC3BBBBO.js
 import { spawn } from "child_process";
 import * as fs from "fs/promises";
 import * as path2 from "path";
@@ -20108,15 +20108,7 @@ async function sign(options) {
     const sigFile = path2.join(tmpDir, "sig.bin");
     try {
       await fs.writeFile(dataFile, processBuffer);
-      const signArgs = [
-        "dgst",
-        "-sha256",
-        "-sign",
-        effectiveKeyPath,
-        "-out",
-        sigFile,
-        dataFile
-      ];
+      const signArgs = ["dgst", "-sha256", "-sign", effectiveKeyPath, "-out", sigFile, dataFile];
       const result = await runOpenSSL(signArgs);
       if (result.exitCode !== 0) {
         throw new Error(`Failed to sign data: ${result.stderr}`);
@@ -20176,8 +20168,8 @@ async function setKeyPermissions(keyPath) {
   }
 }
 var openSSLChecked;
-var init_chunk_MWVVZIGH = __esm({
-  "../core/dist/chunk-MWVVZIGH.js"() {
+var init_chunk_VC3BBBBO = __esm({
+  "../core/dist/chunk-VC3BBBBO.js"() {
     "use strict";
     init_esm_shims();
     openSSLChecked = false;
@@ -29107,9 +29099,9 @@ var require_canonicalize = __commonJS({
   }
 });
 
-// ../core/dist/crypto-I4ZGDVZL.js
-var crypto_I4ZGDVZL_exports = {};
-__export(crypto_I4ZGDVZL_exports, {
+// ../core/dist/crypto-CE2YISRD.js
+var crypto_CE2YISRD_exports = {};
+__export(crypto_CE2YISRD_exports, {
   checkOpenSSL: () => checkOpenSSL,
   generateKeyPair: () => generateKeyPair,
   getDefaultPrivateKeyPath: () => getDefaultPrivateKeyPath,
@@ -29118,11 +29110,11 @@ __export(crypto_I4ZGDVZL_exports, {
   sign: () => sign,
   verify: () => verify
 });
-var init_crypto_I4ZGDVZL = __esm({
-  "../core/dist/crypto-I4ZGDVZL.js"() {
+var init_crypto_CE2YISRD = __esm({
+  "../core/dist/crypto-CE2YISRD.js"() {
     "use strict";
     init_esm_shims();
-    init_chunk_MWVVZIGH();
+    init_chunk_VC3BBBBO();
   }
 });
 
@@ -29132,13 +29124,13 @@ var core = __toESM(require_core(), 1);
 
 // ../core/dist/index.js
 init_esm_shims();
-init_chunk_MWVVZIGH();
-init_chunk_MWVVZIGH();
+init_chunk_VC3BBBBO();
+init_chunk_VC3BBBBO();
 var import_yaml = __toESM(require_dist(), 1);
 import * as fs2 from "fs";
 import { readFileSync as readFileSync2 } from "fs";
-import * as fs5 from "fs/promises";
-import { readFile as readFile2 } from "fs/promises";
+import * as fs6 from "fs/promises";
+import { readFile as readFile3 } from "fs/promises";
 import * as path4 from "path";
 import { join as join3, resolve as resolve3 } from "path";
 
@@ -34095,7 +34087,7 @@ async function loadConfig(configPath) {
     );
   }
   try {
-    const content = await readFile2(resolvedPath, "utf8");
+    const content = await readFile3(resolvedPath, "utf8");
     const format = getConfigFormat(resolvedPath);
     return parseConfigContent(content, format);
   } catch (error2) {
@@ -34299,7 +34291,7 @@ function canonicalizeAttestations(attestations) {
   return canonical;
 }
 async function readAndVerifyAttestations(options) {
-  const { verify: verify2 } = await Promise.resolve().then(() => (init_crypto_I4ZGDVZL(), crypto_I4ZGDVZL_exports));
+  const { verify: verify2 } = await Promise.resolve().then(() => (init_crypto_CE2YISRD(), crypto_CE2YISRD_exports));
   const file = await readAttestations(options.filePath);
   if (!file) {
     throw new Error(`Attestations file not found: ${options.filePath}`);
@@ -34467,7 +34459,7 @@ var FilesystemKeyProvider = class {
    */
   async keyExists(keyRef) {
     try {
-      await fs5.access(keyRef);
+      await fs6.access(keyRef);
       return true;
     } catch {
       return false;
@@ -34625,18 +34617,10 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
         `Key not found in 1Password: "${keyRef}" (vault: ${this.vault})` + (this.account ? ` (account: ${this.account})` : "")
       );
     }
-    const tempDir = await fs5.mkdtemp(path4.join(os2.tmpdir(), "attest-it-"));
+    const tempDir = await fs6.mkdtemp(path4.join(os2.tmpdir(), "attest-it-"));
     const tempKeyPath = path4.join(tempDir, "private.pem");
     try {
-      const args = [
-        "document",
-        "get",
-        keyRef,
-        "--vault",
-        this.vault,
-        "--out-file",
-        tempKeyPath
-      ];
+      const args = ["document", "get", keyRef, "--vault", this.vault, "--out-file", tempKeyPath];
       if (this.account) {
         args.push("--account", this.account);
       }
@@ -34646,15 +34630,15 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
         keyPath: tempKeyPath,
         cleanup: async () => {
           try {
-            await fs5.unlink(tempKeyPath);
-            await fs5.rmdir(tempDir);
+            await fs6.unlink(tempKeyPath);
+            await fs6.rmdir(tempDir);
           } catch {
           }
         }
       };
     } catch (error2) {
       try {
-        await fs5.rm(tempDir, { recursive: true, force: true });
+        await fs6.rm(tempDir, { recursive: true, force: true });
       } catch {
       }
       throw error2;
@@ -34667,7 +34651,7 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
    */
   async generateKeyPair(options) {
     const { publicKeyPath, force = false } = options;
-    const tempDir = await fs5.mkdtemp(path4.join(os2.tmpdir(), "attest-it-keygen-"));
+    const tempDir = await fs6.mkdtemp(path4.join(os2.tmpdir(), "attest-it-keygen-"));
     const tempPrivateKeyPath = path4.join(tempDir, "private.pem");
     try {
       await generateKeyPair({
@@ -34688,8 +34672,8 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
         args.push("--account", this.account);
       }
       await execCommand("op", args);
-      await fs5.unlink(tempPrivateKeyPath);
-      await fs5.rmdir(tempDir);
+      await fs6.unlink(tempPrivateKeyPath);
+      await fs6.rmdir(tempDir);
       return {
         privateKeyRef: this.itemName,
         publicKeyPath,
@@ -34697,7 +34681,7 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
       };
     } catch (error2) {
       try {
-        await fs5.rm(tempDir, { recursive: true, force: true });
+        await fs6.rm(tempDir, { recursive: true, force: true });
       } catch {
       }
       throw error2;
@@ -34718,6 +34702,172 @@ var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
   }
 };
 async function execCommand(command, args) {
+  return new Promise((resolve32, reject) => {
+    const proc = spawn2(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+    proc.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve32(stdout.trim());
+      } else {
+        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
+      }
+    });
+    proc.on("error", (error2) => {
+      reject(error2);
+    });
+  });
+}
+var MacOSKeychainKeyProvider = class _MacOSKeychainKeyProvider {
+  type = "macos-keychain";
+  displayName = "macOS Keychain";
+  itemName;
+  static ACCOUNT = "attest-it";
+  /**
+   * Create a new MacOSKeychainKeyProvider.
+   * @param options - Provider options
+   */
+  constructor(options) {
+    this.itemName = options.itemName;
+  }
+  /**
+   * Check if this provider is available.
+   * Only available on macOS platforms.
+   */
+  static isAvailable() {
+    return process.platform === "darwin";
+  }
+  /**
+   * Check if this provider is available on the current system.
+   */
+  isAvailable() {
+    return Promise.resolve(_MacOSKeychainKeyProvider.isAvailable());
+  }
+  /**
+   * Check if a key exists in the keychain.
+   * @param keyRef - Item name in keychain
+   */
+  async keyExists(keyRef) {
+    try {
+      await execCommand2("security", [
+        "find-generic-password",
+        "-a",
+        _MacOSKeychainKeyProvider.ACCOUNT,
+        "-s",
+        keyRef
+      ]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  /**
+   * Get the private key from keychain for signing.
+   * Downloads to a temporary file and returns a cleanup function.
+   * @param keyRef - Item name in keychain
+   * @throws Error if the key does not exist in keychain
+   */
+  async getPrivateKey(keyRef) {
+    if (!await this.keyExists(keyRef)) {
+      throw new Error(
+        `Key not found in macOS Keychain: "${keyRef}" (account: ${_MacOSKeychainKeyProvider.ACCOUNT})`
+      );
+    }
+    const tempDir = await fs6.mkdtemp(path4.join(os2.tmpdir(), "attest-it-"));
+    const tempKeyPath = path4.join(tempDir, "private.pem");
+    try {
+      const base64Key = await execCommand2("security", [
+        "find-generic-password",
+        "-a",
+        _MacOSKeychainKeyProvider.ACCOUNT,
+        "-s",
+        keyRef,
+        "-w"
+      ]);
+      const keyContent = Buffer.from(base64Key, "base64").toString("utf8");
+      await fs6.writeFile(tempKeyPath, keyContent, { mode: 384 });
+      await setKeyPermissions(tempKeyPath);
+      return {
+        keyPath: tempKeyPath,
+        cleanup: async () => {
+          try {
+            await fs6.unlink(tempKeyPath);
+            await fs6.rmdir(tempDir);
+          } catch {
+          }
+        }
+      };
+    } catch (error2) {
+      try {
+        await fs6.rm(tempDir, { recursive: true, force: true });
+      } catch {
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Generate a new keypair and store private key in keychain.
+   * Public key is written to filesystem for repository commit.
+   * @param options - Key generation options
+   */
+  async generateKeyPair(options) {
+    const { publicKeyPath, force = false } = options;
+    const tempDir = await fs6.mkdtemp(path4.join(os2.tmpdir(), "attest-it-keygen-"));
+    const tempPrivateKeyPath = path4.join(tempDir, "private.pem");
+    try {
+      await generateKeyPair({
+        privatePath: tempPrivateKeyPath,
+        publicPath: publicKeyPath,
+        force
+      });
+      const privateKeyContent = await fs6.readFile(tempPrivateKeyPath, "utf8");
+      const base64Key = Buffer.from(privateKeyContent, "utf8").toString("base64");
+      await execCommand2("security", [
+        "add-generic-password",
+        "-a",
+        _MacOSKeychainKeyProvider.ACCOUNT,
+        "-s",
+        this.itemName,
+        "-w",
+        base64Key,
+        "-T",
+        "",
+        "-U"
+      ]);
+      await fs6.unlink(tempPrivateKeyPath);
+      await fs6.rmdir(tempDir);
+      return {
+        privateKeyRef: this.itemName,
+        publicKeyPath,
+        storageDescription: `macOS Keychain: ${this.itemName}`
+      };
+    } catch (error2) {
+      try {
+        await fs6.rm(tempDir, { recursive: true, force: true });
+      } catch {
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return {
+      type: this.type,
+      options: {
+        itemName: this.itemName
+      }
+    };
+  }
+};
+async function execCommand2(command, args) {
   return new Promise((resolve32, reject) => {
     const proc = spawn2(command, args, { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
@@ -34792,6 +34942,14 @@ KeyProviderRegistry.register("1password", (config) => {
     return new OnePasswordKeyProvider({ account, vault, itemName });
   }
   return new OnePasswordKeyProvider({ vault, itemName });
+});
+KeyProviderRegistry.register("macos-keychain", (config) => {
+  const { options } = config;
+  const itemName = typeof options.itemName === "string" ? options.itemName : "";
+  if (!itemName) {
+    throw new Error("macOS Keychain provider requires itemName option");
+  }
+  return new MacOSKeychainKeyProvider({ itemName });
 });
 
 // src/index.ts

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -47,7 +47,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["filesystem", "1password"],
+              "enum": ["filesystem", "1password", "macos-keychain"],
               "description": "Key provider type"
             },
             "options": {


### PR DESCRIPTION
# PR: feat: add 1Password and macOS Keychain key providers

## Summary

This PR adds support for storing private signing keys in 1Password and macOS Keychain, providing more secure alternatives to filesystem storage.

**New Features:**

- **KeyProvider abstraction**: Extensible interface for pluggable key storage backends
- **1Password provider**: Store and retrieve private keys from 1Password vaults via the `op` CLI
- **macOS Keychain provider**: Store and retrieve private keys from the macOS login keychain
- **Interactive keygen**: New interactive mode in `keygen` command for selecting storage provider and configuration
- **Backward compatible**: Existing filesystem-based key storage continues to work unchanged

## Usage

```bash
# Interactive key generation (auto-detects available providers)
attest-it keygen

# Non-interactive with 1Password
attest-it keygen --provider 1password --vault Private --item-name my-signing-key

# Non-interactive with macOS Keychain
attest-it keygen --provider macos-keychain --item-name my-signing-key
```

## Configuration

```yaml
# 1Password
settings:
  publicKeyPath: .attest-it/pubkey.pem
  keyProvider:
    type: 1password
    options:
      vault: Private
      itemName: attest-it-private-key
      account: user@example.com  # optional

# macOS Keychain
settings:
  publicKeyPath: .attest-it/pubkey.pem
  keyProvider:
    type: macos-keychain
    options:
      itemName: attest-it-private-key
```

## Test plan

- [x] Unit tests for 1Password provider (31 tests)
- [x] Unit tests for macOS Keychain provider (26 tests)
- [x] Interactive keygen tests updated
- [x] Config schema updated
- [ ] Manual testing per MANUAL_TESTS.md
