### PR TITLE
fix: stop CI from fetching manual-attestation policy off the PR branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Test
         run: pnpm run test
 
+      - name: Check policy-ref guard self-test
+        run: node scripts/check-policy-ref-guard.mjs --self-test
+
+      - name: Check no unsafe policy-ref overrides in workflows
+        run: node scripts/check-policy-ref-guard.mjs
+
   # Test the GitHub Action using act (runs action in simulated GitHub environment)
   test-action:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-attest-it.yml
+++ b/.github/workflows/test-attest-it.yml
@@ -18,7 +18,12 @@ jobs:
           working-directory: packages/github-action/test/fixtures/valid-attestation
           policy-path: .attest-it/policy.yaml
           config-path: .attest-it/config.yaml
-          # Use PR branch for policy since test fixtures only exist in PR
+          # Use PR branch for policy since test fixtures only exist in PR.
+          # WARNING: this override is safe ONLY because it targets a fixture
+          # policy.yaml with no real trust value. NEVER copy this pattern into
+          # a workflow that gates a real .attest-it/policy.yaml (see issue #74)
+          # — doing so lets a PR author supply their own policy instead of the
+          # trusted base-branch version.
           policy-ref: ${{ github.head_ref }}
           fail-on-missing: 'true'
 
@@ -40,7 +45,12 @@ jobs:
           working-directory: packages/github-action/test/fixtures/missing-attestation
           policy-path: .attest-it/policy.yaml
           config-path: .attest-it/config.yaml
-          # Use PR branch for policy since test fixtures only exist in PR
+          # Use PR branch for policy since test fixtures only exist in PR.
+          # WARNING: this override is safe ONLY because it targets a fixture
+          # policy.yaml with no real trust value. NEVER copy this pattern into
+          # a workflow that gates a real .attest-it/policy.yaml (see issue #74)
+          # — doing so lets a PR author supply their own policy instead of the
+          # trusted base-branch version.
           policy-ref: ${{ github.head_ref }}
           fail-on-missing: 'true'
 

--- a/.github/workflows/verify-manual-attestations.yml
+++ b/.github/workflows/verify-manual-attestations.yml
@@ -1,8 +1,10 @@
 name: Verify Manual Test Attestations
 
 # This workflow verifies that manual test attestations exist and are valid.
-# The config file contains both trust model (team, gates) and operational
-# config (suites, commands) in a single file.
+# Trust model (team, gates, authorizedSigners) lives in .attest-it/policy.yaml;
+# operational config (suites, commands) lives in .attest-it/config.yaml. This
+# workflow references config.yaml, and the Action resolves policy.yaml itself
+# via its safe base-branch default (see below).
 #
 # attest-it-guard: real-policy-gate
 # This workflow gates the real .attest-it/policy.yaml, which holds every team

--- a/.github/workflows/verify-manual-attestations.yml
+++ b/.github/workflows/verify-manual-attestations.yml
@@ -3,6 +3,15 @@ name: Verify Manual Test Attestations
 # This workflow verifies that manual test attestations exist and are valid.
 # The config file contains both trust model (team, gates) and operational
 # config (suites, commands) in a single file.
+#
+# attest-it-guard: real-policy-gate
+# This workflow gates the real .attest-it/policy.yaml, which holds every team
+# member's Ed25519 public key and each gate's authorizedSigners list. It must
+# NEVER pass an explicit `policy-ref` input to ./packages/github-action — doing
+# so would let a PR author supply their own edited policy.yaml instead of the
+# trusted base-branch version, defeating the Action's safe default (see
+# packages/github-action/src/index.ts and fetch-policy.ts). This is enforced
+# in CI by scripts/check-policy-ref-guard.mjs.
 
 on:
   pull_request:
@@ -32,8 +41,5 @@ jobs:
         uses: ./packages/github-action
         with:
           config-path: .attest-it/config.yaml
-          # Use PR branch for policy since this is the initial dogfooding setup
-          # and policy.yaml doesn't exist on main yet
-          policy-ref: ${{ github.head_ref }}
           fail-on-missing: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/check-policy-ref-guard.mjs
