### PR TITLE
fix(core): passphrase-encrypted key generation/signing under OpenSSL 3.6.x

### DIFF
--- a/.changeset/fix-empty-passphrase-fd3-leak.md
+++ b/.changeset/fix-empty-passphrase-fd3-leak.md
@@ -1,0 +1,6 @@
+---
+'@attest-it/core': patch
+'attest-it': patch
+---
+
+Fix an unhandled `ECONNRESET` that could crash `generateKeyPair` when called with an empty-string passphrase (`passphrase: ''`). The internal `runOpenSSL` helper decided whether to open an extra stdio pipe (fd 3) for the passphrase using `passphrase !== undefined`, while `generateKeyPair` decided whether to reference that fd in OpenSSL's arguments (`-pass fd:3` / `-passin fd:3`) using `if (passphrase)`. Since `''` is not `undefined` but is falsy, an empty passphrase opened fd 3 without any OpenSSL argument reading it — an unconsumed pipe that could raise an unhandled error when the OpenSSL child process exited. Both checks now consistently treat an empty string the same as no passphrase, and the passphrase pipe now has a defensive `'error'` listener.

--- a/.changeset/fix-openssl-passphrase-fd.md
+++ b/.changeset/fix-openssl-passphrase-fd.md
@@ -1,0 +1,6 @@
+---
+'@attest-it/core': patch
+'attest-it': patch
+---
+
+Fix passphrase-encrypted key generation and signing failing under OpenSSL 3.6.x when the passphrase is piped via Node's `spawn` stdio. `generateKeyPair`'s public-key extraction step and `sign`'s `dgst` step now supply the passphrase through a dedicated pipe on file descriptor 3 (`-passin fd:3` / `-pass fd:3`) with stdin left as `'ignore'`, instead of `-passin stdin` / `-pass stdin`. OpenSSL 3.6.x's passphrase-reading UI routine falls back to an interactive console prompt (fatal outside a TTY) whenever fd 0 is a Node-created pipe, regardless of which fd actually carries the passphrase — this sidesteps that fallback.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Report OpenSSL version
+        run: openssl version
+
       - name: Build
         run: pnpm run build
 

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -10,6 +10,7 @@
  */
 
 import { spawn } from 'node:child_process'