+++ b/scripts/check-policy-ref-guard.mjs
@@ -24,7 +24,12 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const GUARD_MARKER = 'attest-it-guard: real-policy-gate'
-const POLICY_REF_PATTERN = /^\s*policy-ref\s*:/
+// Case-insensitive and tolerant of a quoted key (single or double quotes) so a
+// human-written variant like `"policy-ref":` or `Policy-Ref:` can't slip past
+// the guard. YAML keys are technically case-sensitive, but this is a
+// defense-in-depth check, not a YAML parser — it must catch every way a
+// human might write this key, not just the canonical unquoted lowercase form.
+const POLICY_REF_PATTERN = /^\s*["']?policy-ref["']?\s*:/i
 
 /**
  * Find policy-ref violations in a single workflow file's content.
@@ -87,6 +92,30 @@ jobs:
           policy-ref: \${{ github.head_ref }}
 `
 
+  const QUOTED_KEY_WORKFLOW = `name: Verify Manual Test Attestations
+# attest-it-guard: real-policy-gate
+on:
+  pull_request:
+jobs:
+  verify:
+    steps:
+      - uses: ./packages/github-action
+        with:
+          "policy-ref": \${{ github.head_ref }}
+`
+
+  const UPPERCASED_KEY_WORKFLOW = `name: Verify Manual Test Attestations
+# attest-it-guard: real-policy-gate
+on:
+  pull_request:
+jobs:
+  verify:
+    steps:
+      - uses: ./packages/github-action
+        with:
+          Policy-Ref: \${{ github.head_ref }}
+`
+
   const cases = [
     {
       name: 'old workflow with reinstated override',
@@ -98,6 +127,16 @@ jobs:
       name: 'unmarked fixture workflow',
       content: UNMARKED_FIXTURE_WORKFLOW,
       expectViolation: false,
+    },
+    {
+      name: 'quoted-key override',
+      content: QUOTED_KEY_WORKFLOW,
+      expectViolation: true,
+    },
+    {
+      name: 'uppercased-key override',
+      content: UPPERCASED_KEY_WORKFLOW,
+      expectViolation: true,
     },
   ]
 

--- a/scripts/check-policy-ref-guard.mjs
+++ b/scripts/check-policy-ref-guard.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Guards against the class of bug fixed in issue #74: a workflow that gates
+ * a REAL .attest-it/policy.yaml passing an explicit `policy-ref` input to the
+ * attest-it GitHub Action. That input overrides the Action's safe default
+ * (base-branch policy fetch in PR context — see
+ * packages/github-action/src/index.ts and fetch-policy.ts), letting a PR
+ * author supply their own edited policy.yaml instead of the trusted
+ * base-branch version.
+ *
+ * Scope: only workflows explicitly opted in via the `attest-it-guard:
+ * real-policy-gate` marker comment are checked. This keeps the guard narrow —
+ * it must never block the legitimate `policy-ref` override in
+ * test-attest-it.yml, which only exercises the Action against fixtures that
+ * carry no real trust value.
+ *
+ * Usage:
+ *   node scripts/check-policy-ref-guard.mjs             # check real workflow files
+ *   node scripts/check-policy-ref-guard.mjs --self-test  # verify the guard's own logic
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const GUARD_MARKER = 'attest-it-guard: real-policy-gate'
+const POLICY_REF_PATTERN = /^\s*policy-ref\s*:/
+
+/**
+ * Find policy-ref violations in a single workflow file's content.
+ *
+ * A violation is any `policy-ref:` line in a file that carries the
+ * `attest-it-guard: real-policy-gate` opt-in marker.
+ *
+ * @param {string} content - Full text content of the workflow YAML file.
+ * @param {string} name - File name/path, used only for reporting.
+ * @returns {{ file: string, line: number, text: string }[]} Violations found.
+ */
+export function findViolations(content, name) {
+  if (!content.includes(GUARD_MARKER)) {
+    return []
+  }
+
+  const violations = []
+  const lines = content.split('\n')
+  for (const [index, line] of lines.entries()) {
+    if (POLICY_REF_PATTERN.test(line)) {
+      violations.push({ file: name, line: index + 1, text: line.trim() })
+    }
+  }
+  return violations
+}
+
+function runSelfTest() {
+  const OLD_WORKFLOW_WITH_OVERRIDE = `name: Verify Manual Test Attestations
+# attest-it-guard: real-policy-gate
+on:
+  pull_request:
+jobs:
+  verify:
+    steps:
+      - uses: ./packages/github-action
+        with:
+          policy-ref: \${{ github.head_ref }}
+`
+
+  const FIXED_WORKFLOW = `name: Verify Manual Test Attestations
+# attest-it-guard: real-policy-gate
+on:
+  pull_request:
+jobs:
+  verify:
+    steps:
+      - uses: ./packages/github-action
+        with:
+          config-path: .attest-it/config.yaml
+`
+
+  const UNMARKED_FIXTURE_WORKFLOW = `name: Test attest-it Action
+on:
+  pull_request:
+jobs:
+  test:
+    steps:
+      - uses: ./packages/github-action
+        with:
+          policy-ref: \${{ github.head_ref }}
+`
+
+  const cases = [
+    {
+      name: 'old workflow with reinstated override',
+      content: OLD_WORKFLOW_WITH_OVERRIDE,
+      expectViolation: true,
+    },
+    { name: 'fixed workflow', content: FIXED_WORKFLOW, expectViolation: false },
+    {
+      name: 'unmarked fixture workflow',
+      content: UNMARKED_FIXTURE_WORKFLOW,
+      expectViolation: false,
+    },
+  ]
+
+  let failed = false
+  for (const testCase of cases) {
+    const violations = findViolations(testCase.content, testCase.name)
+    const gotViolation = violations.length > 0
+    const ok = gotViolation === testCase.expectViolation
+    console.log(
+      `${ok ? 'PASS' : 'FAIL'}: ${testCase.name} — expected violation=${String(testCase.expectViolation)}, got=${String(gotViolation)}`,
+    )
+    if (!ok) failed = true
+  }
+
+  if (failed) {
+    console.error('\nSelf-test failed: guard logic does not match expected behavior.')
+    process.exit(1)
+  }
+  console.log(
+    '\nSelf-test passed: guard correctly flags the regressed pattern and allows the fixed/fixture patterns.',
+  )
+}
+
+function runRealCheck() {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+  const workflowsDir = join(repoRoot, '.github', 'workflows')
+  const workflowFiles = readdirSync(workflowsDir).filter(
+    (f) => f.endsWith('.yml') || f.endsWith('.yaml'),
+  )
+
+  const allViolations = []
+  for (const file of workflowFiles) {
+    const content = readFileSync(join(workflowsDir, file), 'utf8')
+    allViolations.push(...findViolations(content, `.github/workflows/${file}`))
+  }
+
+  if (allViolations.length > 0) {
+    console.error('policy-ref guard violation(s) found:\n')
+    for (const v of allViolations) {
+      console.error(`  ${v.file}:${String(v.line)}: ${v.text}`)
+    }
+    console.error(
+      '\nA workflow marked `attest-it-guard: real-policy-gate` must never pass an explicit ' +
+        '`policy-ref` input — doing so lets a PR author supply their own policy.yaml instead of ' +
+        'the trusted base-branch version. See issue #74.',
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `No policy-ref guard violations found across ${String(workflowFiles.length)} workflow file(s).`,
+  )
+}
+
+const args = process.argv.slice(2)
+if (args.includes('--self-test')) {
+  runSelfTest()
+} else {
+  runRealCheck()
+}


### PR DESCRIPTION
Refs #74

## Problem

`.github/workflows/verify-manual-attestations.yml` passed
`policy-ref: ${{ github.head_ref }}` to the attest-it Action, overriding its
safe default of fetching `.attest-it/policy.yaml` from the PR's **base**
branch. Since `policy.yaml` holds every team member's Ed25519 public key and
each gate's `authorizedSigners` list, this let a PR author edit their own copy
of `policy.yaml` to add their own key, self-sign a seal, and have CI report
"✓ All attestations valid" for a gate meant to prove real human/hardware
attestation happened.

`packages/github-action/src/index.ts:61-63` and `fetch-policy.ts` already
implement the correct default (base-branch fetch in PR context) — the bug was
entirely in how the workflow YAML called the Action, not in the Action's own
logic.

## Fix

- Removed the `policy-ref` override (and its now-stale "policy.yaml doesn't
  exist on main yet" justification comments) from
  `verify-manual-attestations.yml`, letting the Action's safe default apply.
- Added an explicit warning comment at both `policy-ref` override sites in
  `test-attest-it.yml` (lines 22, 44) stating this pattern must never be
  copied into a workflow gating a real `policy.yaml` — that workflow only
  exercises the Action against fixtures with no real trust value, so its
  override is fine to keep.
- Added `scripts/check-policy-ref-guard.mjs`, a CI guard against this class of
  misconfiguration recurring. Any workflow opted in via an
  `attest-it-guard: real-policy-gate` marker comment now fails CI if it passes
  an explicit `policy-ref` input at all. The script's own detection logic is
  self-tested against synthetic "old" (regressed) and "fixed" workflow content
  via `--self-test`, run as its own CI step in `ci.yml`.

## Acceptance criteria → evidence

- **Remove the override from `verify-manual-attestations.yml`**: done — see
  diff; the workflow now relies on the Action's default.
- **Keep the override in `test-attest-it.yml` with a warning comment**: done
  at both sites (lines ~22, ~30 post-edit).
- **Regression coverage via `index.test.ts:386`**: confirmed still passing —
  ran `pnpm --filter @attest-it/github-action test`, all 62 tests pass
  including "PR context > should fetch policy from base branch in PR
  context", which already proves the Action's own correct-by-default logic
  independent of this fix.
- **CI meta-check guarding against recurrence**: added
  `scripts/check-policy-ref-guard.mjs`, wired into `ci.yml` as two steps
  (`--self-test`, then the real check). Manually verified the guard's
  self-test passes, and separately confirmed by temporarily reinstating the
  override in the real `verify-manual-attestations.yml` file that the guard
  correctly flags it (`policy-ref: ${{ github.head_ref }}` at line 44) before
  restoring the fixed file.
- **Manual live-verification (throwaway PR with a tampered `policy.yaml` +
  self-signed seal)**: not executed as part of this PR — creating a PR against
  the shared repo that intentionally adds an unauthorized signer and signs a
  seal is an adversarial demonstration best run deliberately by a human
  reviewer post-merge, rather than unprompted. Reproduction steps for that
  verification: on a throwaway branch, add a new `authorizedSigners` entry to
  `.attest-it/policy.yaml` under any gate with a key you control, seal an
  artifact for that gate with the corresponding private key
  (`attest-it seal` or `createSeal()`), open a PR against `main`, and confirm
  `verify-manual-attestations.yml` now fails (policy fetched from `main`,
  which does not list the added key) — where before this fix it would have
  passed (policy fetched from the PR branch, which does list it).

## Verification run

- `pnpm build`, `pnpm check` — pass (pre-existing lint warnings only,
  unrelated to this change).
- `pnpm test` — 10 pre-existing failures in `@attest-it/core`'s
  passphrase-encrypted-key crypto tests, caused by an OpenSSL 3.6.x
  environment issue on this machine (tracked as #75); these fail identically
  on `main` and are unrelated to this change. All other packages, including
  `@attest-it/github-action` (62/62), pass.
- No changeset: this is a workflow/infrastructure-only change with no impact
  on published package code.

## Non-goals (per issue)

- No changes to `packages/github-action/src/fetch-policy.ts` or `index.ts` —
  that logic was already correct.
- Does not build the R1 root-gate mechanism (#72) or close the legacy
  `packages`-suite bypass (#68).