+import { Writable } from 'node:stream'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
@@ -85,33 +86,50 @@ interface SpawnResult {
 
 /**
  * Run OpenSSL with the given arguments.
+ *
+ * @remarks
+ * When `passphrase` is supplied, it is written to an extra pipe on stdio slot
+ * 3, which `args` must reference as `fd:3` (e.g. `-pass fd:3`, `-passin fd:3`).
+ * stdin (fd 0) is deliberately left as `'ignore'` rather than `'pipe'`.
+ *
+ * Investigation (see issue #75) found the root cause is not which fd carries
+ * the passphrase: a passphrase piped via `fd:3` fails identically to one piped
+ * via `stdin` as long as fd 0 is *also* a Node `spawn`-created pipe. OpenSSL
+ * 3.6.x's passphrase-reading UI routine — used by the `pkey` and `dgst`
+ * subcommands, though apparently not `genpkey` — falls back to an interactive
+ * console prompt (`UI routines:open_console`, fatal outside a TTY) whenever fd
+ * 0 is that kind of pipe, regardless of where the actual passphrase comes
+ * from. Setting fd 0 to `'ignore'` avoids the fallback; the passphrase is then
+ * supplied cleanly through the unrelated fd 3 pipe.
+ *
  * @param args - Command-line arguments for OpenSSL
- * @param stdin - Optional data to write to stdin
+ * @param passphrase - Optional passphrase to supply via an extra fd (args must reference `fd:3`)
  * @returns Process result with exit code and outputs
  * @internal
  */
-async function runOpenSSL(args: string[], stdin?: Buffer): Promise<SpawnResult> {
+async function runOpenSSL(args: string[], passphrase?: string): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn('openssl', args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
+    const stdio: ('pipe' | 'ignore')[] =
+      passphrase !== undefined ? ['ignore', 'pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe']
+
+    const child = spawn('openssl', args, { stdio })
 
     const stdoutChunks: Buffer[] = []
     let stderr = ''
 
-    child.stdout.on('data', (chunk: Buffer) => {
+    child.stdout?.on('data', (chunk: Buffer) => {
       stdoutChunks.push(chunk)
     })
 
-    child.stderr.on('data', (chunk: Buffer) => {
+    child.stderr?.on('data', (chunk: Buffer) => {
       stderr += chunk.toString()
     })
 
-    child.on('error', (err) => {
+    child.on('error', (err: Error) => {
       reject(new Error(`Failed to spawn OpenSSL: ${err.message}`))
     })
 
-    child.on('close', (code) => {
+    child.on('close', (code: number | null) => {
       resolve({
         exitCode: code ?? 1,
         stdout: Buffer.concat(stdoutChunks),
@@ -119,10 +137,16 @@ async function runOpenSSL(args: string[], stdin?: Buffer): Promise<SpawnResult> 
       })
     })
 
-    if (stdin) {
-      child.stdin.write(stdin)
+    if (passphrase !== undefined) {
+      const passphraseStream = child.stdio[3]
+      if (!(passphraseStream instanceof Writable)) {
+        reject(new Error('Expected a writable stream for the passphrase file descriptor'))
+        return
+      }
+      // Consistently use a newline terminator, matching prior stdin-based behavior.
+      passphraseStream.write(passphrase + '\n')
+      passphraseStream.end()
     }
-    child.stdin.end()
   })
 }
 
@@ -311,16 +335,10 @@ export async function generateKeyPair(options: KeygenOptions = {}): Promise<KeyP
 
     // Add encryption if passphrase is provided
     if (passphrase) {
-      genArgs.push('-aes256', '-pass', 'stdin')
+      genArgs.push('-aes256', '-pass', 'fd:3')
     }
 
-    // Note: OpenSSL reads passphrase from stdin. While OpenSSL accepts passphrases
-    // with or without trailing newlines, we consistently use newline terminators
-    // across all operations for predictable behavior.
-    const genResult = await runOpenSSL(
-      genArgs,
-      passphrase ? Buffer.from(passphrase + '\n') : undefined,
-    )
+    const genResult = await runOpenSSL(genArgs, passphrase)
     if (genResult.exitCode !== 0) {
       throw new Error(`Failed to generate private key: ${genResult.stderr}`)
     }
@@ -331,12 +349,9 @@ export async function generateKeyPair(options: KeygenOptions = {}): Promise<KeyP
     // Extract public key (need passphrase if key is encrypted)
     const pubArgs = ['pkey', '-in', privatePath, '-pubout', '-out', publicPath]
     if (passphrase) {
-      pubArgs.push('-passin', 'stdin')
+      pubArgs.push('-passin', 'fd:3')
     }
-    const pubResult = await runOpenSSL(
-      pubArgs,
-      passphrase ? Buffer.from(passphrase + '\n') : undefined,
-    )
+    const pubResult = await runOpenSSL(pubArgs, passphrase)
 
     if (pubResult.exitCode !== 0) {
       throw new Error(`Failed to extract public key: ${pubResult.stderr}`)
@@ -417,16 +432,12 @@ export async function sign(options: SignOptions): Promise<string> {
 
       // Add passphrase support for encrypted keys
       if (passphrase) {
-        signArgs.push('-passin', 'stdin')
+        signArgs.push('-passin', 'fd:3')
       }
 
       signArgs.push('-sign', effectiveKeyPath, '-out', sigFile, dataFile)
 
-      // Note: We consistently use newline terminators for passphrases passed via stdin
-      const result = await runOpenSSL(
-        signArgs,
-        passphrase ? Buffer.from(passphrase + '\n') : undefined,
-      )
+      const result = await runOpenSSL(signArgs, passphrase)
 
       if (result.exitCode !== 0) {
         // Detect passphrase-related errors and provide a clearer message

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -102,6 +102,14 @@ interface SpawnResult {
  * from. Setting fd 0 to `'ignore'` avoids the fallback; the passphrase is then
  * supplied cleanly through the unrelated fd 3 pipe.
  *
+ * An empty-string passphrase is treated the same as no passphrase at all
+ * (matching the `if (passphrase)` checks in {@link generateKeyPair} and
+ * {@link sign} that decide whether `args` references `fd:3`): fd 3 is only
+ * opened when there is a non-empty passphrase. Opening it whenever
+ * `passphrase !== undefined` would leave slot 3 open with nothing in `args`
+ * to read it for an empty string, an unconsumed pipe that can raise an
+ * unhandled `ECONNRESET` when the child process exits (see issue #75/#79).
+ *
  * @param args - Command-line arguments for OpenSSL
  * @param passphrase - Optional passphrase to supply via an extra fd (args must reference `fd:3`)
  * @returns Process result with exit code and outputs
@@ -109,8 +117,9 @@ interface SpawnResult {
  */
 async function runOpenSSL(args: string[], passphrase?: string): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
-    const stdio: ('pipe' | 'ignore')[] =
-      passphrase !== undefined ? ['ignore', 'pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe']
+    const stdio: ('pipe' | 'ignore')[] = passphrase
+      ? ['ignore', 'pipe', 'pipe', 'pipe']
+      : ['ignore', 'pipe', 'pipe']
 
     const child = spawn('openssl', args, { stdio })
 
@@ -137,12 +146,19 @@ async function runOpenSSL(args: string[], passphrase?: string): Promise<SpawnRes
       })
     })
 
-    if (passphrase !== undefined) {
+    if (passphrase) {
       const passphraseStream = child.stdio[3]
       if (!(passphraseStream instanceof Writable)) {
         reject(new Error('Expected a writable stream for the passphrase file descriptor'))
         return
       }
+      // Defensive: the 'close' handler above already surfaces the child's
+      // real failure via exit code/stderr, so an 'error' here (e.g. the
+      // child exiting before fully reading the passphrase) should not crash
+      // the process as an unhandled event.
+      passphraseStream.on('error', () => {
+        // Intentionally swallowed; see comment above.
+      })
       // Consistently use a newline terminator, matching prior stdin-based behavior.
       passphraseStream.write(passphrase + '\n')
       passphraseStream.end()

--- a/packages/core/test/crypto.test.ts
+++ b/packages/core/test/crypto.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as fsSync from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import { spawn } from 'node:child_process'
 import {
   checkOpenSSL,
   getDefaultPrivateKeyPath,
@@ -13,6 +14,14 @@ import {
   verify,
   setKeyPermissions,
 } from '../src/crypto.js'
+
+// Wraps the real `spawn` in a vi.fn so tests can assert on how crypto.ts
+// invoked OpenSSL (e.g. the `stdio` array) without changing its behavior --
+// every call still runs the real `openssl` binary.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, spawn: vi.fn(actual.spawn) }
+})
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures', 'test-keys')
 const TEST_PRIVATE = path.join(FIXTURES_DIR, 'test-private.pem')
@@ -189,6 +198,37 @@ describe('crypto', () => {
 
       expect(fsSync.existsSync(privatePath)).toBe(true)
       expect(fsSync.existsSync(publicPath)).toBe(true)
+    })
+
+    // Regression test for #79: an empty-string passphrase made runOpenSSL()
+    // open a 4th stdio slot (fd 3) for the passphrase pipe -- its guard was
+    // `passphrase !== undefined`, which is true for '' -- while
+    // generateKeyPair()'s `if (passphrase)` guard is falsy for '' and never
+    // pushed `-pass fd:3`/`-passin fd:3` onto the openssl args. That left fd 3
+    // open with nothing reading it: an unconsumed pipe with no 'error'
+    // listener, which raised an unhandled ECONNRESET when the openssl child
+    // process exited (surfaced in CI as 2 unhandled errors attributed to
+    // the "should return encrypted=false for empty passphrase" test in
+    // key-provider/filesystem-provider.test.ts). This asserts the exact
+    // structural invariant directly -- no fd:3 pipe is opened unless an
+    // openssl argument references fd:3 -- rather than relying on the
+    // ECONNRESET race reproducing, which is timing/platform-sensitive.
+    it('should not open an unread fd:3 pipe for an empty-string passphrase', async () => {
+      const spawnMock = vi.mocked(spawn)
+      spawnMock.mockClear()
+
+      const privatePath = path.join(tmpDir, 'empty-pass-private.pem')
+      const publicPath = path.join(tmpDir, 'empty-pass-public.pem')
+
+      await generateKeyPair({ privatePath, publicPath, passphrase: '' })
+
+      expect(spawnMock).toHaveBeenCalled()
+      for (const [, args, options] of spawnMock.mock.calls) {
+        const argList = args as string[]
+        const stdio = (options as { stdio?: unknown[] } | undefined)?.stdio
+        expect(argList).not.toContain('fd:3')
+        expect(stdio).toHaveLength(3)
+      }
     })
 
     it('should use default paths if none specified', async () => {

--- a/packages/core/test/crypto.test.ts
+++ b/packages/core/test/crypto.test.ts
@@ -583,6 +583,33 @@ describe('crypto', () => {
         // Keys should be different
         expect(secondPrivate).not.toBe(firstPrivate)
       })
+
+      // Regression test for #75: `openssl pkey -in <priv> -pubout -passin stdin`
+      // failed under OpenSSL 3.6.x when driven by Node's spawn pipe stdio,
+      // throwing "Could not find private key of key from <path>" /
+      // "UI routines:open_console:unknown ttyget errno value" — even though
+      // the immediately preceding `openssl genpkey ... -pass stdin` step (in
+      // the same function) succeeded. This exercises the public-key
+      // extraction step repeatedly, since the underlying bug was a pipe/fd
+      // interaction rather than a pure logic error and could pass
+      // intermittently if only exercised once.
+      it('should extract public key from an encrypted private key across repeated invocations', async () => {
+        for (let i = 0; i < 3; i++) {
+          const iteration = i.toString()
+          const iterPrivate = path.join(tmpDir, `repeat-private-${iteration}.pem`)
+          const iterPublic = path.join(tmpDir, `repeat-public-${iteration}.pem`)
+
+          const result = await generateKeyPair({
+            privatePath: iterPrivate,
+            publicPath: iterPublic,
+            passphrase: testPassphrase,
+          })
+
+          expect(result.publicPath).toBe(iterPublic)
+          const publicKeyContent = await fs.readFile(iterPublic, 'utf8')
+          expect(publicKeyContent).toMatch(/PUBLIC KEY/)
+        }
+      })
     })
 
     describe('sign with encrypted key', () => {
@@ -626,6 +653,25 @@ describe('crypto', () => {
             // No passphrase provided
           }),
         ).rejects.toThrow()
+      })
+
+      // Regression test for #75: `openssl dgst -sha256 -passin stdin -sign <priv>`
+      // failed the same way as the pkey extraction step under OpenSSL 3.6.x
+      // when driven by Node's spawn pipe stdio. Signs repeatedly with the same
+      // encrypted key, since the underlying pipe/fd interaction was
+      // order/timing-sensitive and could pass intermittently if only
+      // exercised once.
+      it('should sign repeatedly with an encrypted key without a console-fallback error', async () => {
+        for (let i = 0; i < 3; i++) {
+          const signature = await sign({
+            privateKeyPath: privatePath,
+            data: `repeat signing test data ${i.toString()}`,
+            passphrase: testPassphrase,
+          })
+
+          expect(signature).toBeTruthy()
+          expect(() => Buffer.from(signature, 'base64')).not.toThrow()
+        }
       })
     })
 

--- a/packages/core/test/crypto.test.ts
+++ b/packages/core/test/crypto.test.ts
@@ -224,10 +224,21 @@ describe('crypto', () => {
 
       expect(spawnMock).toHaveBeenCalled()
       for (const [, args, options] of spawnMock.mock.calls) {
-        const argList = args as string[]
-        const stdio = (options as { stdio?: unknown[] } | undefined)?.stdio
-        expect(argList).not.toContain('fd:3')
-        expect(stdio).toHaveLength(3)
+        expect(Array.isArray(args)).toBe(true)
+        if (!Array.isArray(args)) {
+          continue
+        }
+        expect(args).not.toContain('fd:3')
+
+        expect(options).toBeTypeOf('object')
+        if (typeof options !== 'object') {
+          continue
+        }
+        expect('stdio' in options && Array.isArray(options.stdio)).toBe(true)
+        if (!('stdio' in options) || !Array.isArray(options.stdio)) {
+          continue
+        }
+        expect(options.stdio).toHaveLength(3)
       }
     })
 

--- a/packages/core/test/crypto.test.ts
+++ b/packages/core/test/crypto.test.ts
@@ -27,6 +27,32 @@ const FIXTURES_DIR = path.join(__dirname, 'fixtures', 'test-keys')
 const TEST_PRIVATE = path.join(FIXTURES_DIR, 'test-private.pem')
 const TEST_PUBLIC = path.join(FIXTURES_DIR, 'test-public.pem')
 
+// Byte length of an RSA-2048 PKCS#1 v1.5 signature (2048 bits / 8), which is
+// fixed regardless of the signed message. crypto.ts always generates
+// RSA-2048 keys (see generateKeyPair's `rsa_keygen_bits:2048`).
+const RSA_2048_SIGNATURE_BYTE_LENGTH = 256
+
+/**
+ * Asserts that `signature` is well-formed base64 encoding a signature of the
+ * expected RSA-2048 byte length.
+ *
+ * `Buffer.from(str, 'base64')` does not reliably throw on malformed
+ * base64 -- Node's decoder silently ignores characters outside the base64
+ * alphabet rather than raising an error -- so `expect(() =>
+ * Buffer.from(signature, 'base64')).not.toThrow()` does not meaningfully
+ * validate the output. This instead checks the string against the base64
+ * character set, decodes to the expected Ed25519/RSA signature length for
+ * this codebase's RSA-2048 keys, and confirms re-encoding the decoded bytes
+ * reproduces the original string (catching truncation or trailing garbage
+ * that lenient decoding would otherwise hide).
+ */
+function expectValidRsaSignature(signature: string): void {
+  expect(signature).toMatch(/^[A-Za-z0-9+/]+={0,2}$/)
+  const decoded = Buffer.from(signature, 'base64')
+  expect(decoded).toHaveLength(RSA_2048_SIGNATURE_BYTE_LENGTH)
+  expect(decoded.toString('base64')).toBe(signature)
+}
+
 describe('crypto', () => {
   describe('checkOpenSSL', () => {
     it('should return OpenSSL/LibreSSL version string', async () => {
@@ -258,8 +284,7 @@ describe('crypto', () => {
 
       expect(signature).toBeTruthy()
       expect(typeof signature).toBe('string')
-      // Base64 signature should be valid
-      expect(() => Buffer.from(signature, 'base64')).not.toThrow()
+      expectValidRsaSignature(signature)
     })
 
     it('should throw on missing private key', async () => {
@@ -682,8 +707,7 @@ describe('crypto', () => {
 
         expect(signature).toBeTruthy()
         expect(typeof signature).toBe('string')
-        // Base64 signature should be valid
-        expect(() => Buffer.from(signature, 'base64')).not.toThrow()
+        expectValidRsaSignature(signature)
       })
 
       it('should fail to sign with wrong passphrase with clear error message', async () => {
@@ -721,7 +745,7 @@ describe('crypto', () => {
           })
 
           expect(signature).toBeTruthy()
-          expect(() => Buffer.from(signature, 'base64')).not.toThrow()
+          expectValidRsaSignature(signature)
         }
       })
     })

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -16631,7 +16631,7 @@ var require_receiver = __commonJS({
   "../../node_modules/.pnpm/undici@5.29.0/node_modules/undici/lib/websocket/receiver.js"(exports2, module2) {
     "use strict";
     init_cjs_shims();
-    var { Writable } = require("stream");
+    var { Writable: Writable2 } = require("stream");
     var diagnosticsChannel = require("diagnostics_channel");
     var { parserStates, opcodes, states, emptyBuffer } = require_constants5();
     var { kReadyState, kSentClose, kResponse, kReceivedClose } = require_symbols5();
@@ -16640,7 +16640,7 @@ var require_receiver = __commonJS({
     var channels = {};
     channels.ping = diagnosticsChannel.channel("undici:websocket:ping");
     channels.pong = diagnosticsChannel.channel("undici:websocket:pong");
-    var ByteParser = class extends Writable {
+    var ByteParser = class extends Writable2 {
       #buffers = [];
       #byteOffset = 0;
       #state = parserStates.INFO;
@@ -19944,18 +19944,17 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
   }
 });
 
-// ../core/dist/chunk-FGYLU2HL.js
-async function runOpenSSL(args, stdin) {
+// ../core/dist/chunk-RPO4GV4Y.js
+async function runOpenSSL(args, passphrase) {
   return new Promise((resolve5, reject) => {
-    const child = (0, import_child_process.spawn)("openssl", args, {
-      stdio: ["pipe", "pipe", "pipe"]
-    });
+    const stdio = passphrase !== void 0 ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
+    const child = (0, import_child_process.spawn)("openssl", args, { stdio });
     const stdoutChunks = [];
     let stderr = "";
-    child.stdout.on("data", (chunk) => {
+    child.stdout?.on("data", (chunk) => {
       stdoutChunks.push(chunk);
     });
-    child.stderr.on("data", (chunk) => {
+    child.stderr?.on("data", (chunk) => {
       stderr += chunk.toString();
     });
     child.on("error", (err) => {
@@ -19968,10 +19967,15 @@ async function runOpenSSL(args, stdin) {
         stderr
       });
     });
-    if (stdin) {
-      child.stdin.write(stdin);
+    if (passphrase !== void 0) {
+      const passphraseStream = child.stdio[3];
+      if (!(passphraseStream instanceof import_stream.Writable)) {
+        reject(new Error("Expected a writable stream for the passphrase file descriptor"));
+        return;
+      }
+      passphraseStream.write(passphrase + "\n");
+      passphraseStream.end();
     }
-    child.stdin.end();
   });
 }
 async function checkOpenSSL() {
@@ -20061,24 +20065,18 @@ async function generateKeyPair(options = {}) {
       privatePath
     ];
     if (passphrase) {
-      genArgs.push("-aes256", "-pass", "stdin");
+      genArgs.push("-aes256", "-pass", "fd:3");
     }
-    const genResult = await runOpenSSL(
-      genArgs,
-      passphrase ? Buffer.from(passphrase + "\n") : void 0
-    );
+    const genResult = await runOpenSSL(genArgs, passphrase);
     if (genResult.exitCode !== 0) {
       throw new Error(`Failed to generate private key: ${genResult.stderr}`);
     }
     await setKeyPermissions(privatePath);
     const pubArgs = ["pkey", "-in", privatePath, "-pubout", "-out", publicPath];
     if (passphrase) {
-      pubArgs.push("-passin", "stdin");
+      pubArgs.push("-passin", "fd:3");
     }
-    const pubResult = await runOpenSSL(
-      pubArgs,
-      passphrase ? Buffer.from(passphrase + "\n") : void 0
-    );
+    const pubResult = await runOpenSSL(pubArgs, passphrase);
     if (pubResult.exitCode !== 0) {
       throw new Error(`Failed to extract public key: ${pubResult.stderr}`);
     }
@@ -20098,12 +20096,13 @@ async function setKeyPermissions(keyPath) {
     await fs.chmod(keyPath, 384);
   }
 }
-var import_child_process, fs, path, os, openSSLChecked;
-var init_chunk_FGYLU2HL = __esm({
-  "../core/dist/chunk-FGYLU2HL.js"() {
+var import_child_process, import_stream, fs, path, os, openSSLChecked;
+var init_chunk_RPO4GV4Y = __esm({
+  "../core/dist/chunk-RPO4GV4Y.js"() {
     "use strict";
     init_cjs_shims();
     import_child_process = require("child_process");
+    import_stream = require("stream");
     fs = __toESM(require("fs/promises"), 1);
     path = __toESM(require("path"), 1);
     os = __toESM(require("os"), 1);
@@ -36133,8 +36132,8 @@ var import_node_path = require("path");
 
 // ../core/dist/index.js
 init_cjs_shims();
-init_chunk_FGYLU2HL();
-init_chunk_FGYLU2HL();
+init_chunk_RPO4GV4Y();
+init_chunk_RPO4GV4Y();
 var fs2 = __toESM(require("fs"), 1);
 var import_fs2 = require("fs");
 var fs7 = __toESM(require("fs/promises"), 1);

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -19944,10 +19944,10 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
   }
 });
 
-// ../core/dist/chunk-RPO4GV4Y.js
+// ../core/dist/chunk-DEX33VQV.js
 async function runOpenSSL(args, passphrase) {
   return new Promise((resolve5, reject) => {
-    const stdio = passphrase !== void 0 ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
+    const stdio = passphrase ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
     const child = (0, import_child_process.spawn)("openssl", args, { stdio });
     const stdoutChunks = [];
     let stderr = "";
@@ -19967,12 +19967,14 @@ async function runOpenSSL(args, passphrase) {
         stderr
       });
     });
-    if (passphrase !== void 0) {
+    if (passphrase) {
       const passphraseStream = child.stdio[3];
       if (!(passphraseStream instanceof import_stream.Writable)) {
         reject(new Error("Expected a writable stream for the passphrase file descriptor"));
         return;
       }
+      passphraseStream.on("error", () => {
+      });
       passphraseStream.write(passphrase + "\n");
       passphraseStream.end();
     }
@@ -20097,8 +20099,8 @@ async function setKeyPermissions(keyPath) {
   }
 }
 var import_child_process, import_stream, fs, path, os, openSSLChecked;
-var init_chunk_RPO4GV4Y = __esm({
-  "../core/dist/chunk-RPO4GV4Y.js"() {
+var init_chunk_DEX33VQV = __esm({
+  "../core/dist/chunk-DEX33VQV.js"() {
     "use strict";
     init_cjs_shims();
     import_child_process = require("child_process");
@@ -36132,8 +36134,8 @@ var import_node_path = require("path");
 
 // ../core/dist/index.js
 init_cjs_shims();
-init_chunk_RPO4GV4Y();
-init_chunk_RPO4GV4Y();
+init_chunk_DEX33VQV();
+init_chunk_DEX33VQV();
 var fs2 = __toESM(require("fs"), 1);
 var import_fs2 = require("fs");
 var fs7 = __toESM(require("fs/promises"), 1);

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -16635,7 +16635,7 @@ var require_receiver = __commonJS({
   "../../node_modules/.pnpm/undici@5.29.0/node_modules/undici/lib/websocket/receiver.js"(exports, module) {
     "use strict";
     init_esm_shims();
-    var { Writable } = __require("stream");
+    var { Writable: Writable2 } = __require("stream");
     var diagnosticsChannel = __require("diagnostics_channel");
     var { parserStates, opcodes, states, emptyBuffer } = require_constants5();
     var { kReadyState, kSentClose, kResponse, kReceivedClose } = require_symbols5();
@@ -16644,7 +16644,7 @@ var require_receiver = __commonJS({
     var channels = {};
     channels.ping = diagnosticsChannel.channel("undici:websocket:ping");
     channels.pong = diagnosticsChannel.channel("undici:websocket:pong");
-    var ByteParser = class extends Writable {
+    var ByteParser = class extends Writable2 {
       #buffers = [];
       #byteOffset = 0;
       #state = parserStates.INFO;
@@ -19948,22 +19948,22 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
   }
 });
 
-// ../core/dist/chunk-FGYLU2HL.js
+// ../core/dist/chunk-RPO4GV4Y.js
 import { spawn } from "child_process";
+import { Writable } from "stream";
 import * as fs from "fs/promises";
 import * as path2 from "path";
 import * as os from "os";
-async function runOpenSSL(args, stdin) {
+async function runOpenSSL(args, passphrase) {
   return new Promise((resolve5, reject) => {
-    const child = spawn("openssl", args, {
-      stdio: ["pipe", "pipe", "pipe"]
-    });
+    const stdio = passphrase !== void 0 ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
+    const child = spawn("openssl", args, { stdio });
     const stdoutChunks = [];
     let stderr = "";
-    child.stdout.on("data", (chunk) => {
+    child.stdout?.on("data", (chunk) => {
       stdoutChunks.push(chunk);
     });
-    child.stderr.on("data", (chunk) => {
+    child.stderr?.on("data", (chunk) => {
       stderr += chunk.toString();
     });
     child.on("error", (err) => {
@@ -19976,10 +19976,15 @@ async function runOpenSSL(args, stdin) {
         stderr
       });
     });
-    if (stdin) {
-      child.stdin.write(stdin);
+    if (passphrase !== void 0) {
+      const passphraseStream = child.stdio[3];
+      if (!(passphraseStream instanceof Writable)) {
+        reject(new Error("Expected a writable stream for the passphrase file descriptor"));
+        return;
+      }
+      passphraseStream.write(passphrase + "\n");
+      passphraseStream.end();
     }
-    child.stdin.end();
   });
 }
 async function checkOpenSSL() {
@@ -20069,24 +20074,18 @@ async function generateKeyPair(options = {}) {
       privatePath
     ];
     if (passphrase) {
-      genArgs.push("-aes256", "-pass", "stdin");
+      genArgs.push("-aes256", "-pass", "fd:3");
     }
-    const genResult = await runOpenSSL(
-      genArgs,
-      passphrase ? Buffer.from(passphrase + "\n") : void 0
-    );
+    const genResult = await runOpenSSL(genArgs, passphrase);
     if (genResult.exitCode !== 0) {
       throw new Error(`Failed to generate private key: ${genResult.stderr}`);
     }
     await setKeyPermissions(privatePath);
     const pubArgs = ["pkey", "-in", privatePath, "-pubout", "-out", publicPath];
     if (passphrase) {
-      pubArgs.push("-passin", "stdin");
+      pubArgs.push("-passin", "fd:3");
     }
-    const pubResult = await runOpenSSL(
-      pubArgs,
-      passphrase ? Buffer.from(passphrase + "\n") : void 0
-    );
+    const pubResult = await runOpenSSL(pubArgs, passphrase);
     if (pubResult.exitCode !== 0) {
       throw new Error(`Failed to extract public key: ${pubResult.stderr}`);
     }
@@ -20107,8 +20106,8 @@ async function setKeyPermissions(keyPath) {
   }
 }
 var openSSLChecked;
-var init_chunk_FGYLU2HL = __esm({
-  "../core/dist/chunk-FGYLU2HL.js"() {
+var init_chunk_RPO4GV4Y = __esm({
+  "../core/dist/chunk-RPO4GV4Y.js"() {
     "use strict";
     init_esm_shims();
     openSSLChecked = false;
@@ -36132,8 +36131,8 @@ import { resolve as resolve4 } from "path";
 
 // ../core/dist/index.js
 init_esm_shims();
-init_chunk_FGYLU2HL();
-init_chunk_FGYLU2HL();
+init_chunk_RPO4GV4Y();
+init_chunk_RPO4GV4Y();
 var import_ms = __toESM(require_ms(), 1);
 var import_yaml = __toESM(require_dist(), 1);
 import * as fs2 from "fs";

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -19948,7 +19948,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
   }
 });
 
-// ../core/dist/chunk-RPO4GV4Y.js
+// ../core/dist/chunk-DEX33VQV.js
 import { spawn } from "child_process";
 import { Writable } from "stream";
 import * as fs from "fs/promises";
@@ -19956,7 +19956,7 @@ import * as path2 from "path";
 import * as os from "os";
 async function runOpenSSL(args, passphrase) {
   return new Promise((resolve5, reject) => {
-    const stdio = passphrase !== void 0 ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
+    const stdio = passphrase ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
     const child = spawn("openssl", args, { stdio });
     const stdoutChunks = [];
     let stderr = "";
@@ -19976,12 +19976,14 @@ async function runOpenSSL(args, passphrase) {
         stderr
       });
     });
-    if (passphrase !== void 0) {
+    if (passphrase) {
       const passphraseStream = child.stdio[3];
       if (!(passphraseStream instanceof Writable)) {
         reject(new Error("Expected a writable stream for the passphrase file descriptor"));
         return;
       }
+      passphraseStream.on("error", () => {
+      });
       passphraseStream.write(passphrase + "\n");
       passphraseStream.end();
     }
@@ -20106,8 +20108,8 @@ async function setKeyPermissions(keyPath) {
   }
 }
 var openSSLChecked;
-var init_chunk_RPO4GV4Y = __esm({
-  "../core/dist/chunk-RPO4GV4Y.js"() {
+var init_chunk_DEX33VQV = __esm({
+  "../core/dist/chunk-DEX33VQV.js"() {
     "use strict";
     init_esm_shims();
     openSSLChecked = false;
@@ -36131,8 +36133,8 @@ import { resolve as resolve4 } from "path";
 
 // ../core/dist/index.js
 init_esm_shims();
-init_chunk_RPO4GV4Y();
-init_chunk_RPO4GV4Y();
+init_chunk_DEX33VQV();
+init_chunk_DEX33VQV();
 var import_ms = __toESM(require_ms(), 1);
 var import_yaml = __toESM(require_dist(), 1);
 import * as fs2 from "fs";


### PR DESCRIPTION
Refs #75

## Root cause

`generateKeyPair`'s public-key extraction step (`pkey -passin stdin`) and `sign`'s `dgst -passin stdin` step failed on OpenSSL 3.6.2 with:

```
Could not find private key of key from <path>
...UI routines:open_console:unknown ttyget errno value:crypto/ui/ui_openssl.c:457:errno=102
```

Investigation (isolated with standalone repro scripts outside vitest) found the failure is **not** about which file descriptor carries the passphrase. A passphrase piped via a dedicated `fd:3` pipe fails identically to one piped via `stdin`, as long as fd 0 (`stdin`) is *also* a Node `spawn`-created pipe. OpenSSL 3.6.x's passphrase-reading UI routine — used by the `pkey` and `dgst` subcommands, but apparently not `genpkey` — falls back to an interactive console prompt (fatal outside a TTY) whenever fd 0 is that kind of pipe, regardless of where the actual passphrase comes from. Setting fd 0 to `'ignore'` avoids the fallback entirely; the passphrase is then supplied cleanly through an unrelated pipe on fd 3.

(An earlier attempt at this fix used a real file-backed fd 3 while leaving stdin as a pipe — that also failed identically once re-verified outside a single-shot script, which is what led to isolating the true variable: `stdin`'s pipe-ness, not fd 3's file-vs-pipe-ness.)

## Fix

`runOpenSSL()` (`packages/core/src/crypto.ts`) now sets `stdio: ['ignore', 'pipe', 'pipe', 'pipe']` when a passphrase is supplied, and writes the passphrase to the fd-3 stream instead of stdin. All three call sites (`genpkey -pass fd:3`, `pkey -passin fd:3`, `dgst -passin fd:3`) were converted uniformly for consistency, since all three now pass reliably with this approach (confirmed via a 5-iteration stress test across all three during development).

## Acceptance criteria → evidence

- **All 10 named failing tests pass on this machine's OpenSSL (3.6.2)**: confirmed — `pnpm --filter @attest-it/core test` is green (698/698), run 5x in a row with no flakiness.
- **Fix uses fd-based mechanism instead of relying on OpenSSL's console fallback**: done — `fd:3` used for all three invocations; see root-cause note above on why `stdin` also had to become `'ignore'`.
- **No regression to the currently-passing `-pass stdin` key-generation step**: converted to `-pass fd:3` for consistency; verified still passing (existing `should generate an encrypted keypair` test, plus new repeated-invocation regression test).
- **Regression test added**: `packages/core/test/crypto.test.ts` gains two tests — repeated public-key extraction from an encrypted key, and repeated signing with an encrypted key — both reference issue #75 in comments and were verified to fail against the pre-fix code (reverted the fix locally and reran; both new tests failed with the original `ttyget errno` error, confirmed via 12/12 failures instead of the usual 10).
- **CI OpenSSL version documented**: CI runs on `ubuntu-latest`, which is Ubuntu 24.04 as of this PR. Per GitHub's [runner-images Ubuntu 24.04 readme](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md), the installed OpenSSL is **3.0.13-0ubuntu3.11** — well below the 3.6.x branch where this bug appears, so **CI does not currently reproduce the pre-fix bug**. The fix is still necessary for contributors on newer OpenSSL (e.g., macOS Homebrew, which is at 3.6.2 as of this PR) and for whenever Ubuntu's `ubuntu-latest` image eventually ships a newer OpenSSL. Added an `openssl version` diagnostic step to `.github/workflows/ci.yml`'s build job so future drift is visible in CI logs going forward.
- **No behavior change to unencrypted paths**: unencrypted `generateKeyPair`/`sign` calls take the `stdio: ['ignore', 'pipe', 'pipe']` branch (no fd 3), unchanged aside from stdin moving from `'pipe'` to `'ignore'` — stdin was never used for anything except the passphrase in this function, so this has no effect on unencrypted paths. Confirmed by the full 696-test pre-existing suite (now 698 with the two new regression tests) passing, including all non-passphrase `generateKeyPair`/`sign`/`verify` tests.

## Verification

- `pnpm --filter @attest-it/core build && pnpm --filter @attest-it/core test`: 698/698 passing, run 5x for flakiness.
- Full monorepo `pnpm run build && pnpm run check && pnpm run test`: green (core 698, cli 634, github-action 62 — all passing).
- `packages/github-action/dist/*.js` regenerated by the build (github-action bundles core's compiled output directly) and included in this PR.

## Changeset

Patch bump for `@attest-it/core` and `attest-it` (the umbrella package re-exports `@attest-it/core` in full).

## Anomalies encountered

My first fix attempt (writing the passphrase to a real temp file and passing its fd via `stdio[3]`, while leaving `stdio[0]` as `'pipe'`) appeared to work in isolated single-shot Node scripts but **did not** fix the actual failing tests when wired into `crypto.ts` and rerun. Isolating this required a side-by-side comparison of the working script vs. the actual call site, which revealed the working script had used `stdio[0] = 'ignore'`, not `'pipe'` — the real fix, as described above. Flagging this in case it's useful context for anyone touching this code later: the interaction is with `stdin`'s pipe-ness, not with which fd carries the passphrase.