### PR TITLE
Make setup commands non-interactive-capable (identity create, init, team add/join, run)

### DIFF
--- a/.changeset/non-interactive-setup.md
+++ b/.changeset/non-interactive-setup.md
@@ -1,0 +1,15 @@
+---
+'@attest-it/core': minor
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Make the setup command surface (`identity create`, `init`, `team add`, `team join`, `run`) non-interactive-capable, so CI, embedders, and agent-driven callers no longer hang on a TTY prompt.
+
+- **`identity create`** accepts `--name`, `--slug` (derived from `--name` when omitted), `--email`, `--github`, `--storage <file|keychain|1password|yubikey>`, and backend-specific flags (`--keychain-path`/`--keychain-item`, `--op-account`/`--op-vault`/`--op-item`, `--yubikey-serial`/`--encrypted-key-name`). `--passphrase-stdin` encrypts a file-backed private key with a passphrase piped via stdin (never prompted).
+- **`init`** now fails fast naming `--force` when config already exists and stdin is not a TTY, instead of hanging on the overwrite-confirmation prompt.
+- **`team add`** and **`team join`** accept `--slug`, `--name`, `--email`, `--github`, `--public-key` (add only), and `--gates` (comma-separated gate IDs); gate authorization defaults to none rather than prompting when non-interactive.
+- **`run`** accepts `-y, --yes` to auto-confirm seal creation; without it, a non-interactive run fails fast instead of hanging. Running `run` with no `--suite`/`--all` and no TTY now fails fast instead of launching an interactive UI that can never receive input. Signing with a passphrase-encrypted identity key resolves the passphrase from the `ATTEST_IT_KEY_PASSPHRASE` environment variable, an interactive prompt, or fails fast.
+- The shell-completion offer shown after `init`/`identity create` is now skipped (rather than prompting unconditionally) when stdin is not an interactive TTY.
+- Interactive mode remains the default for every command above when stdin is a TTY and flags are omitted -- no behavior change for humans running these by hand.
+- `@attest-it/core`: `generateEd25519KeyPair`/`signEd25519` gained an optional passphrase parameter, `createSeal` gained an optional `passphrase` option, and a new `isEncryptedPrivateKeyPem` helper detects passphrase-encrypted keys.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,43 @@ npx attest-it run --suite my-suite
 npx attest-it verify
 ```
 
+### Non-interactive (CI, embedders, agents)
+
+Every setup command above is interactive by default, but accepts flags so it
+can run with zero TTY prompts -- useful for CI, embedders, or agent-driven
+workflows. Pipe `< /dev/null` (or run under a supervisor with no TTY) and each
+command either completes without prompting or fails fast with a clear error
+naming the missing flag:
+
+```bash
+npm install attest-it
+
+# Create an identity with no prompts (file-backed key, optionally passphrase-encrypted)
+npx attest-it identity create --name "CI Bot" --storage file --slug ci-bot < /dev/null
+
+# Scaffold config non-interactively (fails fast with --force if files already exist)
+npx attest-it init --force < /dev/null
+
+# Add yourself to the team without prompting for gate authorization
+npx attest-it team join --gates my-gate < /dev/null
+
+# Run a suite and auto-confirm the seal
+npx attest-it run --suite my-suite --yes < /dev/null
+
+# In CI: verify all seals (already non-interactive)
+npx attest-it verify
+```
+
+To encrypt a file-backed private key, pipe a passphrase in via `--passphrase-stdin`:
+
+```bash
+echo "$CI_KEY_PASSPHRASE" | npx attest-it identity create \
+  --name "CI Bot" --storage file --slug ci-bot --passphrase-stdin
+```
+
+When `run` later needs to sign with that key, supply the same passphrase
+through the `ATTEST_IT_KEY_PASSPHRASE` environment variable.
+
 ## How It Works
 
 1. **Identity** - Your Ed25519 keypair (stored in 1Password, Keychain, YubiKey, or filesystem)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,6 +68,30 @@ Next steps:
 
 Your identity is stored locally at `~/.config/attest-it/config.yaml`.
 
+### Non-interactive identity creation
+
+For CI, embedders, or agent-driven setups, pass flags instead of answering
+prompts. `identity create` accepts `--name`, `--slug`, `--storage
+<file|keychain|1password|yubikey>`, `--email`, and `--github`; when every
+required value is supplied, it creates the identity with zero prompts:
+
+```bash
+npx attest-it identity create --name "CI Bot" --storage file --slug ci-bot < /dev/null
+```
+
+If stdin is not an interactive terminal and a required value (like `--name`
+or `--storage`) is missing, the command fails fast with an error naming the
+missing flag instead of hanging. `--slug` is optional even non-interactively
+-- it is derived from `--name` when omitted.
+
+To store an encrypted private key with the `file` backend, pipe a passphrase
+in via `--passphrase-stdin` (never typed into a prompt):
+
+```bash
+echo "$CI_KEY_PASSPHRASE" | npx attest-it identity create \
+  --name "CI Bot" --storage file --slug ci-bot --passphrase-stdin
+```
+
 ### Multiple Identities
 
 You can have multiple identities (e.g., work and personal):
@@ -90,6 +114,14 @@ npx attest-it init
 This creates a **split configuration**: `.attest-it/policy.yaml` (trust-critical: team and gates) and `.attest-it/config.yaml` (operational: suites), with your first gate.
 
 Already have an existing legacy unified `config.yaml` (one file holding `team`, `gates`, and `suites` together)? Run `npx attest-it init --migrate` instead to split it into the pair automatically.
+
+`init` only prompts when `.attest-it/policy.yaml` or `config.yaml` already
+exist and `--force` was not passed; pass `--force` to overwrite them
+non-interactively (or run it in a fresh directory, which never prompts):
+
+```bash
+npx attest-it init --force < /dev/null
+```
 
 ### Example Configuration Session
 
@@ -187,6 +219,25 @@ To get your public key for manual addition:
 npx attest-it identity export
 ```
 
+### Non-interactive team join / add
+
+Pass `--gates` (comma-separated gate IDs) to authorize gates without the
+checkbox prompt; omitting it authorizes no gates rather than prompting or
+failing. `team join` also accepts `--slug` for the rare case where your
+identity slug is already taken by another member:
+
+```bash
+npx attest-it team join --gates desktop-tests < /dev/null
+```
+
+`team add` (adding someone _else's_ public key) similarly accepts `--slug`,
+`--name`, `--public-key`, `--email`, `--github`, and `--gates`:
+
+```bash
+npx attest-it team add --slug bob --name "Bob Jones" \
+  --public-key "MCowBQYDK2VwAyEA..." --gates desktop-tests < /dev/null
+```
+
 ## Step 4: Run Tests and Create Seal
 
 Run your test suite and create a seal:
@@ -226,9 +277,21 @@ Test Files  1 passed (1)
 Commit: git add .attest-it/seals.json && git commit -m "Seal desktop-tests"
 ```
 
+### Non-interactive sealing
+
+Pass `--yes` to skip the "Create seal?" confirmation prompt:
+
+```bash
+npx attest-it run --suite desktop-tests --yes < /dev/null
+```
+
+Without `--yes`, a non-interactive run (no TTY on stdin) fails fast instead
+of hanging, naming `--yes` as the flag needed to confirm sealing.
+
 ### Direct Sealing
 
-If you run tests separately, seal directly:
+If you run tests separately, seal directly (already non-interactive -- `seal`
+takes no confirmation prompt):
 
 ```bash
 npx attest-it seal desktop-tests

--- a/packages/cli/src/commands/identity/create.ts
+++ b/packages/cli/src/commands/identity/create.ts
@@ -417,6 +417,7 @@ async function runCreate(options: CreateOptions): Promise<void> {
         // Prompt for item name
         const keychainItemName = await resolveOptionalOrPrompt(
           options.keychainItem,
+          '--keychain-item',
           `attest-it-${slug}`,
           () =>
             input({
@@ -533,17 +534,21 @@ async function runCreate(options: CreateOptions): Promise<void> {
         }
 
         // Prompt for item name
-        const item = await resolveOptionalOrPrompt(options.opItem, `attest-it-${slug}`, () =>
-          input({
-            message: '1Password item name:',
-            default: `attest-it-${slug}`,
-            validate: (value) => {
-              if (!value || value.trim().length === 0) {
-                return 'Item name cannot be empty'
-              }
-              return true
-            },
-          }),
+        const item = await resolveOptionalOrPrompt(
+          options.opItem,
+          '--op-item',
+          `attest-it-${slug}`,
+          () =>
+            input({
+              message: '1Password item name:',
+              default: `attest-it-${slug}`,
+              validate: (value) => {
+                if (!value || value.trim().length === 0) {
+                  return 'Item name cannot be empty'
+                }
+                return true
+              },
+            }),
         )
 
         storageConfig = {
@@ -630,6 +635,7 @@ async function runCreate(options: CreateOptions): Promise<void> {
         // Prompt for encrypted key file name
         const encryptedKeyName = await resolveOptionalOrPrompt(
           options.encryptedKeyName,
+          '--encrypted-key-name',
           `${slug}.enc`,
           () =>
             input({

--- a/packages/cli/src/commands/identity/create.ts
+++ b/packages/cli/src/commands/identity/create.ts
@@ -14,6 +14,7 @@ import {
   isYubiKeyConnected,
   listYubiKeyDevices,
   isYubiKeyChallengeResponseConfigured,
+  KeyProviderRegistry,
   savePublicKey,
   storePrivateKey,
 } from '@attest-it/core'
@@ -22,18 +23,127 @@ import { log, success, error, info, verbose, getTheme } from '../../utils/output
 import { ExitCode } from '../../utils/exit-codes.js'
 import { validateSlug, validateEmail } from './validation.js'
 import { offerCompletionInstall } from '../../utils/completion-offer.js'
+import {
+  resolveOrPrompt,
+  resolveOptionalOrPrompt,
+  isInteractiveTTY,
+  readStdin,
+} from '../../utils/prompts.js'
 import { join } from 'node:path'
+
+/**
+ * Storage backend values accepted by `--storage`.
+ *
+ * These are the CLI-facing names (matching the existing interactive picker's
+ * choice values); {@link STORAGE_TYPE_TO_REGISTRY} maps each to the
+ * `KeyProviderRegistry` type it corresponds to, so a `--storage` value is
+ * always validated against whatever is *currently* registered rather than a
+ * list that can silently drift from it.
+ */
+const STORAGE_TYPES = ['file', 'keychain', '1password', 'yubikey'] as const
+type StorageType = (typeof STORAGE_TYPES)[number]
+
+const STORAGE_TYPE_TO_REGISTRY: Record<StorageType, string> = {
+  file: 'filesystem',
+  keychain: 'macos-keychain',
+  '1password': '1password',
+  yubikey: 'yubikey',
+}
+
+function isStorageType(value: string): value is StorageType {
+  return STORAGE_TYPES.some((storageType) => storageType === value)
+}
+
+/**
+ * Turn a display name into a lowercase, hyphenated slug candidate.
+ * @internal
+ */
+function slugify(name: string): string {
+  const base = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return base.length > 0 ? base : 'identity'
+}
+
+/**
+ * Derive a slug from a display name, disambiguating against existing
+ * identities with a numeric suffix if needed.
+ * @internal
+ */
+function deriveUniqueSlug(name: string, existingIdentities?: Record<string, unknown>): string {
+  const base = slugify(name)
+  if (!existingIdentities?.[base]) {
+    return base
+  }
+  let suffix = 2
+  while (existingIdentities[`${base}-${String(suffix)}`]) {
+    suffix += 1
+  }
+  return `${base}-${String(suffix)}`
+}
+
+interface CreateOptions {
+  name?: string
+  slug?: string
+  email?: string
+  github?: string
+  storage?: string
+  passphraseStdin?: boolean
+  keychainPath?: string
+  keychainItem?: string
+  opAccount?: string
+  opVault?: string
+  opItem?: string
+  yubikeySerial?: string
+  encryptedKeyName?: string
+}
 
 export const createCommand = new Command('create')
   .description('Create a new identity with Ed25519 keypair')
-  .action(async () => {
-    await runCreate()
+  .option('--name <name>', 'Display name for the identity')
+  .option('--slug <slug>', 'Unique identity slug (derived from --name when omitted)')
+  .option('--email <email>', 'Email address (optional)')
+  .option('--github <username>', 'GitHub username (optional)')
+  .option('--storage <backend>', `Key storage backend: ${STORAGE_TYPES.join('|')}`)
+  .option(
+    '--passphrase-stdin',
+    'Read a passphrase from stdin to encrypt a file-backed private key (only used with --storage file)',
+  )
+  .option(
+    '--keychain-path <path>',
+    'macOS Keychain path (needed only when multiple keychains exist)',
+  )
+  .option('--keychain-item <name>', 'macOS Keychain item name (default: attest-it-<slug>)')
+  .option(
+    '--op-account <uuid>',
+    '1Password account UUID (needed only when multiple accounts are signed in)',
+  )
+  .option('--op-vault <name>', '1Password vault name (needed only when multiple vaults exist)')
+  .option('--op-item <name>', '1Password item name (default: attest-it-<slug>)')
+  .option(
+    '--yubikey-serial <serial>',
+    'YubiKey serial number (needed only when multiple devices are connected)',
+  )
+  .option(
+    '--encrypted-key-name <name>',
+    'Encrypted key file name for YubiKey storage (default: <slug>.enc)',
+  )
+  .action(async (options: CreateOptions) => {
+    await runCreate(options)
   })
 
 /**
- * Run the create command to interactively create a new identity.
+ * Run the create command to create a new identity.
+ *
+ * Interactive by default when stdin is a TTY and flags are omitted. Every
+ * prompt is gated behind "flag not supplied AND stdin is an interactive TTY";
+ * when stdin is not a TTY and a required value is missing, this fails fast
+ * with an error naming the missing flag rather than hanging on a prompt that
+ * can never resolve. See issue #80.
  */
-async function runCreate(): Promise<void> {
+async function runCreate(options: CreateOptions): Promise<void> {
   try {
     const theme = getTheme()
 
@@ -44,36 +154,70 @@ async function runCreate(): Promise<void> {
     // Load existing config if it exists
     const existingConfig = await loadLocalConfig()
 
-    // Prompt for identity details
-    const slug = (
-      await input({
-        message: 'Identity slug (unique identifier):',
-        validate: (value) => validateSlug(value, existingConfig?.identities),
-      })
-    ).trim()
+    // Display name (required)
+    const name = await resolveOrPrompt(options.name, '--name', () =>
+      input({
+        message: 'Display name:',
+        validate: (value) => {
+          if (!value || value.trim().length === 0) {
+            return 'Name cannot be empty'
+          }
+          return true
+        },
+      }),
+    )
+    if (name.trim().length === 0) {
+      throw new Error('--name cannot be empty')
+    }
 
-    const name = await input({
-      message: 'Display name:',
-      validate: (value) => {
-        if (!value || value.trim().length === 0) {
-          return 'Name cannot be empty'
-        }
-        return true
-      },
-    })
+    // Slug (optional -- auto-derived from the name when omitted)
+    let slug: string
+    if (options.slug !== undefined) {
+      slug = options.slug.trim()
+      const validation = validateSlug(slug, existingConfig?.identities)
+      if (validation !== true) {
+        throw new Error(validation)
+      }
+    } else {
+      const derived = deriveUniqueSlug(name, existingConfig?.identities)
+      slug = isInteractiveTTY()
+        ? (
+            await input({
+              message: 'Identity slug (unique identifier):',
+              default: derived,
+              validate: (value) => validateSlug(value, existingConfig?.identities),
+            })
+          ).trim()
+        : derived
+    }
 
-    const email = (
-      await input({
-        message: 'Email (optional):',
-        default: '',
-        validate: validateEmail,
-      })
-    ).trim()
+    // Email (optional)
+    let email: string
+    if (options.email !== undefined) {
+      email = options.email.trim()
+      const emailValidation = validateEmail(email)
+      if (emailValidation !== true) {
+        throw new Error(emailValidation)
+      }
+    } else {
+      email = isInteractiveTTY()
+        ? (
+            await input({
+              message: 'Email (optional):',
+              default: '',
+              validate: validateEmail,
+            })
+          ).trim()
+        : ''
+    }
 
-    const github = await input({
-      message: 'GitHub username (optional):',
-      default: '',
-    })
+    // GitHub username (optional)
+    const github =
+      options.github !== undefined
+        ? options.github.trim()
+        : isInteractiveTTY()
+          ? (await input({ message: 'GitHub username (optional):', default: '' })).trim()
+          : ''
 
     // Check provider availability
     // Note: Checking 1Password/YubiKey may trigger authentication prompts
@@ -98,7 +242,7 @@ async function runCreate(): Promise<void> {
 
     // Build choices based on availability
     const configDir = getIdentityConfigDir()
-    const storageChoices: { name: string; value: string }[] = [
+    const storageChoices: { name: string; value: StorageType }[] = [
       { name: `File system (${join(configDir, 'keys')})`, value: 'file' },
     ]
 
@@ -116,20 +260,51 @@ async function runCreate(): Promise<void> {
         : 'YubiKey (not connected - insert YubiKey first)'
       storageChoices.push({ name: yubikeyLabel, value: 'yubikey' })
     } else {
-      // Show YubiKey as disabled option so users know it exists
+      // Show YubiKey as disabled option so users know it exists. The value
+      // is never read (the entry is disabled and cannot be selected), so it
+      // reuses the real 'yubikey' literal rather than inventing a sentinel
+      // that would need a type assertion to fit StorageType.
       storageChoices.push({
         name: theme.muted('YubiKey (install ykman CLI to enable)'),
-        value: 'yubikey-disabled',
+        value: 'yubikey',
         // @ts-expect-error -- @inquirer/prompts supports disabled property but types may not reflect it
         disabled: true,
       })
     }
 
-    // Prompt for key storage type
-    const keyStorageType = await select({
-      message: 'Where should the private key be stored?',
-      choices: storageChoices,
-    })
+    // Storage backend selector (required)
+    let flagStorage: StorageType | undefined
+    if (options.storage !== undefined) {
+      if (!isStorageType(options.storage)) {
+        throw new Error(
+          `Unknown --storage value "${options.storage}". Supported values: ${STORAGE_TYPES.join(', ')}`,
+        )
+      }
+      const registryType = STORAGE_TYPE_TO_REGISTRY[options.storage]
+      if (!KeyProviderRegistry.getProviderTypes().includes(registryType)) {
+        throw new Error(
+          `Storage backend "${options.storage}" is not registered in this build ` +
+            `(expected registry type "${registryType}"). Registered types: ${KeyProviderRegistry.getProviderTypes().join(', ')}`,
+        )
+      }
+      if (options.storage === 'keychain' && !keychainAvailable) {
+        throw new Error('macOS Keychain is not available on this system')
+      }
+      if (options.storage === '1password' && !opAvailable) {
+        throw new Error('1Password CLI (op) is not installed')
+      }
+      if (options.storage === 'yubikey' && !yubikeyInstalled) {
+        throw new Error('YubiKey CLI (ykman) is not installed')
+      }
+      flagStorage = options.storage
+    }
+
+    const keyStorageType = await resolveOrPrompt(flagStorage, '--storage', () =>
+      select({
+        message: 'Where should the private key be stored?',
+        choices: storageChoices,
+      }),
+    )
 
     // ============================================================
     // PHASE 1: Collect all provider-specific configuration
@@ -140,6 +315,7 @@ async function runCreate(): Promise<void> {
     interface FileStorageConfig {
       type: 'file'
       keyPath: string
+      passphrase?: string
     }
     interface KeychainStorageConfig {
       type: 'keychain'
@@ -172,7 +348,16 @@ async function runCreate(): Promise<void> {
         // Determine file path (respects --home-dir override)
         const keysDir = join(getIdentityConfigDir(), 'keys')
         const keyPath = join(keysDir, `${slug}.pem`)
-        storageConfig = { type: 'file', keyPath }
+
+        let passphrase: string | undefined
+        if (options.passphraseStdin) {
+          passphrase = await readStdin()
+          if (passphrase.length === 0) {
+            throw new Error('--passphrase-stdin was set but stdin was empty')
+          }
+        }
+
+        storageConfig = { type: 'file', keyPath, ...(passphrase !== undefined && { passphrase }) }
         break
       }
       case 'keychain': {
@@ -199,37 +384,52 @@ async function runCreate(): Promise<void> {
           return `${theme.blue.bold()(kc.name)} ${theme.muted(`(${kc.path})`)}`
         }
 
-        // Select keychain (auto-select if only one, typically "login")
+        // Select keychain (flag > auto-select if only one > prompt)
         let selectedKeychain: { name: string; path: string }
-        if (keychains.length === 1 && keychains[0]) {
+        if (options.keychainPath !== undefined) {
+          const found = keychains.find((kc) => kc.path === options.keychainPath)
+          if (!found) {
+            throw new Error(
+              `--keychain-path "${options.keychainPath}" not found. Available keychains: ${keychains.map((kc) => kc.path).join(', ')}`,
+            )
+          }
+          selectedKeychain = found
+        } else if (keychains.length === 1 && keychains[0]) {
           selectedKeychain = keychains[0]
           info(`Using keychain: ${formatKeychainChoice(selectedKeychain)}`)
         } else {
-          const selectedPath = await select({
-            message: 'Select keychain:',
-            choices: keychains.map((kc) => ({
-              name: formatKeychainChoice(kc),
-              value: kc.path,
-            })),
+          selectedKeychain = await resolveOrPrompt(undefined, '--keychain-path', async () => {
+            const selectedPath = await select({
+              message: 'Select keychain:',
+              choices: keychains.map((kc) => ({
+                name: formatKeychainChoice(kc),
+                value: kc.path,
+              })),
+            })
+            const foundKeychain = keychains.find((kc) => kc.path === selectedPath)
+            if (!foundKeychain) {
+              throw new Error('Selected keychain not found')
+            }
+            return foundKeychain
           })
-          const foundKeychain = keychains.find((kc) => kc.path === selectedPath)
-          if (!foundKeychain) {
-            throw new Error('Selected keychain not found')
-          }
-          selectedKeychain = foundKeychain
         }
 
         // Prompt for item name
-        const keychainItemName = await input({
-          message: 'Keychain item name:',
-          default: `attest-it-${slug}`,
-          validate: (value) => {
-            if (!value || value.trim().length === 0) {
-              return 'Item name cannot be empty'
-            }
-            return true
-          },
-        })
+        const keychainItemName = await resolveOptionalOrPrompt(
+          options.keychainItem,
+          `attest-it-${slug}`,
+          () =>
+            input({
+              message: 'Keychain item name:',
+              default: `attest-it-${slug}`,
+              validate: (value) => {
+                if (!value || value.trim().length === 0) {
+                  return 'Item name cannot be empty'
+                }
+                return true
+              },
+            }),
+        )
 
         storageConfig = { type: 'keychain', selectedKeychain, keychainItemName }
         break
@@ -242,7 +442,7 @@ async function runCreate(): Promise<void> {
           'You may see biometric prompts or be asked to unlock 1Password for each configured account.',
         )
 
-        // List available 1Password accounts (includes friendly names from OnePasswordKeyProvider)
+        // List available 1Password accounts (includes friendly names)
         const { accounts, inaccessible } = await listOnePasswordAccounts()
 
         if (accounts.length === 0) {
@@ -267,22 +467,33 @@ async function runCreate(): Promise<void> {
           return `${theme.blue.bold()(acc.name)} ${theme.muted(`(${acc.url})`)}`
         }
 
-        // Select account (auto-select if only one)
+        // Select account (flag > auto-select if only one > prompt)
         // Use account_uuid as the identifier (required by `op` CLI)
         let selectedAccountUuid: string
         let selectedAccountDisplayName: string
-        if (accounts.length === 1 && accounts[0]) {
+        if (options.opAccount !== undefined) {
+          const found = accounts.find((acc) => acc.account_uuid === options.opAccount)
+          if (!found) {
+            throw new Error(
+              `--op-account "${options.opAccount}" not found among signed-in accounts`,
+            )
+          }
+          selectedAccountUuid = found.account_uuid
+          selectedAccountDisplayName = found.name
+        } else if (accounts.length === 1 && accounts[0]) {
           selectedAccountUuid = accounts[0].account_uuid
           selectedAccountDisplayName = accounts[0].name
           info(`Using 1Password account: ${formatAccountChoice(accounts[0])}`)
         } else {
-          selectedAccountUuid = await select({
-            message: 'Select 1Password account:',
-            choices: accounts.map((acc) => ({
-              name: formatAccountChoice(acc),
-              value: acc.account_uuid,
-            })),
-          })
+          selectedAccountUuid = await resolveOrPrompt(undefined, '--op-account', () =>
+            select({
+              message: 'Select 1Password account:',
+              choices: accounts.map((acc) => ({
+                name: formatAccountChoice(acc),
+                value: acc.account_uuid,
+              })),
+            }),
+          )
           const selectedAcc = accounts.find((acc) => acc.account_uuid === selectedAccountUuid)
           if (!selectedAcc) {
             throw new Error('Selected account not found')
@@ -297,26 +508,43 @@ async function runCreate(): Promise<void> {
           throw new Error(`No vaults found in 1Password account: ${selectedAccountDisplayName}`)
         }
 
-        // Select vault
-        const selectedVault = await select({
-          message: 'Select vault for private key storage:',
-          choices: vaults.map((v) => ({
-            name: v.name,
-            value: v.name,
-          })),
-        })
+        // Select vault (flag > auto-select if only one > prompt)
+        let selectedVault: string
+        if (options.opVault !== undefined) {
+          const found = vaults.find((v) => v.name === options.opVault)
+          if (!found) {
+            throw new Error(
+              `--op-vault "${options.opVault}" not found in account ${selectedAccountDisplayName}`,
+            )
+          }
+          selectedVault = found.name
+        } else if (vaults.length === 1 && vaults[0]) {
+          selectedVault = vaults[0].name
+        } else {
+          selectedVault = await resolveOrPrompt(undefined, '--op-vault', () =>
+            select({
+              message: 'Select vault for private key storage:',
+              choices: vaults.map((v) => ({
+                name: v.name,
+                value: v.name,
+              })),
+            }),
+          )
+        }
 
         // Prompt for item name
-        const item = await input({
-          message: '1Password item name:',
-          default: `attest-it-${slug}`,
-          validate: (value) => {
-            if (!value || value.trim().length === 0) {
-              return 'Item name cannot be empty'
-            }
-            return true
-          },
-        })
+        const item = await resolveOptionalOrPrompt(options.opItem, `attest-it-${slug}`, () =>
+          input({
+            message: '1Password item name:',
+            default: `attest-it-${slug}`,
+            validate: (value) => {
+              if (!value || value.trim().length === 0) {
+                return 'Item name cannot be empty'
+              }
+              return true
+            },
+          }),
+        )
 
         storageConfig = {
           type: '1password',
@@ -355,19 +583,29 @@ async function runCreate(): Promise<void> {
           return `${theme.blue.bold()(yk.type)} ${theme.muted(`(Serial: ${yk.serial}, FW: ${yk.firmware})`)}`
         }
 
-        // Select YubiKey (auto-select if only one)
+        // Select YubiKey (flag > auto-select if only one > prompt)
         let selectedSerial: string
-        if (yubikeys.length === 1 && yubikeys[0]) {
+        if (options.yubikeySerial !== undefined) {
+          const found = yubikeys.find((yk) => yk.serial === options.yubikeySerial)
+          if (!found) {
+            throw new Error(
+              `--yubikey-serial "${options.yubikeySerial}" not found among connected devices`,
+            )
+          }
+          selectedSerial = found.serial
+        } else if (yubikeys.length === 1 && yubikeys[0]) {
           selectedSerial = yubikeys[0].serial
           info(`Using YubiKey: ${formatYubiKeyChoice(yubikeys[0])}`)
         } else {
-          selectedSerial = await select({
-            message: 'Select YubiKey:',
-            choices: yubikeys.map((yk) => ({
-              name: formatYubiKeyChoice(yk),
-              value: yk.serial,
-            })),
-          })
+          selectedSerial = await resolveOrPrompt(undefined, '--yubikey-serial', () =>
+            select({
+              message: 'Select YubiKey:',
+              choices: yubikeys.map((yk) => ({
+                name: formatYubiKeyChoice(yk),
+                value: yk.serial,
+              })),
+            }),
+          )
         }
 
         // Check if challenge-response is configured on slot 2
@@ -390,16 +628,21 @@ async function runCreate(): Promise<void> {
         }
 
         // Prompt for encrypted key file name
-        const encryptedKeyName = await input({
-          message: 'Encrypted key file name:',
-          default: `${slug}.enc`,
-          validate: (value) => {
-            if (!value || value.trim().length === 0) {
-              return 'File name cannot be empty'
-            }
-            return true
-          },
-        })
+        const encryptedKeyName = await resolveOptionalOrPrompt(
+          options.encryptedKeyName,
+          `${slug}.enc`,
+          () =>
+            input({
+              message: 'Encrypted key file name:',
+              default: `${slug}.enc`,
+              validate: (value) => {
+                if (!value || value.trim().length === 0) {
+                  return 'File name cannot be empty'
+                }
+                return true
+              },
+            }),
+        )
 
         // Determine encrypted key path
         const keysDir = join(getIdentityConfigDir(), 'keys')
@@ -409,7 +652,7 @@ async function runCreate(): Promise<void> {
         break
       }
       default:
-        throw new Error(`Unknown key storage type: ${keyStorageType}`)
+        throw new Error(`Unknown key storage type: ${String(keyStorageType)}`)
     }
 
     // ============================================================
@@ -419,7 +662,11 @@ async function runCreate(): Promise<void> {
     log('Generating Ed25519 keypair...')
 
     // Generate keypair (this is synchronous, returns KeyPair not Promise)
-    const keyPair = generateEd25519KeyPair()
+    const keyPair = generateEd25519KeyPair(
+      storageConfig.type === 'file' && storageConfig.passphrase !== undefined
+        ? { passphrase: storageConfig.passphrase }
+        : {},
+    )
 
     // ============================================================
     // PHASE 3: Store the key using collected configuration
@@ -433,9 +680,13 @@ async function runCreate(): Promise<void> {
       case 'file': {
         log('')
         info('Storing private key via VaultKeeper (file backend)...')
+        // When --passphrase-stdin is set, PHASE 2 already encrypted the PEM, so
+        // the value handed to VaultKeeper is the passphrase-protected key.
         const result = await storePrivateKey('file', keyPair.privateKey, name)
         privateKeyRef = { type: 'file', id: result.secretId }
-        keyStorageDescription = result.storageDescription
+        keyStorageDescription = storageConfig.passphrase
+          ? `${result.storageDescription} (passphrase-encrypted)`
+          : result.storageDescription
         break
       }
       case 'keychain': {
@@ -545,3 +796,6 @@ async function runCreate(): Promise<void> {
     process.exit(ExitCode.CONFIG_ERROR)
   }
 }
+
+// Exported for testing
+export { slugify, deriveUniqueSlug, runCreate }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path'
 import { stringify as stringifyYaml } from 'yaml'
 import { migrateUnifiedContent } from '@attest-it/core'
 import { log, success, error } from '../utils/output.js'
-import { confirmAction } from '../utils/prompts.js'
+import { confirmAction, isInteractiveTTY } from '../utils/prompts.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { offerCompletionInstall } from '../utils/completion-offer.js'
 import { getPackageVersion } from '../utils/version.js'
@@ -134,10 +134,18 @@ async function ensureDevDependency(): Promise<{ packageManager: string; created:
  * Confirm overwrite of an existing file unless --force is set.
  *
  * @returns True if it is safe to write, false if the user declined.
+ * @throws Error if the file exists, --force was not passed, and stdin is not
+ * an interactive TTY -- prompting would hang forever, so this fails fast
+ * instead, naming --force as the flag needed to proceed non-interactively.
  */
 async function confirmOverwrite(filePath: string, force: boolean | undefined): Promise<boolean> {
   if (!fs.existsSync(filePath) || force) {
     return true
+  }
+  if (!isInteractiveTTY()) {
+    throw new Error(
+      `Config already exists at ${filePath}. Pass --force to overwrite non-interactively.`,
+    )
   }
   return confirmAction({
     message: `Config already exists at ${filePath}. Overwrite?`,

--- a/packages/cli/src/commands/run-interactive.tsx
+++ b/packages/cli/src/commands/run-interactive.tsx
@@ -35,6 +35,7 @@ import { getAllSuiteStatuses, type SuiteStatus } from './run-utils.js'
 import { loadSession, saveSession as persistSession, clearSession } from '../session/session.js'
 import { error, log } from '../utils/output.js'
 import { ExitCode } from '../utils/exit-codes.js'
+import { isInteractiveTTY } from '../utils/prompts.js'
 
 /**
  * Options for interactive mode.
@@ -85,6 +86,17 @@ export async function runInteractive(options: InteractiveOptions): Promise<void>
   if (pendingSuites.length === 0) {
     log('All suites are valid. Nothing to run.')
     process.exit(ExitCode.NO_WORK)
+  }
+
+  // The interactive UI reads raw keypresses from stdin and never resolves on
+  // its own; without a TTY it would otherwise hang forever. Fail fast instead
+  // and point at the non-interactive flags. See issue #80.
+  if (!isInteractiveTTY()) {
+    error(
+      'attest-it run requires an interactive terminal when neither --suite nor --all is given ' +
+        '(no TTY detected). Pass --suite <name> or --all to run non-interactively.',
+    )
+    process.exit(ExitCode.CONFIG_ERROR)
   }
 
   // Check for dirty working tree (skip if ATTEST_IT_ALLOW_DIRTY is set - for dogfooding)

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -561,7 +561,10 @@ async function resolveKeyPassphrase(): Promise<string> {
     return fromEnv
   }
   if (isInteractiveTTY()) {
-    return password({ message: 'Passphrase for encrypted private key:' })
+    return password({
+      message: 'Passphrase for encrypted private key:',
+      validate: (value) => (value.length > 0 ? true : 'Passphrase cannot be empty'),
+    })
   }
   throw new Error(
     `This identity's private key is passphrase-encrypted. Set ${KEY_PASSPHRASE_ENV} ` +

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -5,6 +5,7 @@
 import { Command } from 'commander'
 import { spawn } from 'node:child_process'
 import { parse as parseShellCommand } from 'shell-quote'
+import { password } from '@inquirer/prompts'
 import {
   loadSplitConfig,
   computeFingerprint,
@@ -16,14 +17,18 @@ import {
   createSeal,
   readSealsSync,
   writeSealsSync,
+  isEncryptedPrivateKeyPem,
   type AttestItConfig,
   type Identity,
 } from '@attest-it/core'
 import { log, success, error, warn, verbose } from '../utils/output.js'
-import { confirmAction } from '../utils/prompts.js'
+import { confirmAction, isInteractiveTTY } from '../utils/prompts.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { runInteractive } from './run-interactive.js'
 import { getAllSuiteStatuses } from './run-utils.js'
+
+/** Env var read for the passphrase of an encrypted file-backed identity key. */
+const KEY_PASSPHRASE_ENV = 'ATTEST_IT_KEY_PASSPHRASE'
 
 export const runCommand = new Command('run')
   .description('Execute tests and create attestation')
@@ -33,6 +38,7 @@ export const runCommand = new Command('run')
   .option('--dry-run', 'Show what would run without executing')
   .option('-c, --continue', 'Resume interrupted session')
   .option('--filter <pattern>', 'Filter suites by pattern (glob-style)')
+  .option('-y, --yes', 'Automatically confirm seal creation without prompting')
   .action(async (options: RunOptions) => {
     await runTests(options)
   })
@@ -44,6 +50,7 @@ interface RunOptions {
   dryRun?: boolean
   continue?: boolean
   filter?: string
+  yes?: boolean
 }
 
 /**
@@ -396,20 +403,28 @@ async function runSingleSuite(
   // A successful run authorizes creating a seal for the suite's gate. The seal
   // is the single cryptographic record of the passing run (the legacy
   // attestations file has been retired).
-  await promptForSeal(suiteName, suiteConfig.gate, config)
+  await promptForSeal(suiteName, suiteConfig.gate, config, options.yes)
 }
 
 /**
  * Prompt for seal creation after successful suite execution.
  *
+ * Gated behind "flag not supplied AND stdin is an interactive TTY": with
+ * `--yes`, sealing proceeds without prompting; interactively without `--yes`,
+ * the existing confirm prompt runs unchanged; non-interactively without
+ * `--yes`, this fails fast instead of hanging on a prompt that can never
+ * resolve. See issue #80.
+ *
  * @param suiteName - Name of the suite that was executed
  * @param gateId - ID of the gate linked to the suite
  * @param config - Configuration object
+ * @param autoConfirm - Skip the confirmation prompt and seal automatically (from `--yes`)
  */
 async function promptForSeal(
   suiteName: string,
   gateId: string,
   config: AttestItConfig,
+  autoConfirm?: boolean,
 ): Promise<void> {
   log('')
   log(`Suite '${suiteName}' is linked to gate '${gateId}'`)
@@ -436,11 +451,23 @@ async function promptForSeal(
     return
   }
 
-  // Prompt for seal confirmation
-  const shouldSeal = await confirmAction({
-    message: `Create seal for gate '${gateId}'`,
-    default: true,
-  })
+  // Resolve seal confirmation: --yes skips the prompt; interactively without
+  // it, the existing confirm prompt runs; non-interactively without it, fail
+  // fast rather than hang on a prompt that can never resolve.
+  let shouldSeal: boolean
+  if (autoConfirm) {
+    shouldSeal = true
+  } else if (isInteractiveTTY()) {
+    shouldSeal = await confirmAction({
+      message: `Create seal for gate '${gateId}'`,
+      default: true,
+    })
+  } else {
+    throw new Error(
+      `Missing required --yes to confirm seal creation for gate '${gateId}' ` +
+        '(no interactive terminal available to prompt for it). Pass --yes to run non-interactively.',
+    )
+  }
 
   if (!shouldSeal) {
     log('Seal creation skipped')
@@ -477,6 +504,13 @@ async function promptForSeal(
     // Clean up after reading
     await keyResult.cleanup()
 
+    // A file-backed key created with `identity create --passphrase-stdin` is
+    // encrypted; resolve the passphrase needed to sign with it from the
+    // environment, an interactive prompt, or fail fast. See issue #80.
+    const passphrase = isEncryptedPrivateKeyPem(privateKeyPem)
+      ? await resolveKeyPassphrase()
+      : undefined
+
     // Create seal using identity slug (not display name) for verification lookup
     const identitySlug = localConfig.activeIdentity
     const seal = createSeal({
@@ -484,6 +518,7 @@ async function promptForSeal(
       fingerprint: gateFingerprint.fingerprint,
       sealedBy: identitySlug,
       privateKey: privateKeyPem,
+      ...(passphrase !== undefined && { passphrase }),
     })
 
     // Read existing seals
@@ -507,6 +542,31 @@ async function promptForSeal(
       error('Failed to create seal: Unknown error')
     }
   }
+}
+
+/**
+ * Resolve the passphrase needed to sign with an encrypted file-backed
+ * private key (created via `identity create --storage file --passphrase-stdin`).
+ *
+ * Order: the `ATTEST_IT_KEY_PASSPHRASE` env var, then (interactively) a
+ * masked prompt, then fail fast naming the env var -- this never hangs on a
+ * prompt that can never resolve. See issue #80.
+ *
+ * @returns The resolved passphrase
+ * @throws Error if non-interactive and the env var is not set
+ */
+async function resolveKeyPassphrase(): Promise<string> {
+  const fromEnv = process.env[KEY_PASSPHRASE_ENV]
+  if (fromEnv !== undefined && fromEnv.length > 0) {
+    return fromEnv
+  }
+  if (isInteractiveTTY()) {
+    return password({ message: 'Passphrase for encrypted private key:' })
+  }
+  throw new Error(
+    `This identity's private key is passphrase-encrypted. Set ${KEY_PASSPHRASE_ENV} ` +
+      '(no interactive terminal available to prompt for it).',
+  )
 }
 
 /**
@@ -578,4 +638,4 @@ function getKeyRefFromIdentity(identity: Identity): string {
 }
 
 // Export for testing
-export { buildCommand, parseCommand, executeCommand, checkDirtyWorkingTree }
+export { buildCommand, parseCommand, executeCommand, checkDirtyWorkingTree, resolveKeyPassphrase }

--- a/packages/cli/src/commands/team/add.ts
+++ b/packages/cli/src/commands/team/add.ts
@@ -5,19 +5,38 @@ import { ExitCode } from '../../utils/exit-codes.js'
 import { getTheme } from '../../components/theme.js'
 import { writeFile } from 'node:fs/promises'
 import { stringify as stringifyYaml } from 'yaml'
-import { promptForGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
+import { resolveOrPrompt, isInteractiveTTY } from '../../utils/prompts.js'
+import { resolveGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
+
+interface AddOptions {
+  slug?: string
+  name?: string
+  email?: string
+  github?: string
+  publicKey?: string
+  gates?: string
+}
 
 export const addCommand = new Command('add')
   .description('Add a new team member')
-  .action(async () => {
-    await runAdd()
+  .option('--slug <slug>', 'Unique identifier for the team member')
+  .option('--name <name>', 'Display name')
+  .option('--email <email>', 'Email address (optional)')
+  .option('--github <username>', 'GitHub username (optional)')
+  .option(
+    '--public-key <key>',
+    "Base64-encoded Ed25519 public key (from 'attest-it identity export')",
+  )
+  .option('--gates <ids>', 'Comma-separated gate IDs to authorize (default: none)')
+  .action(async (options: AddOptions) => {
+    await runAdd(options)
   })
 
 /**
  * Validate Base64 encoded Ed25519 public key.
  * Ed25519 public keys are 32 bytes, which is 44 characters in Base64.
  */
-function validatePublicKey(value: string): boolean | string {
+function validatePublicKey(value: string): true | string {
   if (!value || value.trim().length === 0) {
     return 'Public key cannot be empty'
   }
@@ -47,9 +66,15 @@ function validatePublicKey(value: string): boolean | string {
 }
 
 /**
- * Run the add command to interactively add a team member.
+ * Run the add command to add a team member.
+ *
+ * Interactive by default when stdin is a TTY and flags are omitted. Every
+ * prompt is gated behind "flag not supplied AND stdin is an interactive TTY";
+ * when stdin is not a TTY and a required value is missing, this fails fast
+ * with an error naming the missing flag rather than hanging on a prompt that
+ * can never resolve. See issue #80.
  */
-async function runAdd(): Promise<void> {
+async function runAdd(options: AddOptions = {}): Promise<void> {
   try {
     const theme = getTheme()
 
@@ -61,54 +86,72 @@ async function runAdd(): Promise<void> {
     const { policy, path: policyPath } = loadPolicyForEdit()
     const existingTeam = policy.team ?? {}
 
-    // Prompt for member details
-    const slug = await input({
-      message: 'Member slug (unique identifier):',
-      validate: (value) => {
-        if (!value || value.trim().length === 0) {
-          return 'Slug cannot be empty'
-        }
-        if (!/^[a-z0-9-]+$/.test(value)) {
-          return 'Slug must contain only lowercase letters, numbers, and hyphens'
-        }
-        // eslint-disable-next-line security/detect-object-injection
-        if (existingTeam[value]) {
-          return `Team member "${value}" already exists`
-        }
-        return true
-      },
-    })
+    const validateSlugInput = (value: string): true | string => {
+      if (!value || value.trim().length === 0) {
+        return 'Slug cannot be empty'
+      }
+      if (!/^[a-z0-9-]+$/.test(value)) {
+        return 'Slug must contain only lowercase letters, numbers, and hyphens'
+      }
+      // eslint-disable-next-line security/detect-object-injection
+      if (existingTeam[value]) {
+        return `Team member "${value}" already exists`
+      }
+      return true
+    }
 
-    const name = await input({
-      message: 'Display name:',
-      validate: (value) => {
-        if (!value || value.trim().length === 0) {
-          return 'Name cannot be empty'
-        }
-        return true
-      },
-    })
+    // Member details
+    const slug = await resolveOrPrompt(options.slug, '--slug', () =>
+      input({ message: 'Member slug (unique identifier):', validate: validateSlugInput }),
+    )
+    const slugValidation = validateSlugInput(slug)
+    if (slugValidation !== true) {
+      throw new Error(slugValidation)
+    }
 
-    const email = await input({
-      message: 'Email (optional):',
-      default: '',
-    })
+    const name = await resolveOrPrompt(options.name, '--name', () =>
+      input({
+        message: 'Display name:',
+        validate: (value) => {
+          if (!value || value.trim().length === 0) {
+            return 'Name cannot be empty'
+          }
+          return true
+        },
+      }),
+    )
+    if (name.trim().length === 0) {
+      throw new Error('--name cannot be empty')
+    }
 
-    const github = await input({
-      message: 'GitHub username (optional):',
-      default: '',
-    })
+    const email =
+      options.email ??
+      (isInteractiveTTY() ? await input({ message: 'Email (optional):', default: '' }) : '')
 
+    const github =
+      options.github ??
+      (isInteractiveTTY()
+        ? await input({ message: 'GitHub username (optional):', default: '' })
+        : '')
+
+    let publicKey: string
+    if (options.publicKey !== undefined) {
+      publicKey = options.publicKey
+    } else {
+      log('')
+      log('Paste the public key (from "attest-it identity export"):')
+      publicKey = await resolveOrPrompt(undefined, '--public-key', () =>
+        input({ message: 'Public key:', validate: validatePublicKey }),
+      )
+    }
+    const publicKeyValidation = validatePublicKey(publicKey)
+    if (publicKeyValidation !== true) {
+      throw new Error(publicKeyValidation)
+    }
+
+    // Resolve gate authorizations
     log('')
-    log('Paste the public key (from "attest-it identity export"):')
-    const publicKey = await input({
-      message: 'Public key:',
-      validate: validatePublicKey,
-    })
-
-    // Prompt for gate authorizations
-    log('')
-    const authorizedGates = await promptForGateAuthorization(policy.gates)
+    const authorizedGates = await resolveGateAuthorization(policy.gates, options.gates)
 
     // Update config with new team member
     const memberData: Parameters<typeof addTeamMemberToPolicy>[2] = {
@@ -147,3 +190,6 @@ async function runAdd(): Promise<void> {
     process.exit(ExitCode.CONFIG_ERROR)
   }
 }
+
+// Exported for testing
+export { runAdd }

--- a/packages/cli/src/commands/team/join.ts
+++ b/packages/cli/src/commands/team/join.ts
@@ -6,19 +6,34 @@ import { ExitCode } from '../../utils/exit-codes.js'
 import { getTheme } from '../../components/theme.js'
 import { writeFile } from 'node:fs/promises'
 import { stringify as stringifyYaml } from 'yaml'
-import { promptForGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
+import { resolveOrPrompt } from '../../utils/prompts.js'
+import { resolveGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
+
+interface JoinOptions {
+  slug?: string
+  gates?: string
+}
 
 export const joinCommand = new Command('join')
   .description('Add yourself to the project team using your active identity')
-  .action(async () => {
-    await runJoin()
+  .option('--slug <slug>', 'Slug to use if your identity slug is already taken by another member')
+  .option('--gates <ids>', 'Comma-separated gate IDs to authorize (default: none)')
+  .action(async (options: JoinOptions) => {
+    await runJoin(options)
   })
 
 /**
  * Run the join command to add the user's active identity to the project team.
+ *
+ * Interactive by default when stdin is a TTY and flags are omitted. Every
+ * prompt is gated behind "flag not supplied AND stdin is an interactive TTY";
+ * when stdin is not a TTY and a required value is missing, this fails fast
+ * with an error naming the missing flag rather than hanging on a prompt that
+ * can never resolve. See issue #80.
+ *
  * @public
  */
-export async function runJoin(): Promise<void> {
+export async function runJoin(options: JoinOptions = {}): Promise<void> {
   try {
     const theme = getTheme()
 
@@ -59,32 +74,36 @@ export async function runJoin(): Promise<void> {
       process.exit(ExitCode.CONFIG_ERROR)
     }
 
-    // Determine slug - use identity slug if available, prompt if taken
+    // Determine slug - use identity slug if available, resolve if taken
     let slug = activeSlug
     // eslint-disable-next-line security/detect-object-injection -- slug comes from validated config
     if (existingTeam[slug]) {
       log(`Slug "${slug}" is already taken by another team member.`)
-      slug = await input({
-        message: 'Choose a different slug:',
-        validate: (value) => {
-          if (!value || value.trim().length === 0) {
-            return 'Slug cannot be empty'
-          }
-          if (!/^[a-z0-9-]+$/.test(value)) {
-            return 'Slug must contain only lowercase letters, numbers, and hyphens'
-          }
-          // eslint-disable-next-line security/detect-object-injection -- value is user input being validated
-          if (existingTeam[value]) {
-            return `Slug "${value}" is already taken`
-          }
-          return true
-        },
-      })
+      const validateAlternateSlug = (value: string): true | string => {
+        if (!value || value.trim().length === 0) {
+          return 'Slug cannot be empty'
+        }
+        if (!/^[a-z0-9-]+$/.test(value)) {
+          return 'Slug must contain only lowercase letters, numbers, and hyphens'
+        }
+        // eslint-disable-next-line security/detect-object-injection -- value is user input being validated
+        if (existingTeam[value]) {
+          return `Slug "${value}" is already taken`
+        }
+        return true
+      }
+      slug = await resolveOrPrompt(options.slug, '--slug', () =>
+        input({ message: 'Choose a different slug:', validate: validateAlternateSlug }),
+      )
+      const slugValidation = validateAlternateSlug(slug)
+      if (slugValidation !== true) {
+        throw new Error(slugValidation)
+      }
     }
 
-    // Prompt for gate authorizations
+    // Resolve gate authorizations
     log('')
-    const authorizedGates = await promptForGateAuthorization(policy.gates)
+    const authorizedGates = await resolveGateAuthorization(policy.gates, options.gates)
 
     // Update config with new team member
     const memberData: Parameters<typeof addTeamMemberToPolicy>[2] = {

--- a/packages/cli/src/commands/team/utils.ts
+++ b/packages/cli/src/commands/team/utils.ts
@@ -82,8 +82,7 @@ export async function resolveGateAuthorization(
       .split(',')
       .map((id) => id.trim())
       .filter((id) => id.length > 0)
-    // eslint-disable-next-line security/detect-object-injection -- id is validated below via the resulting `unknown` list before use
-    const unknown = requested.filter((id) => !gates[id])
+    const unknown = requested.filter((id) => !Object.hasOwn(gates, id))
     if (unknown.length > 0) {
       throw new Error(
         `--gates references unknown gate(s): ${unknown.join(', ')}. Known gates: ${Object.keys(gates).join(', ')}`,

--- a/packages/cli/src/commands/team/utils.ts
+++ b/packages/cli/src/commands/team/utils.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { checkbox } from '@inquirer/prompts'
 import { findPolicyPath, parsePolicyContent, type PolicyConfig } from '@attest-it/core'
+import { isInteractiveTTY } from '../../utils/prompts.js'
 
 /**
  * Load the policy configuration for editing.
@@ -51,6 +52,51 @@ export async function promptForGateAuthorization(
   })
 
   return authorizedGates
+}
+
+/**
+ * Resolve which gates to authorize for a team member, from a `--gates` flag,
+ * an interactive checkbox prompt, or neither.
+ *
+ * @remarks
+ * Gate authorization is optional (a team member can be added with no gates
+ * authorized), so a missing `--gates` flag in a non-interactive context is
+ * not an error -- it resolves to an empty array rather than failing fast.
+ *
+ * @param gates - The gates configuration from the policy file
+ * @param gatesFlag - Comma-separated gate IDs from a `--gates` flag, if supplied
+ * @returns Array of gate IDs to authorize
+ * @throws Error if `gatesFlag` names a gate ID that does not exist
+ * @public
+ */
+export async function resolveGateAuthorization(
+  gates: PolicyConfig['gates'] | undefined,
+  gatesFlag?: string,
+): Promise<string[]> {
+  if (!gates || Object.keys(gates).length === 0) {
+    return []
+  }
+
+  if (gatesFlag !== undefined) {
+    const requested = gatesFlag
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0)
+    // eslint-disable-next-line security/detect-object-injection -- id is validated below via the resulting `unknown` list before use
+    const unknown = requested.filter((id) => !gates[id])
+    if (unknown.length > 0) {
+      throw new Error(
+        `--gates references unknown gate(s): ${unknown.join(', ')}. Known gates: ${Object.keys(gates).join(', ')}`,
+      )
+    }
+    return requested
+  }
+
+  if (!isInteractiveTTY()) {
+    return []
+  }
+
+  return promptForGateAuthorization(gates)
 }
 
 /**

--- a/packages/cli/src/utils/completion-offer.ts
+++ b/packages/cli/src/utils/completion-offer.ts
@@ -6,6 +6,7 @@
 import { confirm } from '@inquirer/prompts'
 import { loadPreferences, savePreferences } from '@attest-it/core'
 import { log, info, success, error } from './output.js'
+import { isInteractiveTTY } from './prompts.js'
 import tabtab from '@pnpm/tabtab'
 
 /** Primary program name */
@@ -50,10 +51,20 @@ function getSourceCommand(shell: SupportedShell): string {
  * Offer to install shell completions if the user hasn't declined before.
  * Should be called at the end of init and identity create commands.
  *
+ * @remarks
+ * This is purely a cosmetic, optional offer -- never something a
+ * non-interactive caller (CI, an embedder, an agent) needs to answer. It is
+ * skipped entirely when stdin is not an interactive TTY rather than prompting
+ * (which would otherwise hang forever; see issue #80).
+ *
  * @returns true if completions were installed, false otherwise
  */
 export async function offerCompletionInstall(): Promise<boolean> {
   try {
+    if (!isInteractiveTTY()) {
+      return false
+    }
+
     // Check if user has already declined
     const prefs = await loadPreferences()
     if (prefs.cliExperience?.declinedCompletionInstall) {

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -7,6 +7,129 @@ export interface ConfirmOptions {
 }
 
 /**
+ * Whether stdin is attached to an interactive terminal.
+ *
+ * @remarks
+ * Every prompt in the CLI must be gated behind this check. When stdin is a
+ * pipe or `/dev/null` (CI, an embedder, or an agent), `isTTY` is `undefined`,
+ * and any attempt to read interactive input hangs indefinitely rather than
+ * failing — so callers must check this first and fail fast instead of
+ * prompting. See issue #80.
+ *
+ * @public
+ */
+export function isInteractiveTTY(): boolean {
+  // @types/node declares `isTTY` as a non-optional `boolean`, but at runtime
+  // it is `undefined` whenever stdin is not a TTY (piped input, /dev/null) --
+  // exactly the case this function exists to detect. The explicit coercion
+  // is intentional, not redundant, despite the ambient type declaration.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion
+  return Boolean(process.stdin.isTTY)
+}
+
+/**
+ * Resolve a value that would normally be collected via an interactive prompt.
+ *
+ * @remarks
+ * - If `value` is already supplied (e.g. from a CLI flag), it is returned
+ *   immediately and `prompt` is never invoked.
+ * - Otherwise, if stdin is an interactive TTY, `prompt()` runs to collect the
+ *   value interactively (unchanged default behavior for humans).
+ * - Otherwise (non-TTY and missing), throws an error naming `flagName` so the
+ *   caller's existing catch block can fail fast with a legible message
+ *   instead of hanging on a prompt that will never resolve.
+ *
+ * @param value - The already-supplied value (e.g. a parsed CLI flag), if any
+ * @param flagName - The flag name to report in the fail-fast error (e.g. `--name`)
+ * @param prompt - Callback that interactively collects the value
+ * @returns The resolved value
+ * @throws Error if `value` is undefined and stdin is not an interactive TTY
+ * @public
+ */
+export async function resolveOrPrompt<T>(
+  value: T | undefined,
+  flagName: string,
+  prompt: () => Promise<T>,
+): Promise<T> {
+  if (value !== undefined) {
+    return value
+  }
+  if (!isInteractiveTTY()) {
+    throw new Error(
+      `Missing required ${flagName} (no interactive terminal available to prompt for it). ` +
+        `Pass ${flagName} explicitly to run non-interactively.`,
+    )
+  }
+  return prompt()
+}
+
+/**
+ * Resolve a value that would normally be collected via an interactive prompt,
+ * but which has a sensible default rather than being strictly required.
+ *
+ * @remarks
+ * Unlike {@link resolveOrPrompt}, a missing value in a non-interactive
+ * context is not an error here: it simply falls back to `defaultValue`.
+ * Interactively, `prompt` is invoked (typically pre-filled with the same
+ * default) so a human can still override it.
+ *
+ * @param value - The already-supplied value (e.g. a parsed CLI flag), if any
+ * @param defaultValue - Value to use when non-interactive and `value` is missing
+ * @param prompt - Callback that interactively collects the value
+ * @returns The resolved value
+ * @public
+ */
+export async function resolveOptionalOrPrompt(
+  value: string | undefined,
+  defaultValue: string,
+  prompt: () => Promise<string>,
+): Promise<string> {
+  if (value !== undefined) {
+    return value.trim()
+  }
+  if (isInteractiveTTY()) {
+    return (await prompt()).trim()
+  }
+  return defaultValue
+}
+
+/** Coerce a stdin chunk (Buffer or string, per Node's stream typing) into a Buffer. */
+function toBuffer(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk
+  }
+  if (typeof chunk === 'string') {
+    return Buffer.from(chunk, 'utf8')
+  }
+  throw new Error('Unexpected stdin chunk type')
+}
+
+/**
+ * Read all of stdin to completion and return it as a UTF-8 string with a
+ * single trailing newline (if any) trimmed.
+ *
+ * @remarks
+ * Used by flags like `--passphrase-stdin` that read a secret piped into the
+ * process (e.g. `echo "$PASSPHRASE" | attest-it identity create ...`),
+ * mirroring conventions like `docker login --password-stdin`. This reads the
+ * CLI's own stdin directly — it does not shell out to another process, so
+ * there is no fd contention with OpenSSL's dedicated fd:3 passphrase pipe
+ * (see the `runOpenSSL` mechanism in `@attest-it/core`, added for issue #75).
+ *
+ * @returns The trimmed stdin content
+ * @public
+ */
+export async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(toBuffer(chunk))
+  }
+  return Buffer.concat(chunks)
+    .toString('utf8')
+    .replace(/\r?\n$/, '')
+}
+
+/**
  * Display a visually distinctive confirmation prompt.
  *
  * Creates a styled box with yellow border to make the attestation prompt

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -73,19 +73,32 @@ export async function resolveOrPrompt<T>(
  * Interactively, `prompt` is invoked (typically pre-filled with the same
  * default) so a human can still override it.
  *
+ * A *supplied* value that is empty (or all whitespace) after trimming is
+ * rejected rather than silently accepted: every caller's interactive
+ * `prompt` already enforces "cannot be empty" via its `validate` callback,
+ * so a flag-supplied empty string must fail the same way instead of
+ * bypassing that check.
+ *
  * @param value - The already-supplied value (e.g. a parsed CLI flag), if any
+ * @param flagName - The flag name to report if a supplied `value` is empty (e.g. `--name`)
  * @param defaultValue - Value to use when non-interactive and `value` is missing
  * @param prompt - Callback that interactively collects the value
  * @returns The resolved value
+ * @throws Error if `value` is supplied but empty (or all whitespace)
  * @public
  */
 export async function resolveOptionalOrPrompt(
   value: string | undefined,
+  flagName: string,
   defaultValue: string,
   prompt: () => Promise<string>,
 ): Promise<string> {
   if (value !== undefined) {
-    return value.trim()
+    const trimmed = value.trim()
+    if (trimmed.length === 0) {
+      throw new Error(`${flagName} cannot be empty`)
+    }
+    return trimmed
   }
   if (isInteractiveTTY()) {
     return (await prompt()).trim()

--- a/packages/cli/test/completion-offer.test.ts
+++ b/packages/cli/test/completion-offer.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the shell-completion offer helper.
+ *
+ * `offerCompletionInstall` is called at the end of both `init` and
+ * `identity create`. Before issue #80 it called `@inquirer/prompts`'
+ * `confirm()` completely unconditionally -- with no TTY gate at all -- so a
+ * non-interactive run (CI, an embedder, an agent) with `SHELL` set and no
+ * saved preference would hang forever. It must now skip the offer entirely
+ * when stdin is not an interactive TTY.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { confirm } from '@inquirer/prompts'
+import { loadPreferences, savePreferences } from '@attest-it/core'
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(),
+}))
+
+vi.mock('@attest-it/core', async () => {
+  const actual = await vi.importActual<typeof import('@attest-it/core')>('@attest-it/core')
+  return {
+    ...actual,
+    loadPreferences: vi.fn(),
+    savePreferences: vi.fn(),
+  }
+})
+
+vi.mock('@pnpm/tabtab', () => ({
+  default: { install: vi.fn() },
+}))
+
+vi.mock('../src/utils/output.js', () => ({
+  log: vi.fn(),
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}))
+
+// Import after mocks
+const { offerCompletionInstall } = await import('../src/utils/completion-offer.js')
+
+describe('offerCompletionInstall', () => {
+  const originalIsTTY = process.stdin.isTTY
+  const originalShell = process.env.SHELL
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(loadPreferences).mockResolvedValue({})
+    process.env.SHELL = '/bin/zsh'
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+    if (originalShell === undefined) {
+      delete process.env.SHELL
+    } else {
+      process.env.SHELL = originalShell
+    }
+  })
+
+  it('should skip the offer entirely without prompting when stdin is not a TTY (never hangs)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+
+    const result = await offerCompletionInstall()
+
+    expect(result).toBe(false)
+    expect(confirm).not.toHaveBeenCalled()
+    expect(loadPreferences).not.toHaveBeenCalled()
+  })
+
+  it('should prompt when stdin is an interactive TTY and no preference is saved', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    vi.mocked(confirm).mockResolvedValue(false)
+
+    await offerCompletionInstall()
+
+    expect(confirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('should skip the offer when the user already declined, even with a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    vi.mocked(loadPreferences).mockResolvedValue({
+      cliExperience: { declinedCompletionInstall: true },
+    })
+
+    const result = await offerCompletionInstall()
+
+    expect(result).toBe(false)
+    expect(confirm).not.toHaveBeenCalled()
+  })
+
+  it('should save the declined preference when the user declines interactively', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    vi.mocked(confirm).mockResolvedValue(false)
+
+    const result = await offerCompletionInstall()
+
+    expect(result).toBe(false)
+    const savedPreferences = vi.mocked(savePreferences).mock.calls[0]?.[0]
+    expect(savedPreferences?.cliExperience?.declinedCompletionInstall).toBe(true)
+  })
+})

--- a/packages/cli/test/identity-create.test.ts
+++ b/packages/cli/test/identity-create.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for `identity create`'s non-interactive flags (issue #80).
+ *
+ * These drive the real `runCreate` implementation end-to-end against a real
+ * temp-directory home (via `setAttestItHomeDir`), so identity files and
+ * config are genuinely written and read back -- not mocked away. Key-backend
+ * availability checks (1Password/Keychain/YubiKey) are stubbed to simulate a
+ * bare CI machine where only the filesystem backend is usable, which is the
+ * primary non-interactive use case this issue targets.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { Readable } from 'node:stream'
+import {
+  setAttestItHomeDir,
+  loadLocalConfig,
+  OnePasswordKeyProvider,
+  MacOSKeychainKeyProvider,
+  YubiKeyProvider,
+  isEncryptedPrivateKeyPem,
+  signEd25519,
+  type PrivateKeyRef,
+} from '@attest-it/core'
+import { runCreate, slugify, deriveUniqueSlug } from '../src/commands/identity/create.js'
+import { ExitCode } from '../src/utils/exit-codes.js'
+
+/** Narrow a PrivateKeyRef to the 'file' variant, failing the test clearly if it isn't. */
+function expectFilePrivateKey(privateKey: PrivateKeyRef | undefined): {
+  type: 'file'
+  path: string
+} {
+  if (privateKey?.type !== 'file') {
+    throw new Error(
+      `Expected a file-backed private key reference, got: ${JSON.stringify(privateKey)}`,
+    )
+  }
+  return privateKey
+}
+
+describe('slugify', () => {
+  it('should lowercase and hyphenate a display name', () => {
+    expect(slugify('CI Bot')).toBe('ci-bot')
+  })
+
+  it('should collapse non-alphanumeric runs into a single hyphen', () => {
+    expect(slugify('Jane   Q. Public!!')).toBe('jane-q-public')
+  })
+
+  it('should strip leading and trailing hyphens', () => {
+    expect(slugify('--Weird Name--')).toBe('weird-name')
+  })
+
+  it('should fall back to "identity" when nothing alphanumeric remains', () => {
+    expect(slugify('!!!')).toBe('identity')
+  })
+})
+
+describe('deriveUniqueSlug', () => {
+  it('should return the plain slug when there is no collision', () => {
+    expect(deriveUniqueSlug('Jane Doe', {})).toBe('jane-doe')
+  })
+
+  it('should append -2 on a single collision', () => {
+    expect(deriveUniqueSlug('Jane Doe', { 'jane-doe': {} })).toBe('jane-doe-2')
+  })
+
+  it('should keep incrementing past multiple collisions', () => {
+    expect(
+      deriveUniqueSlug('Jane Doe', {
+        'jane-doe': {},
+        'jane-doe-2': {},
+        'jane-doe-3': {},
+      }),
+    ).toBe('jane-doe-4')
+  })
+
+  it('should handle an undefined existing-identities map', () => {
+    expect(deriveUniqueSlug('Jane Doe', undefined)).toBe('jane-doe')
+  })
+})
+
+/** Replace process.stdin with a fake readable stream for the duration of one test. */
+function withFakeStdin<T>(content: string, fn: () => Promise<T>): Promise<T> {
+  const fake = content.length === 0 ? Readable.from([]) : Readable.from([content])
+  const original = process.stdin
+  Object.defineProperty(process, 'stdin', { value: fake, configurable: true })
+  return fn().finally(() => {
+    Object.defineProperty(process, 'stdin', { value: original, configurable: true })
+  })
+}
+
+describe('runCreate (non-interactive)', () => {
+  let tempHome: string
+  const originalIsTTY = process.stdin.isTTY
+  let mockProcessExit: ReturnType<typeof vi.spyOn>
+  let mockConsoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-it-identity-create-'))
+    setAttestItHomeDir(tempHome)
+
+    // Simulate a bare CI machine: only the filesystem backend is usable.
+    vi.spyOn(OnePasswordKeyProvider, 'isInstalled').mockResolvedValue(false)
+    vi.spyOn(MacOSKeychainKeyProvider, 'isAvailable').mockReturnValue(false)
+    vi.spyOn(YubiKeyProvider, 'isInstalled').mockResolvedValue(false)
+
+    // Non-interactive by default; individual tests override this.
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+  })
+
+  afterEach(() => {
+    setAttestItHomeDir(null)
+    fs.rmSync(tempHome, { recursive: true, force: true })
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+    vi.restoreAllMocks()
+  })
+
+  describe('required flags', () => {
+    it('should fail fast naming --name when missing and stdin is not a TTY', async () => {
+      await expect(runCreate({ storage: 'file' })).rejects.toThrow('process.exit called')
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--name'))
+    })
+
+    it('should fail fast naming --storage when missing and stdin is not a TTY', async () => {
+      await expect(runCreate({ name: 'CI Bot' })).rejects.toThrow('process.exit called')
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--storage'))
+    })
+
+    it('should reject an unknown --storage value', async () => {
+      await expect(runCreate({ name: 'CI Bot', storage: 'floppy-disk' })).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown --storage value'),
+      )
+    })
+
+    it('should reject --storage keychain when macOS Keychain is unavailable', async () => {
+      await expect(
+        runCreate({ name: 'CI Bot', storage: 'keychain', slug: 'ci-bot' }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('macOS Keychain is not available'),
+      )
+    })
+  })
+
+  describe('successful non-interactive creation (--storage file)', () => {
+    it('should create an identity with zero prompts given --name, --storage, and --slug', async () => {
+      await runCreate({
+        name: 'CI Bot',
+        slug: 'ci-bot',
+        email: 'ci-bot@example.com',
+        github: 'ci-bot-gh',
+        storage: 'file',
+      })
+
+      const config = await loadLocalConfig()
+      expect(config).not.toBeNull()
+      expect(config?.activeIdentity).toBe('ci-bot')
+      const identity = config?.identities['ci-bot']
+      expect(identity).toMatchObject({
+        name: 'CI Bot',
+        email: 'ci-bot@example.com',
+        github: 'ci-bot-gh',
+      })
+      expect(identity?.privateKey.type).toBe('file')
+      expect(mockProcessExit).not.toHaveBeenCalled()
+    })
+
+    it('should auto-derive a slug from --name when --slug is omitted', async () => {
+      await runCreate({ name: 'Jane Q. Public', storage: 'file' })
+
+      const config = await loadLocalConfig()
+      expect(config?.activeIdentity).toBe('jane-q-public')
+      expect(config?.identities['jane-q-public']).toBeDefined()
+    })
+
+    it('should default email and github to unset when omitted non-interactively', async () => {
+      await runCreate({ name: 'CI Bot', storage: 'file' })
+
+      const config = await loadLocalConfig()
+      const identity = config?.identities['ci-bot']
+      expect(identity?.email).toBeUndefined()
+      expect(identity?.github).toBeUndefined()
+    })
+
+    it('should fail with a clear error when --slug collides with an existing identity', async () => {
+      await runCreate({ name: 'CI Bot', slug: 'ci-bot', storage: 'file' })
+      mockProcessExit.mockClear()
+
+      await expect(
+        runCreate({ name: 'Another Bot', slug: 'ci-bot', storage: 'file' }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('already exists'))
+    })
+  })
+
+  describe('--passphrase-stdin', () => {
+    it('should encrypt the private key file using a passphrase piped via stdin', async () => {
+      await withFakeStdin('super-secret-passphrase\n', () =>
+        runCreate({
+          name: 'CI Bot',
+          slug: 'ci-bot',
+          storage: 'file',
+          passphraseStdin: true,
+        }),
+      )
+
+      const config = await loadLocalConfig()
+      const identity = config?.identities['ci-bot']
+      const filePath = expectFilePrivateKey(identity?.privateKey).path
+      const pem = fs.readFileSync(filePath, 'utf8')
+
+      expect(isEncryptedPrivateKeyPem(pem)).toBe(true)
+      // Round-trip: the encrypted key must actually be usable with the passphrase.
+      const signature = signEd25519('some data', pem, 'super-secret-passphrase')
+      expect(typeof signature).toBe('string')
+    })
+
+    it('should fail fast when --passphrase-stdin is set but stdin is empty', async () => {
+      await withFakeStdin('', async () => {
+        await expect(
+          runCreate({ name: 'CI Bot', slug: 'ci-bot', storage: 'file', passphraseStdin: true }),
+        ).rejects.toThrow('process.exit called')
+      })
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('stdin was empty'))
+    })
+
+    it('should leave the private key unencrypted when --passphrase-stdin is not set', async () => {
+      await runCreate({ name: 'CI Bot', slug: 'ci-bot', storage: 'file' })
+
+      const config = await loadLocalConfig()
+      const identity = config?.identities['ci-bot']
+      const filePath = expectFilePrivateKey(identity?.privateKey).path
+      const pem = fs.readFileSync(filePath, 'utf8')
+
+      expect(isEncryptedPrivateKeyPem(pem)).toBe(false)
+    })
+  })
+})

--- a/packages/cli/test/identity-create.test.ts
+++ b/packages/cli/test/identity-create.test.ts
@@ -7,6 +7,11 @@
  * availability checks (1Password/Keychain/YubiKey) are stubbed to simulate a
  * bare CI machine where only the filesystem backend is usable, which is the
  * primary non-interactive use case this issue targets.
+ *
+ * Private keys are stored through VaultKeeper (see `storePrivateKey`), so a
+ * file-backed key's v2 reference is `{ type: 'file', id }` where `id` is the
+ * VaultKeeper secret ID. To assert on the stored PEM we retrieve it back
+ * through the same provider the CLI's `run` command uses.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as fs from 'node:fs'
@@ -16,20 +21,34 @@ import { Readable } from 'node:stream'
 import {
   setAttestItHomeDir,
   loadLocalConfig,
-  OnePasswordKeyProvider,
-  MacOSKeychainKeyProvider,
-  YubiKeyProvider,
+  isOnePasswordInstalled,
+  isMacOSKeychainAvailable,
+  isYubiKeyInstalled,
   isEncryptedPrivateKeyPem,
   signEd25519,
+  KeyProviderRegistry,
   type PrivateKeyRef,
 } from '@attest-it/core'
 import { runCreate, slugify, deriveUniqueSlug } from '../src/commands/identity/create.js'
 import { ExitCode } from '../src/utils/exit-codes.js'
 
-/** Narrow a PrivateKeyRef to the 'file' variant, failing the test clearly if it isn't. */
+// Only the backend-availability probes are stubbed (to simulate a bare CI
+// machine); everything else -- config read/write, key generation, VaultKeeper
+// storage/retrieval -- runs for real against the temp home.
+vi.mock('@attest-it/core', async () => {
+  const actual = await vi.importActual<typeof import('@attest-it/core')>('@attest-it/core')
+  return {
+    ...actual,
+    isOnePasswordInstalled: vi.fn(),
+    isMacOSKeychainAvailable: vi.fn(),
+    isYubiKeyInstalled: vi.fn(),
+  }
+})
+
+/** Narrow a PrivateKeyRef to the v2 'file' variant, failing the test clearly if it isn't. */
 function expectFilePrivateKey(privateKey: PrivateKeyRef | undefined): {
   type: 'file'
-  path: string
+  id: string
 } {
   if (privateKey?.type !== 'file') {
     throw new Error(
@@ -37,6 +56,21 @@ function expectFilePrivateKey(privateKey: PrivateKeyRef | undefined): {
     )
   }
   return privateKey
+}
+
+/**
+ * Retrieve the PEM stored for a v2 file-backed key, using the same VaultKeeper
+ * filesystem provider `attest-it run` uses to load a key for signing.
+ */
+async function readStoredFilePem(privateKey: PrivateKeyRef | undefined): Promise<string> {
+  const ref = expectFilePrivateKey(privateKey)
+  const provider = KeyProviderRegistry.create({ type: 'filesystem', options: {} })
+  const result = await provider.getPrivateKey(ref.id)
+  try {
+    return await fs.promises.readFile(result.keyPath, 'utf8')
+  } finally {
+    await result.cleanup()
+  }
 }
 
 describe('slugify', () => {
@@ -102,9 +136,9 @@ describe('runCreate (non-interactive)', () => {
     setAttestItHomeDir(tempHome)
 
     // Simulate a bare CI machine: only the filesystem backend is usable.
-    vi.spyOn(OnePasswordKeyProvider, 'isInstalled').mockResolvedValue(false)
-    vi.spyOn(MacOSKeychainKeyProvider, 'isAvailable').mockReturnValue(false)
-    vi.spyOn(YubiKeyProvider, 'isInstalled').mockResolvedValue(false)
+    vi.mocked(isOnePasswordInstalled).mockResolvedValue(false)
+    vi.mocked(isMacOSKeychainAvailable).mockReturnValue(false)
+    vi.mocked(isYubiKeyInstalled).mockResolvedValue(false)
 
     // Non-interactive by default; individual tests override this.
     Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
@@ -171,6 +205,7 @@ describe('runCreate (non-interactive)', () => {
 
       const config = await loadLocalConfig()
       expect(config).not.toBeNull()
+      expect(config?.version).toBe(2)
       expect(config?.activeIdentity).toBe('ci-bot')
       const identity = config?.identities['ci-bot']
       expect(identity).toMatchObject({
@@ -179,6 +214,8 @@ describe('runCreate (non-interactive)', () => {
         github: 'ci-bot-gh',
       })
       expect(identity?.privateKey.type).toBe('file')
+      // v2 file refs carry a VaultKeeper secret id, not an on-disk path.
+      expect(expectFilePrivateKey(identity?.privateKey).id).toBeTruthy()
       expect(mockProcessExit).not.toHaveBeenCalled()
     })
 
@@ -212,7 +249,7 @@ describe('runCreate (non-interactive)', () => {
   })
 
   describe('--passphrase-stdin', () => {
-    it('should encrypt the private key file using a passphrase piped via stdin', async () => {
+    it('should encrypt the private key using a passphrase piped via stdin', async () => {
       await withFakeStdin('super-secret-passphrase\n', () =>
         runCreate({
           name: 'CI Bot',
@@ -224,8 +261,7 @@ describe('runCreate (non-interactive)', () => {
 
       const config = await loadLocalConfig()
       const identity = config?.identities['ci-bot']
-      const filePath = expectFilePrivateKey(identity?.privateKey).path
-      const pem = fs.readFileSync(filePath, 'utf8')
+      const pem = await readStoredFilePem(identity?.privateKey)
 
       expect(isEncryptedPrivateKeyPem(pem)).toBe(true)
       // Round-trip: the encrypted key must actually be usable with the passphrase.
@@ -248,8 +284,7 @@ describe('runCreate (non-interactive)', () => {
 
       const config = await loadLocalConfig()
       const identity = config?.identities['ci-bot']
-      const filePath = expectFilePrivateKey(identity?.privateKey).path
-      const pem = fs.readFileSync(filePath, 'utf8')
+      const pem = await readStoredFilePem(identity?.privateKey)
 
       expect(isEncryptedPrivateKeyPem(pem)).toBe(false)
     })

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -23,9 +23,13 @@ vi.mock('node:fs', async () => {
   }
 })
 
-// Mock prompts
+// Mock prompts. isInteractiveTTY defaults to true so existing tests continue
+// to exercise the interactive overwrite-confirmation prompt unchanged; the
+// dedicated 'non-interactive guard' describe block below overrides it with
+// mockReturnValue(false) to exercise the fail-fast path from issue #80.
 vi.mock('../src/utils/prompts.js', () => ({
   confirmAction: vi.fn(),
+  isInteractiveTTY: vi.fn(() => true),
 }))
 
 // Mock completion offer (no-op in tests)
@@ -54,7 +58,7 @@ const mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
 })
 
 // Import mocked functions
-const { confirmAction } = await import('../src/utils/prompts.js')
+const { confirmAction, isInteractiveTTY } = await import('../src/utils/prompts.js')
 const { migrateUnifiedContent } = await import('@attest-it/core')
 
 // Load the *real* template files from disk (via the unmocked fs module) so the
@@ -100,6 +104,12 @@ describe('init command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    // Most of these tests exercise the interactive overwrite-confirmation
+    // prompt, only reachable with an interactive TTY (see issue #80's
+    // fail-fast guard). The dedicated 'non-interactive' describe block below
+    // overrides this per-test to exercise the guard itself.
+    vi.mocked(isInteractiveTTY).mockReturnValue(true)
+
     // By default: nothing exists on disk (fresh init), no lock files.
     vi.mocked(fs.existsSync).mockReturnValue(false)
 
@@ -131,6 +141,44 @@ describe('init command', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+  })
+
+  describe('non-interactive guard (issue #80)', () => {
+    it('should fail fast naming --force when policy.yaml exists, stdin is not a TTY, and --force is omitted', async () => {
+      vi.mocked(isInteractiveTTY).mockReturnValue(false)
+      vi.mocked(fs.existsSync).mockImplementation((filePath) =>
+        filePath.toString().endsWith('policy.yaml'),
+      )
+
+      await expect(runInit({ dir: DEFAULT_DIR })).rejects.toThrow('process.exit called')
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringMatching(/Config already exists.*--force/),
+      )
+      expect(confirmAction).not.toHaveBeenCalled()
+      expect(fs.promises.writeFile).not.toHaveBeenCalled()
+    })
+
+    it('should proceed without prompting when stdin is not a TTY and --force is set, even if files exist', async () => {
+      vi.mocked(isInteractiveTTY).mockReturnValue(false)
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+
+      await runInit({ dir: DEFAULT_DIR, force: true })
+
+      expect(confirmAction).not.toHaveBeenCalled()
+      expect(fs.promises.writeFile).toHaveBeenCalled()
+    })
+
+    it('should not require a TTY when neither config file exists yet', async () => {
+      vi.mocked(isInteractiveTTY).mockReturnValue(false)
+      vi.mocked(fs.existsSync).mockReturnValue(false)
+
+      await runInit({ dir: DEFAULT_DIR })
+
+      expect(confirmAction).not.toHaveBeenCalled()
+      expect(fs.promises.writeFile).toHaveBeenCalled()
+    })
   })
 
   describe('positive cases (default split scaffold)', () => {

--- a/packages/cli/test/integration/non-interactive-setup.integration.test.ts
+++ b/packages/cli/test/integration/non-interactive-setup.integration.test.ts
@@ -1,0 +1,322 @@
+/**
+ * End-to-end non-interactive setup test (issue #80).
+ *
+ * Drives the real, built CLI as subprocesses with stdin fully closed
+ * (mirroring `< /dev/null`), through `identity create` -> `init` -> `run`
+ * (seal) -> `verify`, and asserts the whole flow completes with zero TTY
+ * prompts. This mirrors PRD R3's "sample embedder script" acceptance
+ * criterion: a scripted caller must be able to go from nothing to a verified
+ * seal without ever answering a terminal prompt.
+ *
+ * Every subprocess call in this file uses `stdio: ['ignore', 'pipe', 'pipe']`
+ * (stdin closed, equivalent to `/dev/null`) and a hard timeout: if any
+ * command were to fall back to an interactive prompt, it would hang until
+ * killed and the test would fail loudly rather than pass silently.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+
+const CLI_CALL_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run the built CLI as a real subprocess with stdin closed and a hard
+ * timeout. If the CLI ever falls back to an interactive prompt despite
+ * having no TTY, the child never exits on its own; the timeout kills it and
+ * fails the test with a clear message instead of hanging the whole suite.
+ */
+function runCliNonInteractive(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      // stdin: 'ignore' is Node's equivalent of `< /dev/null` -- there is
+      // nothing to read, ever. This is the exact scenario issue #80 requires
+      // every setup command to survive without hanging.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(CLI_CALL_TIMEOUT_MS)}ms -- this indicates it ` +
+            `hung on an interactive prompt with no TTY available: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+async function runGit(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', args, { cwd, stdio: 'ignore' })
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`git ${args.join(' ')} exited with code ${String(code)}`))
+      }
+    })
+    child.on('error', reject)
+  })
+}
+
+function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+// `Array.isArray` narrows `unknown` to `any[]` (a long-standing TS quirk), so
+// a dedicated guard is used here to keep the destructured element `unknown`.
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value)
+}
+
+/** Read the public key attest-it just wrote for `slug` under a temp ATTEST_IT_HOME. */
+async function readCreatedPublicKey(homeDir: string, slug: string): Promise<string> {
+  const content = await fs.promises.readFile(path.join(homeDir, 'config.yaml'), 'utf8')
+  const parsed: unknown = parseYaml(content)
+  if (!isRecordOfUnknown(parsed) || !isRecordOfUnknown(parsed.identities)) {
+    throw new Error('Expected local config to contain an identities map')
+  }
+  const identity = parsed.identities[slug]
+  if (!isRecordOfUnknown(identity) || typeof identity.publicKey !== 'string') {
+    throw new Error(`Expected identity "${slug}" to have a string publicKey`)
+  }
+  return identity.publicKey
+}
+
+describe('non-interactive setup end-to-end (issue #80)', () => {
+  let projectDir: string
+  let homeDir: string
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-e2e-project-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-e2e-home-'))
+
+    // A trivial source file so fingerprinting has something to hash.
+    await fs.promises.mkdir(path.join(projectDir, 'src'), { recursive: true })
+    await fs.promises.writeFile(path.join(projectDir, 'src', 'index.ts'), 'export const x = 1\n')
+
+    await runGit(['init'], projectDir)
+    await runGit(['config', 'user.email', 'test@example.com'], projectDir)
+    await runGit(['config', 'user.name', 'Test User'], projectDir)
+    await runGit(['add', '.'], projectDir)
+    await runGit(['commit', '-m', 'initial commit'], projectDir)
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  it(
+    'runs identity create -> init -> run (seal) -> verify with zero TTY prompts and stdin closed throughout',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir }
+
+      // 1. identity create: the very first onboarding step. This is the
+      // exact hang this issue reports -- it must complete with no prompt.
+      const createResult = await runCliNonInteractive(
+        ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+        projectDir,
+        env,
+      )
+      expect(createResult.exitCode).toBe(0)
+      expect(createResult.stdout).toContain('Identity created successfully')
+
+      const publicKey = await readCreatedPublicKey(homeDir, 'test-user')
+
+      // 2. init: scaffolds the split config non-interactively (fresh
+      // directory, so no overwrite confirmation is needed).
+      const initResult = await runCliNonInteractive(['init'], projectDir, env)
+      expect(initResult.exitCode).toBe(0)
+      expect(fs.existsSync(path.join(projectDir, '.attest-it', 'policy.yaml'))).toBe(true)
+      expect(fs.existsSync(path.join(projectDir, '.attest-it', 'config.yaml'))).toBe(true)
+
+      // Wire up a gate/suite authorizing the identity just created -- the
+      // manual editing step init's own "Next steps" output points to.
+      const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+      const policy = {
+        version: 1,
+        settings: { maxAgeDays: 30 },
+        team: {
+          'test-user': { name: 'Test User', publicKey, publicKeyAlgorithm: 'ed25519' },
+        },
+        gates: {
+          'example-gate': {
+            name: 'Example Gate',
+            description: 'Example gate for the non-interactive e2e test',
+            authorizedSigners: ['test-user'],
+            fingerprint: { paths: ['src'] },
+            maxAge: '30d',
+          },
+        },
+      }
+      await fs.promises.writeFile(policyPath, stringifyYaml(policy), 'utf8')
+
+      const configPath = path.join(projectDir, '.attest-it', 'config.yaml')
+      const operationalConfig = {
+        version: 1,
+        settings: {},
+        suites: {
+          example: {
+            description: 'Example suite',
+            gate: 'example-gate',
+            command: 'echo "example tests passed"',
+          },
+        },
+      }
+      await fs.promises.writeFile(configPath, stringifyYaml(operationalConfig), 'utf8')
+
+      await runGit(['add', '.'], projectDir)
+      await runGit(['commit', '-m', 'configure gate and suite'], projectDir)
+
+      // 3. run --suite ... --yes: executes the suite and creates a seal
+      // without prompting for confirmation.
+      const runResult = await runCliNonInteractive(
+        ['run', '--suite', 'example', '--yes'],
+        projectDir,
+        env,
+      )
+      expect(runResult.exitCode).toBe(0)
+      expect(runResult.stdout).toContain('Tests passed')
+      expect(runResult.stdout).toContain("Seal created for gate 'example-gate'")
+      expect(fs.existsSync(path.join(projectDir, '.attest-it', 'seals.json'))).toBe(true)
+
+      // 4. verify: the freshly created seal must validate.
+      const verifyResult = await runCliNonInteractive(
+        ['verify', 'example-gate', '--json'],
+        projectDir,
+        env,
+      )
+      expect(verifyResult.exitCode).toBe(0)
+      const verifyJson: unknown = JSON.parse(verifyResult.stdout)
+      if (!isUnknownArray(verifyJson)) {
+        throw new Error('Expected verify --json to output an array')
+      }
+      const [gateStatus] = verifyJson
+      expect(isRecordOfUnknown(gateStatus) && gateStatus.state).toBe('VALID')
+    },
+    CLI_CALL_TIMEOUT_MS * 5,
+  )
+
+  it(
+    'fails fast (never hangs) when identity create is missing required flags with no TTY',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir }
+
+      const result = await runCliNonInteractive(['identity', 'create'], projectDir, env)
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toMatch(/--name/)
+    },
+    CLI_CALL_TIMEOUT_MS,
+  )
+
+  it(
+    'fails fast (never hangs) when init would overwrite existing config without --force, with no TTY',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir }
+
+      const first = await runCliNonInteractive(['init'], projectDir, env)
+      expect(first.exitCode).toBe(0)
+
+      const second = await runCliNonInteractive(['init'], projectDir, env)
+      expect(second.exitCode).not.toBe(0)
+      expect(second.stderr).toMatch(/--force/)
+    },
+    CLI_CALL_TIMEOUT_MS * 2,
+  )
+
+  it(
+    'fails fast (never hangs) when run has pending suites but neither --suite nor --all is given, with no TTY',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir }
+
+      const initResult = await runCliNonInteractive(['init'], projectDir, env)
+      expect(initResult.exitCode).toBe(0)
+
+      const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+      await fs.promises.writeFile(
+        policyPath,
+        stringifyYaml({
+          version: 1,
+          settings: { maxAgeDays: 30 },
+          team: {
+            nobody: {
+              name: 'Nobody',
+              publicKey: 'oB5OUxsnFR7GdTPURp9loSGinbcb6EKDTrFGKl2VTPk=',
+              publicKeyAlgorithm: 'ed25519',
+            },
+          },
+          gates: {
+            'example-gate': {
+              name: 'Example Gate',
+              description: 'Example gate',
+              authorizedSigners: ['nobody'],
+              fingerprint: { paths: ['src'] },
+              maxAge: '30d',
+            },
+          },
+        }),
+        'utf8',
+      )
+      const configPath = path.join(projectDir, '.attest-it', 'config.yaml')
+      await fs.promises.writeFile(
+        configPath,
+        stringifyYaml({
+          version: 1,
+          settings: {},
+          suites: {
+            example: { description: 'Example', gate: 'example-gate', command: 'echo ok' },
+          },
+        }),
+        'utf8',
+      )
+
+      const result = await runCliNonInteractive(['run'], projectDir, env)
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toMatch(/--suite|--all/)
+    },
+    CLI_CALL_TIMEOUT_MS * 2,
+  )
+})

--- a/packages/cli/test/prompts.test.ts
+++ b/packages/cli/test/prompts.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the non-interactive setup helpers (issue #80): every CLI prompt
+ * must be gated behind "flag not supplied AND stdin is an interactive TTY",
+ * failing fast with a legible error instead of hanging when it is not.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  isInteractiveTTY,
+  resolveOrPrompt,
+  resolveOptionalOrPrompt,
+  readStdin,
+} from '../src/utils/prompts.js'
+import { Readable } from 'node:stream'
+
+describe('isInteractiveTTY', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  it('should return true when stdin.isTTY is true', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    expect(isInteractiveTTY()).toBe(true)
+  })
+
+  it('should return false when stdin.isTTY is undefined (e.g. piped or /dev/null)', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    expect(isInteractiveTTY()).toBe(false)
+  })
+
+  it('should return false when stdin.isTTY is false', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+    expect(isInteractiveTTY()).toBe(false)
+  })
+})
+
+describe('resolveOrPrompt', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  it('should return the supplied value without invoking the prompt', async () => {
+    const prompt = vi.fn().mockResolvedValue('should not be used')
+
+    const result = await resolveOrPrompt('flag-value', '--name', prompt)
+
+    expect(result).toBe('flag-value')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+
+  it('should invoke the prompt when value is missing and stdin is an interactive TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    const prompt = vi.fn().mockResolvedValue('prompted-value')
+
+    const result = await resolveOrPrompt<string>(undefined, '--name', prompt)
+
+    expect(result).toBe('prompted-value')
+    expect(prompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw naming the flag when value is missing and stdin is not a TTY (never hangs)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    const prompt = vi.fn().mockResolvedValue('should not be used')
+
+    await expect(resolveOrPrompt<string>(undefined, '--name', prompt)).rejects.toThrow('--name')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveOptionalOrPrompt', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  it('should return the trimmed supplied value without invoking the prompt', async () => {
+    const prompt = vi.fn().mockResolvedValue('should not be used')
+
+    const result = await resolveOptionalOrPrompt('  flag-value  ', 'default-value', prompt)
+
+    expect(result).toBe('flag-value')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+
+  it('should invoke the prompt when value is missing and stdin is an interactive TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    const prompt = vi.fn().mockResolvedValue('prompted-value')
+
+    const result = await resolveOptionalOrPrompt(undefined, 'default-value', prompt)
+
+    expect(result).toBe('prompted-value')
+    expect(prompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('should fall back to the default (not throw) when value is missing and stdin is not a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    const prompt = vi.fn().mockResolvedValue('should not be used')
+
+    const result = await resolveOptionalOrPrompt(undefined, 'default-value', prompt)
+
+    expect(result).toBe('default-value')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+})
+
+describe('readStdin', () => {
+  /** Replace process.stdin with a fake readable stream for the duration of one test. */
+  function withFakeStdin<T>(content: string | null, fn: () => Promise<T>): Promise<T> {
+    const fake = content === null ? Readable.from([]) : Readable.from([content])
+    const original = process.stdin
+    Object.defineProperty(process, 'stdin', { value: fake, configurable: true })
+    return fn().finally(() => {
+      Object.defineProperty(process, 'stdin', { value: original, configurable: true })
+    })
+  }
+
+  it('should read piped content and trim a single trailing newline', async () => {
+    const result = await withFakeStdin('super-secret\n', () => readStdin())
+    expect(result).toBe('super-secret')
+  })
+
+  it('should read piped content with no trailing newline unchanged', async () => {
+    const result = await withFakeStdin('super-secret', () => readStdin())
+    expect(result).toBe('super-secret')
+  })
+
+  it('should return an empty string when stdin is empty (e.g. /dev/null)', async () => {
+    const result = await withFakeStdin('', () => readStdin())
+    expect(result).toBe('')
+  })
+
+  it('should only trim one trailing newline, preserving internal newlines', async () => {
+    const result = await withFakeStdin('line1\nline2\n', () => readStdin())
+    expect(result).toBe('line1\nline2')
+  })
+})

--- a/packages/cli/test/prompts.test.ts
+++ b/packages/cli/test/prompts.test.ts
@@ -80,7 +80,12 @@ describe('resolveOptionalOrPrompt', () => {
   it('should return the trimmed supplied value without invoking the prompt', async () => {
     const prompt = vi.fn().mockResolvedValue('should not be used')
 
-    const result = await resolveOptionalOrPrompt('  flag-value  ', 'default-value', prompt)
+    const result = await resolveOptionalOrPrompt(
+      '  flag-value  ',
+      '--name',
+      'default-value',
+      prompt,
+    )
 
     expect(result).toBe('flag-value')
     expect(prompt).not.toHaveBeenCalled()
@@ -90,7 +95,7 @@ describe('resolveOptionalOrPrompt', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
     const prompt = vi.fn().mockResolvedValue('prompted-value')
 
-    const result = await resolveOptionalOrPrompt(undefined, 'default-value', prompt)
+    const result = await resolveOptionalOrPrompt(undefined, '--name', 'default-value', prompt)
 
     expect(result).toBe('prompted-value')
     expect(prompt).toHaveBeenCalledTimes(1)
@@ -100,9 +105,20 @@ describe('resolveOptionalOrPrompt', () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
     const prompt = vi.fn().mockResolvedValue('should not be used')
 
-    const result = await resolveOptionalOrPrompt(undefined, 'default-value', prompt)
+    const result = await resolveOptionalOrPrompt(undefined, '--name', 'default-value', prompt)
 
     expect(result).toBe('default-value')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+
+  it('should reject a supplied value that is empty (or all whitespace) instead of silently accepting it', async () => {
+    // Regression test: a flag-supplied empty string previously bypassed the
+    // "cannot be empty" validation every interactive `prompt` enforces.
+    const prompt = vi.fn().mockResolvedValue('should not be used')
+
+    await expect(resolveOptionalOrPrompt('   ', '--name', 'default-value', prompt)).rejects.toThrow(
+      '--name cannot be empty',
+    )
     expect(prompt).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/test/run-interactive.test.tsx
+++ b/packages/cli/test/run-interactive.test.tsx
@@ -111,6 +111,7 @@ function createMockChildProcess() {
 describe('runInteractive', () => {
   let mockExit: ReturnType<typeof vi.spyOn<typeof process, 'exit'>>
   let originalProcessExit: typeof process.exit
+  const originalIsTTY = process.stdin.isTTY
 
   beforeEach(() => {
     // Save original process.exit
@@ -124,6 +125,12 @@ describe('runInteractive', () => {
     // Reset all mocks
     vi.clearAllMocks()
 
+    // Most of these tests exercise the interactive UI (or code paths that run
+    // before it), which is only reachable with an interactive TTY (see issue
+    // #80's non-TTY guard). The dedicated 'non-interactive' describe block
+    // below overrides this per-test to exercise the guard itself.
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+
     // Setup default mocks
     vi.mocked(loadSplitConfig).mockResolvedValue(createMockConfig())
     vi.mocked(getAllSuiteStatuses).mockResolvedValue([
@@ -136,6 +143,28 @@ describe('runInteractive', () => {
   afterEach(() => {
     // Restore original process.exit
     mockExit.mockRestore()
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  describe('non-interactive guard (issue #80)', () => {
+    it('should fail fast instead of hanging when stdin is not a TTY and pending suites exist', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+
+      await expect(runInteractive({})).rejects.toThrow('process.exit called')
+
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining('requires an interactive terminal'),
+      )
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+    })
+
+    it('should not require a TTY for --dry-run', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+
+      await expect(runInteractive({ dryRun: true })).rejects.toThrow('process.exit called')
+
+      expect(mockExit).toHaveBeenCalledWith(ExitCode.SUCCESS)
+    })
   })
 
   describe('dry run mode', () => {

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -108,6 +108,23 @@ describe('resolveKeyPassphrase', () => {
 
     await expect(resolveKeyPassphrase()).rejects.toThrow(PASSPHRASE_ENV)
   })
+
+  it('should reject an empty passphrase at the interactive prompt instead of accepting it', async () => {
+    // Regression test: an empty passphrase previously passed through
+    // resolveKeyPassphrase() unchecked, then caused ed25519 signing to fail
+    // with a cryptic OpenSSL decrypt error instead of a clear message.
+    vi.mocked(isInteractiveTTY).mockReturnValue(true)
+    vi.mocked(password).mockResolvedValue('prompted-passphrase')
+
+    await resolveKeyPassphrase()
+
+    const call = vi.mocked(password).mock.calls[0]
+    expect(call).toBeDefined()
+    const { validate } = call?.[0] ?? {}
+    expect(validate).toBeDefined()
+    expect(validate?.('')).toBe('Passphrase cannot be empty')
+    expect(validate?.('non-empty')).toBe(true)
+  })
 })
 
 describe('buildCommand', () => {

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   buildCommand,
   parseCommand,
   executeCommand,
   checkDirtyWorkingTree,
+  resolveKeyPassphrase,
 } from '../src/commands/run.js'
 import type { Config } from '@attest-it/core'
 import type { ChildProcess } from 'node:child_process'
@@ -40,6 +41,13 @@ vi.mock('../src/utils/output.js', () => ({
 // Mock prompts
 vi.mock('../src/utils/prompts.js', () => ({
   confirmAction: vi.fn(),
+  isInteractiveTTY: vi.fn(() => false),
+}))
+
+// Mock @inquirer/prompts' password() -- used to prompt for an encrypted
+// identity key's passphrase interactively (issue #80)
+vi.mock('@inquirer/prompts', () => ({
+  password: vi.fn(),
 }))
 
 // Mock os module
@@ -48,6 +56,59 @@ vi.mock('node:os', () => ({
 }))
 
 const { spawn } = await import('node:child_process')
+const { isInteractiveTTY } = await import('../src/utils/prompts.js')
+const { password } = await import('@inquirer/prompts')
+
+describe('resolveKeyPassphrase', () => {
+  const PASSPHRASE_ENV = 'ATTEST_IT_KEY_PASSPHRASE'
+  const originalEnvValue = process.env[PASSPHRASE_ENV]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.ATTEST_IT_KEY_PASSPHRASE
+  })
+
+  afterEach(() => {
+    if (originalEnvValue === undefined) {
+      delete process.env.ATTEST_IT_KEY_PASSPHRASE
+    } else {
+      process.env[PASSPHRASE_ENV] = originalEnvValue
+    }
+  })
+
+  it('should resolve from the ATTEST_IT_KEY_PASSPHRASE env var without prompting', async () => {
+    process.env[PASSPHRASE_ENV] = 'env-passphrase'
+
+    const result = await resolveKeyPassphrase()
+
+    expect(result).toBe('env-passphrase')
+    expect(password).not.toHaveBeenCalled()
+  })
+
+  it('should prompt interactively when the env var is unset and stdin is a TTY', async () => {
+    vi.mocked(isInteractiveTTY).mockReturnValue(true)
+    vi.mocked(password).mockResolvedValue('prompted-passphrase')
+
+    const result = await resolveKeyPassphrase()
+
+    expect(result).toBe('prompted-passphrase')
+    expect(password).toHaveBeenCalledTimes(1)
+  })
+
+  it('should fail fast naming the env var when unset and stdin is not a TTY (never hangs)', async () => {
+    vi.mocked(isInteractiveTTY).mockReturnValue(false)
+
+    await expect(resolveKeyPassphrase()).rejects.toThrow(PASSPHRASE_ENV)
+    expect(password).not.toHaveBeenCalled()
+  })
+
+  it('should treat an empty env var the same as unset', async () => {
+    process.env[PASSPHRASE_ENV] = ''
+    vi.mocked(isInteractiveTTY).mockReturnValue(false)
+
+    await expect(resolveKeyPassphrase()).rejects.toThrow(PASSPHRASE_ENV)
+  })
+})
 
 describe('buildCommand', () => {
   // Helper to create a mock config

--- a/packages/cli/test/team-add.test.ts
+++ b/packages/cli/test/team-add.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for `team add`'s non-interactive flags (issue #80).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { runAdd, addCommand } from '../src/commands/team/add.js'
+import * as core from '@attest-it/core'
+import type { PolicyConfig } from '@attest-it/core'
+import * as fs from 'node:fs/promises'
+import * as prompts from '@inquirer/prompts'
+import YAML from 'yaml'
+
+/** Parse the policy YAML written by the most recent fs.writeFile call. */
+function getWrittenPolicyYaml(): string {
+  const writeCall = vi.mocked(fs.writeFile).mock.calls[0]
+  if (!writeCall) {
+    throw new Error('Expected fs.writeFile to have been called')
+  }
+  const content: unknown = writeCall[1]
+  if (typeof content !== 'string') {
+    throw new Error('Expected written policy content to be a string')
+  }
+  return content
+}
+
+function isPolicyConfig(value: unknown): value is PolicyConfig {
+  return typeof value === 'object' && value !== null && 'version' in value
+}
+
+function parseWrittenPolicy(): PolicyConfig {
+  const parsed: unknown = YAML.parse(getWrittenPolicyYaml())
+  if (!isPolicyConfig(parsed)) {
+    throw new Error('Expected written content to parse as a PolicyConfig')
+  }
+  return parsed
+}
+
+vi.mock('@attest-it/core', async () => {
+  const actual = await vi.importActual<typeof import('@attest-it/core')>('@attest-it/core')
+  return {
+    ...actual,
+    findPolicyPath: vi.fn(),
+    parsePolicyContent: vi.fn(),
+  }
+})
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => ''),
+}))
+
+vi.mock('@inquirer/prompts', () => ({
+  input: vi.fn(),
+  checkbox: vi.fn(),
+}))
+
+const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+const mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+  throw new Error('process.exit called')
+})
+
+function mockPolicy(policy: PolicyConfig, path = '/test/policy.yaml'): void {
+  vi.mocked(core.findPolicyPath).mockReturnValue(path)
+  vi.mocked(core.parsePolicyContent).mockReturnValue(policy)
+}
+
+const BASE_POLICY: PolicyConfig = {
+  version: 1,
+  settings: {
+    maxAgeDays: 30,
+    publicKeyPath: '.attest-it/pubkey.pem',
+    attestationsPath: '.attest-it/attestations.json',
+    sealsPath: '.attest-it/seals.json',
+  },
+  team: {},
+}
+
+const VALID_PUBLIC_KEY = 'oB5OUxsnFR7GdTPURp9loSGinbcb6EKDTrFGKl2VTPk='
+
+describe('team add command', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  beforeEach(() => {
+    mockConsoleLog.mockClear()
+    mockConsoleError.mockClear()
+    mockProcessExit.mockClear()
+    vi.clearAllMocks()
+    mockPolicy(BASE_POLICY)
+
+    // Non-interactive by default (matches a CI/embedder environment); the
+    // 'interactive fallback' describe block below overrides this to true to
+    // exercise unchanged human-driven behavior.
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  it('should be defined', () => {
+    expect(addCommand).toBeDefined()
+    expect(addCommand.name()).toBe('add')
+  })
+
+  describe('non-interactive (flags supplied)', () => {
+    it('should add a team member with zero prompts given all required flags', async () => {
+      await runAdd({
+        slug: 'new-user',
+        name: 'New User',
+        publicKey: VALID_PUBLIC_KEY,
+      })
+
+      expect(prompts.input).not.toHaveBeenCalled()
+      expect(prompts.checkbox).not.toHaveBeenCalled()
+
+      const parsedConfig = parseWrittenPolicy()
+      expect(parsedConfig.team?.['new-user']).toMatchObject({
+        name: 'New User',
+        publicKey: VALID_PUBLIC_KEY,
+      })
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringMatching(/✓.*Team member "new-user" added successfully/),
+      )
+    })
+
+    it('should authorize gates listed in --gates without prompting', async () => {
+      mockPolicy({
+        ...BASE_POLICY,
+        gates: {
+          'gate-1': {
+            name: 'Gate 1',
+            description: 'desc',
+            authorizedSigners: [],
+            fingerprint: { paths: ['.'] },
+            maxAge: '30d',
+          },
+        },
+      })
+
+      await runAdd({
+        slug: 'new-user',
+        name: 'New User',
+        publicKey: VALID_PUBLIC_KEY,
+        gates: 'gate-1',
+      })
+
+      expect(prompts.checkbox).not.toHaveBeenCalled()
+      const parsedConfig = parseWrittenPolicy()
+      expect(parsedConfig.gates?.['gate-1']?.authorizedSigners).toContain('new-user')
+    })
+
+    it('should reject --gates referencing an unknown gate ID', async () => {
+      mockPolicy({
+        ...BASE_POLICY,
+        gates: {
+          'gate-1': {
+            name: 'Gate 1',
+            description: 'desc',
+            authorizedSigners: [],
+            fingerprint: { paths: ['.'] },
+            maxAge: '30d',
+          },
+        },
+      })
+
+      await expect(
+        runAdd({
+          slug: 'new-user',
+          name: 'New User',
+          publicKey: VALID_PUBLIC_KEY,
+          gates: 'no-such-gate',
+        }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('unknown gate(s): no-such-gate'),
+      )
+    })
+
+    it('should reject an invalid public key even when supplied via flag', async () => {
+      await expect(
+        runAdd({ slug: 'new-user', name: 'New User', publicKey: 'not-valid-base64!!!' }),
+      ).rejects.toThrow('process.exit called')
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Base64'))
+    })
+  })
+
+  describe('non-interactive guard (missing required flags, no TTY)', () => {
+    it('should fail fast naming --slug when missing', async () => {
+      await expect(runAdd({ name: 'New User', publicKey: VALID_PUBLIC_KEY })).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--slug'))
+    })
+
+    it('should fail fast naming --name when missing', async () => {
+      await expect(runAdd({ slug: 'new-user', publicKey: VALID_PUBLIC_KEY })).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--name'))
+    })
+
+    it('should fail fast naming --public-key when missing', async () => {
+      await expect(runAdd({ slug: 'new-user', name: 'New User' })).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--public-key'))
+    })
+
+    it('should default to zero authorized gates when --gates is omitted', async () => {
+      mockPolicy({
+        ...BASE_POLICY,
+        gates: {
+          'gate-1': {
+            name: 'Gate 1',
+            description: 'desc',
+            authorizedSigners: [],
+            fingerprint: { paths: ['.'] },
+            maxAge: '30d',
+          },
+        },
+      })
+
+      await runAdd({ slug: 'new-user', name: 'New User', publicKey: VALID_PUBLIC_KEY })
+
+      const parsedConfig = parseWrittenPolicy()
+      expect(parsedConfig.gates?.['gate-1']?.authorizedSigners).not.toContain('new-user')
+    })
+  })
+
+  describe('interactive fallback (unchanged for humans)', () => {
+    it('should prompt for slug, name, and public key when flags are omitted with a TTY', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+      vi.mocked(prompts.input)
+        .mockResolvedValueOnce('new-user')
+        .mockResolvedValueOnce('New User')
+        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce('')
+        .mockResolvedValueOnce(VALID_PUBLIC_KEY)
+
+      await runAdd({})
+
+      expect(prompts.input).toHaveBeenCalledTimes(5)
+      const parsedConfig = parseWrittenPolicy()
+      expect(parsedConfig.team?.['new-user']).toBeDefined()
+    })
+  })
+})

--- a/packages/cli/test/team-join.test.ts
+++ b/packages/cli/test/team-join.test.ts
@@ -74,6 +74,8 @@ function mockPolicy(policy: PolicyConfig, path = '/test/policy.yaml'): void {
 const PUBLIC_KEY = 'dGVzdHB1YmxpY2tleXRlc3RwdWJsaWNrZXl0ZXN0cHVibGlja2V5'
 
 describe('team join command', () => {
+  const originalIsTTY = process.stdin.isTTY
+
   beforeEach(() => {
     // Clear mock call history but keep the implementations
     mockConsoleLog.mockClear()
@@ -82,10 +84,17 @@ describe('team join command', () => {
 
     // Also clear mocks from vi.mock
     vi.clearAllMocks()
+
+    // Most of these tests exercise interactive prompts (slug collision,
+    // gate authorization), only reachable with an interactive TTY (see issue
+    // #80's fail-fast guard). The dedicated 'non-interactive' describe block
+    // below overrides this per-test to exercise the guard itself.
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
   })
 
   afterEach(() => {
-    // Don't restore - we want to keep our mocks in place
+    // Don't restore mocks -- we want to keep our mocks in place
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
   })
 
   it('should be defined', () => {
@@ -781,6 +790,166 @@ describe('team join command', () => {
 
       expect(parsedConfig.gates?.['gate-1']?.authorizedSigners).toEqual(['new-user'])
       expect(parsedConfig.gates?.['gate-1']?.authorizedSigners).toHaveLength(1)
+    })
+  })
+
+  describe('non-interactive (issue #80)', () => {
+    beforeEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    })
+
+    it('should resolve a slug collision via --slug without prompting', async () => {
+      vi.mocked(core.loadLocalConfig).mockResolvedValue({
+        activeIdentity: 'taken-slug',
+        identities: {
+          'taken-slug': {
+            name: 'New User',
+            publicKey: PUBLIC_KEY,
+            privateKey: { type: 'file', path: '/test/path' },
+          },
+        },
+      })
+      vi.mocked(core.getActiveIdentity).mockReturnValue({
+        name: 'New User',
+        publicKey: PUBLIC_KEY,
+        privateKey: { type: 'file', path: '/test/path' },
+      })
+      mockPolicy({
+        version: 1,
+        settings: {
+          maxAgeDays: 30,
+          publicKeyPath: '.attest-it/pubkey.pem',
+          attestationsPath: '.attest-it/attestations.json',
+          sealsPath: '.attest-it/seals.json',
+        },
+        team: {
+          'taken-slug': { name: 'Existing User', publicKey: 'different-key' },
+        },
+      })
+
+      await runJoin({ slug: 'new-slug' })
+
+      expect(prompts.input).not.toHaveBeenCalled()
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringMatching(/✓.*Team member "new-slug" added successfully/),
+      )
+    })
+
+    it('should fail fast naming --slug when the slug collides and no TTY is available', async () => {
+      vi.mocked(core.loadLocalConfig).mockResolvedValue({
+        activeIdentity: 'taken-slug',
+        identities: {
+          'taken-slug': {
+            name: 'New User',
+            publicKey: PUBLIC_KEY,
+            privateKey: { type: 'file', path: '/test/path' },
+          },
+        },
+      })
+      vi.mocked(core.getActiveIdentity).mockReturnValue({
+        name: 'New User',
+        publicKey: PUBLIC_KEY,
+        privateKey: { type: 'file', path: '/test/path' },
+      })
+      mockPolicy({
+        version: 1,
+        settings: {
+          maxAgeDays: 30,
+          publicKeyPath: '.attest-it/pubkey.pem',
+          attestationsPath: '.attest-it/attestations.json',
+          sealsPath: '.attest-it/seals.json',
+        },
+        team: {
+          'taken-slug': { name: 'Existing User', publicKey: 'different-key' },
+        },
+      })
+
+      await expect(runJoin()).rejects.toThrow('process.exit')
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringMatching(/✗.*--slug/))
+    })
+
+    it('should authorize gates listed in --gates without prompting', async () => {
+      vi.mocked(core.loadLocalConfig).mockResolvedValue({
+        activeIdentity: 'new-user',
+        identities: {
+          'new-user': {
+            name: 'New User',
+            publicKey: PUBLIC_KEY,
+            privateKey: { type: 'file', path: '/test/path' },
+          },
+        },
+      })
+      vi.mocked(core.getActiveIdentity).mockReturnValue({
+        name: 'New User',
+        publicKey: PUBLIC_KEY,
+        privateKey: { type: 'file', path: '/test/path' },
+      })
+      mockPolicy({
+        version: 1,
+        settings: {
+          maxAgeDays: 30,
+          publicKeyPath: '.attest-it/pubkey.pem',
+          attestationsPath: '.attest-it/attestations.json',
+          sealsPath: '.attest-it/seals.json',
+        },
+        team: {},
+        gates: {
+          'gate-1': makeGate({ name: 'First Gate' }),
+          'gate-2': makeGate({ name: 'Second Gate' }),
+        },
+      })
+
+      await runJoin({ gates: 'gate-1' })
+
+      expect(prompts.checkbox).not.toHaveBeenCalled()
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0]
+      expect(writeCall).toBeDefined()
+      const yamlContent = writeCall?.[1] as string
+      const parsedConfig = YAML.parse(yamlContent) as PolicyConfig
+      expect(parsedConfig.gates?.['gate-1']?.authorizedSigners).toContain('new-user')
+      expect(parsedConfig.gates?.['gate-2']?.authorizedSigners).not.toContain('new-user')
+    })
+
+    it('should default to zero authorized gates when --gates is omitted and no TTY is available', async () => {
+      vi.mocked(core.loadLocalConfig).mockResolvedValue({
+        activeIdentity: 'new-user',
+        identities: {
+          'new-user': {
+            name: 'New User',
+            publicKey: PUBLIC_KEY,
+            privateKey: { type: 'file', path: '/test/path' },
+          },
+        },
+      })
+      vi.mocked(core.getActiveIdentity).mockReturnValue({
+        name: 'New User',
+        publicKey: PUBLIC_KEY,
+        privateKey: { type: 'file', path: '/test/path' },
+      })
+      mockPolicy({
+        version: 1,
+        settings: {
+          maxAgeDays: 30,
+          publicKeyPath: '.attest-it/pubkey.pem',
+          attestationsPath: '.attest-it/attestations.json',
+          sealsPath: '.attest-it/seals.json',
+        },
+        team: {},
+        gates: {
+          'gate-1': makeGate({ name: 'First Gate' }),
+        },
+      })
+
+      await runJoin()
+
+      expect(prompts.checkbox).not.toHaveBeenCalled()
+      expect(mockProcessExit).not.toHaveBeenCalled()
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0]
+      expect(writeCall).toBeDefined()
+      const yamlContent = writeCall?.[1] as string
+      const parsedConfig = YAML.parse(yamlContent) as PolicyConfig
+      expect(parsedConfig.gates?.['gate-1']?.authorizedSigners).not.toContain('new-user')
     })
   })
 })

--- a/packages/cli/test/team-utils.test.ts
+++ b/packages/cli/test/team-utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { resolveGateAuthorization } from '../src/commands/team/utils.js'
+import type { PolicyConfig } from '@attest-it/core'
+
+type GateConfig = NonNullable<PolicyConfig['gates']>[string]
+
+function makeGate(overrides: Partial<GateConfig> = {}): GateConfig {
+  return {
+    name: 'Release gate',
+    description: 'Release approval gate',
+    authorizedSigners: [],
+    fingerprint: { paths: ['src/**'] },
+    maxAge: '30d',
+    ...overrides,
+  }
+}
+
+describe('resolveGateAuthorization', () => {
+  it('should resolve a --gates flag naming real gate IDs', async () => {
+    const gates = { release: makeGate() }
+
+    const result = await resolveGateAuthorization(gates, 'release')
+
+    expect(result).toEqual(['release'])
+  })
+
+  it('should throw naming unknown gate IDs from a --gates flag', async () => {
+    const gates = { release: makeGate() }
+
+    await expect(resolveGateAuthorization(gates, 'release,nonexistent')).rejects.toThrow(
+      'nonexistent',
+    )
+  })
+
+  it('should reject a gate ID that only matches an inherited Object.prototype property', async () => {
+    // Regression test: `!gates[id]` treated `gates['toString']` as a known
+    // gate because Object.prototype.toString is a truthy function value, so
+    // an id of `toString` (or `constructor`, `hasOwnProperty`, etc.) silently
+    // passed validation despite not being a real, own gate entry.
+    const gates = { release: makeGate() }
+
+    await expect(resolveGateAuthorization(gates, 'toString')).rejects.toThrow(
+      '--gates references unknown gate(s): toString',
+    )
+  })
+
+  it('should return an empty array when no gates are configured', async () => {
+    const result = await resolveGateAuthorization(undefined, 'release')
+
+    expect(result).toEqual([])
+  })
+})

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -84,6 +84,7 @@ export function createSeal(options: CreateSealOptions): Seal;
 export interface CreateSealOptions {
     fingerprint: string;
     gateId: string;
+    passphrase?: string;
     privateKey: string;
     sealedBy: string;
 }
@@ -106,6 +107,11 @@ export interface CryptoVerifyOptions {
     data: Buffer | string;
     publicKeyPath: string;
     signature: string;
+}
+
+// @public
+export interface Ed25519GenerateKeyPairOptions {
+    passphrase?: string;
 }
 
 // @public
@@ -179,7 +185,7 @@ export interface GateDescriptor {
 }
 
 // @public
-export function generateEd25519KeyPair(): Ed25519KeyPair;
+export function generateEd25519KeyPair(options?: Ed25519GenerateKeyPairOptions): Ed25519KeyPair;
 
 // @public
 export function generateKeyPair(options?: KeygenOptions): Promise<KeyPaths>;
@@ -244,6 +250,9 @@ export interface InaccessibleAccount {
 
 // @public
 export function isAuthorizedSigner(config: AttestItConfig, gateId: string, publicKey: string): boolean;
+
+// @public
+export function isEncryptedPrivateKeyPem(privateKeyPem: string): boolean;
 
 // @public
 export function isMacOSKeychainAvailable(): boolean;
@@ -859,7 +868,7 @@ export interface SignatureVerificationResult {
 }
 
 // @public
-export function signEd25519(data: Buffer | string, privateKeyPem: string): string;
+export function signEd25519(data: Buffer | string, privateKeyPem: string, passphrase?: string): string;
 
 // @public
 export interface SignOptions {

--- a/packages/core/src/crypto/ed25519.ts
+++ b/packages/core/src/crypto/ed25519.ts
@@ -33,26 +33,55 @@ function isBuffer(value: unknown): value is Buffer {
 }
 
 /**
+ * Options for generating an Ed25519 keypair.
+ * @public
+ */
+export interface GenerateKeyPairOptions {
+  /**
+   * Passphrase to encrypt the private key with (AES-256-CBC over the PKCS8
+   * export). Omit, or pass an empty string, for an unencrypted private key.
+   */
+  passphrase?: string
+}
+
+/**
  * Generate a new Ed25519 keypair.
  *
+ * @param options - Key generation options
  * @returns A keypair with base64-encoded public key and PEM-encoded private key
  * @throws Error if key generation fails
  * @public
  */
-export function generateKeyPair(): KeyPair {
+export function generateKeyPair(options: GenerateKeyPairOptions = {}): KeyPair {
   try {
+    const { passphrase } = options
+
     // Generate Ed25519 keypair using Node.js native crypto
     // When format is 'pem', the keys are returned as strings
-    const keyPair = crypto.generateKeyPairSync('ed25519', {
-      publicKeyEncoding: {
-        type: 'spki',
-        format: 'pem',
-      },
-      privateKeyEncoding: {
-        type: 'pkcs8',
-        format: 'pem',
-      },
-    })
+    const keyPair =
+      passphrase !== undefined && passphrase.length > 0
+        ? crypto.generateKeyPairSync('ed25519', {
+            publicKeyEncoding: {
+              type: 'spki',
+              format: 'pem',
+            },
+            privateKeyEncoding: {
+              type: 'pkcs8',
+              format: 'pem',
+              cipher: 'aes-256-cbc',
+              passphrase,
+            },
+          })
+        : crypto.generateKeyPairSync('ed25519', {
+            publicKeyEncoding: {
+              type: 'spki',
+              format: 'pem',
+            },
+            privateKeyEncoding: {
+              type: 'pkcs8',
+              format: 'pem',
+            },
+          })
 
     const { publicKey, privateKey } = keyPair
     if (typeof publicKey !== 'string' || typeof privateKey !== 'string') {
@@ -91,17 +120,21 @@ export function generateKeyPair(): KeyPair {
  *
  * @param data - Data to sign (Buffer or UTF-8 string)
  * @param privateKeyPem - PEM-encoded private key
+ * @param passphrase - Passphrase to decrypt the private key, if it is encrypted
  * @returns Base64-encoded signature
  * @throws Error if signing fails
  * @public
  */
-export function sign(data: Buffer | string, privateKeyPem: string): string {
+export function sign(data: Buffer | string, privateKeyPem: string, passphrase?: string): string {
   try {
     // Convert string data to Buffer
     const dataBuffer = typeof data === 'string' ? Buffer.from(data, 'utf8') : data
 
-    // Create private key object
-    const privateKeyObj = crypto.createPrivateKey(privateKeyPem)
+    // Create private key object (supplying a passphrase only when the key is encrypted)
+    const privateKeyObj =
+      passphrase !== undefined && passphrase.length > 0
+        ? crypto.createPrivateKey({ key: privateKeyPem, format: 'pem', passphrase })
+        : crypto.createPrivateKey(privateKeyPem)
 
     // Sign the data (null algorithm parameter for Ed25519)
     const signatureResult = crypto.sign(null, dataBuffer, privateKeyObj)
@@ -217,4 +250,21 @@ export function getPublicKeyFromPrivate(privateKeyPem: string): string {
       `Failed to extract public key from Ed25519 private key: ${err instanceof Error ? err.message : String(err)}`,
     )
   }
+}
+
+/**
+ * Check whether a PEM-encoded private key is passphrase-encrypted.
+ *
+ * @remarks
+ * Detects the PKCS8 `ENCRYPTED PRIVATE KEY` PEM header produced when
+ * {@link generateKeyPair} is called with a passphrase. Callers use this to
+ * decide whether a passphrase must be supplied before the key can be used
+ * (e.g. with {@link sign}).
+ *
+ * @param privateKeyPem - PEM-encoded private key content
+ * @returns true if the key is encrypted, false otherwise
+ * @public
+ */
+export function isEncryptedPrivateKeyPem(privateKeyPem: string): boolean {
+  return privateKeyPem.includes('ENCRYPTED PRIVATE KEY')
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,8 +97,12 @@ export {
   sign as signEd25519,
   verify as verifyEd25519,
   getPublicKeyFromPrivate,
+  isEncryptedPrivateKeyPem,
 } from './crypto/ed25519.js'
-export type { KeyPair as Ed25519KeyPair } from './crypto/ed25519.js'
+export type {
+  KeyPair as Ed25519KeyPair,
+  GenerateKeyPairOptions as Ed25519GenerateKeyPairOptions,
+} from './crypto/ed25519.js'
 
 // Key Providers
 export {

--- a/packages/core/src/seal/operations.ts
+++ b/packages/core/src/seal/operations.ts
@@ -52,6 +52,8 @@ export interface CreateSealOptions {
   sealedBy: string
   /** PEM-encoded Ed25519 private key for signing */
   privateKey: string
+  /** Passphrase to decrypt `privateKey`, if it is passphrase-encrypted */
+  passphrase?: string
 }
 
 /**
@@ -74,7 +76,7 @@ export interface SignatureVerificationResult {
  * @public
  */
 export function createSeal(options: CreateSealOptions): Seal {
-  const { gateId, fingerprint, sealedBy, privateKey } = options
+  const { gateId, fingerprint, sealedBy, privateKey, passphrase } = options
 
   // Create ISO 8601 timestamp
   const timestamp = new Date().toISOString()
@@ -83,7 +85,7 @@ export function createSeal(options: CreateSealOptions): Seal {
   const canonicalString = `${gateId}:${fingerprint}:${timestamp}`
 
   // Sign the canonical string
-  const signature = ed25519.sign(canonicalString, privateKey)
+  const signature = ed25519.sign(canonicalString, privateKey, passphrase)
 
   return {
     gateId,

--- a/packages/core/test/ed25519.test.ts
+++ b/packages/core/test/ed25519.test.ts
@@ -247,4 +247,62 @@ describe('Ed25519 Cryptography', () => {
       expect(ed25519.verify(dataString, sig2, keyPair.publicKey)).toBe(true)
     })
   })
+
+  // Passphrase-encrypted keys back CLI's `identity create --passphrase-stdin`
+  // (issue #80): a file-backed identity key can be encrypted so the
+  // passphrase (piped via stdin, never prompted) is required to sign with it.
+  describe('passphrase-encrypted keys', () => {
+    it('should produce a PKCS8 "ENCRYPTED PRIVATE KEY" PEM when a passphrase is supplied', () => {
+      const keyPair = ed25519.generateKeyPair({ passphrase: 'correct horse battery staple' })
+
+      expect(keyPair.privateKey).toContain('-----BEGIN ENCRYPTED PRIVATE KEY-----')
+      expect(keyPair.privateKey).toContain('-----END ENCRYPTED PRIVATE KEY-----')
+      expect(ed25519.isEncryptedPrivateKeyPem(keyPair.privateKey)).toBe(true)
+    })
+
+    it('should produce an unencrypted key when no passphrase is supplied', () => {
+      const keyPair = ed25519.generateKeyPair()
+
+      expect(keyPair.privateKey).toContain('-----BEGIN PRIVATE KEY-----')
+      expect(ed25519.isEncryptedPrivateKeyPem(keyPair.privateKey)).toBe(false)
+    })
+
+    it('should produce an unencrypted key when passphrase is an empty string', () => {
+      const keyPair = ed25519.generateKeyPair({ passphrase: '' })
+
+      expect(ed25519.isEncryptedPrivateKeyPem(keyPair.privateKey)).toBe(false)
+    })
+
+    it('should sign and verify correctly with an encrypted key given the right passphrase', () => {
+      const keyPair = ed25519.generateKeyPair({ passphrase: 'my-passphrase' })
+      const data = 'Attest this'
+
+      const signature = ed25519.sign(data, keyPair.privateKey, 'my-passphrase')
+
+      expect(ed25519.verify(data, signature, keyPair.publicKey)).toBe(true)
+    })
+
+    it('should throw when signing with an encrypted key and no passphrase', () => {
+      const keyPair = ed25519.generateKeyPair({ passphrase: 'my-passphrase' })
+
+      expect(() => ed25519.sign('data', keyPair.privateKey)).toThrow(/Failed to sign/)
+    })
+
+    it('should throw when signing with an encrypted key and the wrong passphrase', () => {
+      const keyPair = ed25519.generateKeyPair({ passphrase: 'my-passphrase' })
+
+      expect(() => ed25519.sign('data', keyPair.privateKey, 'wrong-passphrase')).toThrow(
+        /Failed to sign/,
+      )
+    })
+
+    it('should still sign correctly when an unnecessary passphrase is passed for an unencrypted key', () => {
+      const keyPair = ed25519.generateKeyPair()
+      const data = 'Attest this'
+
+      const signature = ed25519.sign(data, keyPair.privateKey, 'unused-passphrase')
+
+      expect(ed25519.verify(data, signature, keyPair.publicKey)).toBe(true)
+    })
+  })
 })

--- a/packages/core/test/seal/operations.test.ts
+++ b/packages/core/test/seal/operations.test.ts
@@ -149,6 +149,55 @@ describe('createSeal', () => {
       }),
     ).toThrow()
   })
+
+  // A passphrase-encrypted private key (from CLI's `identity create
+  // --passphrase-stdin`, issue #80) must be sign-able given the right
+  // passphrase, and must fail clearly otherwise.
+  describe('with a passphrase-encrypted private key', () => {
+    it('should create a verifiable seal when the correct passphrase is supplied', () => {
+      const { publicKey, privateKey } = generateKeyPair({ passphrase: 'seal-passphrase' })
+      const config = createTestConfig()
+      config.team ??= {}
+      config.team.alice = { name: 'Alice', publicKey }
+
+      const seal = createSeal({
+        gateId: 'unit-tests',
+        fingerprint: 'sha256:abc123',
+        sealedBy: 'alice',
+        privateKey,
+        passphrase: 'seal-passphrase',
+      })
+
+      expect(verifySeal(seal, config)).toEqual({ valid: true })
+    })
+
+    it('should throw when no passphrase is supplied for an encrypted private key', () => {
+      const { privateKey } = generateKeyPair({ passphrase: 'seal-passphrase' })
+
+      expect(() =>
+        createSeal({
+          gateId: 'unit-tests',
+          fingerprint: 'sha256:abc123',
+          sealedBy: 'alice',
+          privateKey,
+        }),
+      ).toThrow()
+    })
+
+    it('should throw when the wrong passphrase is supplied for an encrypted private key', () => {
+      const { privateKey } = generateKeyPair({ passphrase: 'seal-passphrase' })
+
+      expect(() =>
+        createSeal({
+          gateId: 'unit-tests',
+          fingerprint: 'sha256:abc123',
+          sealedBy: 'alice',
+          privateKey,
+          passphrase: 'wrong-passphrase',
+        }),
+      ).toThrow()
+    })
+  })
 })
 
 describe('verifySeal', () => {

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -110,11 +110,11 @@ var require_command = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.issue = exports2.issueCommand = void 0;
-    var os2 = __importStar(require("os"));
+    var os3 = __importStar(require("os"));
     var utils_1 = require_utils();
     function issueCommand(command, properties, message) {
       const cmd = new Command(command, properties, message);
-      process.stdout.write(cmd.toString() + os2.EOL);
+      process.stdout.write(cmd.toString() + os3.EOL);
     }
     exports2.issueCommand = issueCommand;
     function issue(name, message = "") {
@@ -198,18 +198,18 @@ var require_file_command = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.prepareKeyValueMessage = exports2.issueFileCommand = void 0;
     var crypto = __importStar(require("crypto"));
-    var fs3 = __importStar(require("fs"));
-    var os2 = __importStar(require("os"));
+    var fs4 = __importStar(require("fs"));
+    var os3 = __importStar(require("os"));
     var utils_1 = require_utils();
     function issueFileCommand(command, message) {
       const filePath = process.env[`GITHUB_${command}`];
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
       }
-      if (!fs3.existsSync(filePath)) {
+      if (!fs4.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
       }
-      fs3.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os2.EOL}`, {
+      fs4.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os3.EOL}`, {
         encoding: "utf8"
       });
     }
@@ -223,7 +223,7 @@ var require_file_command = __commonJS({
       if (convertedValue.includes(delimiter)) {
         throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
       }
-      return `${key}<<${delimiter}${os2.EOL}${convertedValue}${os2.EOL}${delimiter}`;
+      return `${key}<<${delimiter}${os3.EOL}${convertedValue}${os3.EOL}${delimiter}`;
     }
     exports2.prepareKeyValueMessage = prepareKeyValueMessage;
   }
@@ -353,44 +353,44 @@ var require_tunnel = __commonJS({
       return agent;
     }
     function TunnelingAgent(options) {
-      var self = this;
-      self.options = options || {};
-      self.proxyOptions = self.options.proxy || {};
-      self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
-      self.requests = [];
-      self.sockets = [];
-      self.on("free", function onFree(socket, host, port, localAddress) {
+      var self2 = this;
+      self2.options = options || {};
+      self2.proxyOptions = self2.options.proxy || {};
+      self2.maxSockets = self2.options.maxSockets || http.Agent.defaultMaxSockets;
+      self2.requests = [];
+      self2.sockets = [];
+      self2.on("free", function onFree(socket, host, port, localAddress) {
         var options2 = toOptions(host, port, localAddress);
-        for (var i = 0, len = self.requests.length; i < len; ++i) {
-          var pending = self.requests[i];
+        for (var i = 0, len = self2.requests.length; i < len; ++i) {
+          var pending = self2.requests[i];
           if (pending.host === options2.host && pending.port === options2.port) {
-            self.requests.splice(i, 1);
+            self2.requests.splice(i, 1);
             pending.request.onSocket(socket);
             return;
           }
         }
         socket.destroy();
-        self.removeSocket(socket);
+        self2.removeSocket(socket);
       });
     }
     util2.inherits(TunnelingAgent, events.EventEmitter);
     TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
-      var self = this;
-      var options = mergeOptions({ request: req }, self.options, toOptions(host, port, localAddress));
-      if (self.sockets.length >= this.maxSockets) {
-        self.requests.push(options);
+      var self2 = this;
+      var options = mergeOptions({ request: req }, self2.options, toOptions(host, port, localAddress));
+      if (self2.sockets.length >= this.maxSockets) {
+        self2.requests.push(options);
         return;
       }
-      self.createSocket(options, function(socket) {
+      self2.createSocket(options, function(socket) {
         socket.on("free", onFree);
         socket.on("close", onCloseOrRemove);
         socket.on("agentRemove", onCloseOrRemove);
         req.onSocket(socket);
         function onFree() {
-          self.emit("free", socket, options);
+          self2.emit("free", socket, options);
         }
         function onCloseOrRemove(err) {
-          self.removeSocket(socket);
+          self2.removeSocket(socket);
           socket.removeListener("free", onFree);
           socket.removeListener("close", onCloseOrRemove);
           socket.removeListener("agentRemove", onCloseOrRemove);
@@ -398,10 +398,10 @@ var require_tunnel = __commonJS({
       });
     };
     TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
-      var self = this;
+      var self2 = this;
       var placeholder = {};
-      self.sockets.push(placeholder);
-      var connectOptions = mergeOptions({}, self.proxyOptions, {
+      self2.sockets.push(placeholder);
+      var connectOptions = mergeOptions({}, self2.proxyOptions, {
         method: "CONNECT",
         path: options.host + ":" + options.port,
         agent: false,
@@ -417,7 +417,7 @@ var require_tunnel = __commonJS({
         connectOptions.headers["Proxy-Authorization"] = "Basic " + new Buffer(connectOptions.proxyAuth).toString("base64");
       }
       debug("making CONNECT request");
-      var connectReq = self.request(connectOptions);
+      var connectReq = self2.request(connectOptions);
       connectReq.useChunkedEncodingByDefault = false;
       connectReq.once("response", onResponse);
       connectReq.once("upgrade", onUpgrade);
@@ -444,7 +444,7 @@ var require_tunnel = __commonJS({
           var error2 = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
           error2.code = "ECONNRESET";
           options.request.emit("error", error2);
-          self.removeSocket(placeholder);
+          self2.removeSocket(placeholder);
           return;
         }
         if (head.length > 0) {
@@ -453,11 +453,11 @@ var require_tunnel = __commonJS({
           var error2 = new Error("got illegal response body from proxy");
           error2.code = "ECONNRESET";
           options.request.emit("error", error2);
-          self.removeSocket(placeholder);
+          self2.removeSocket(placeholder);
           return;
         }
         debug("tunneling connection has established");
-        self.sockets[self.sockets.indexOf(placeholder)] = socket;
+        self2.sockets[self2.sockets.indexOf(placeholder)] = socket;
         return cb(socket);
       }
       function onError(cause) {
@@ -470,7 +470,7 @@ var require_tunnel = __commonJS({
         var error2 = new Error("tunneling socket could not be established, cause=" + cause.message);
         error2.code = "ECONNRESET";
         options.request.emit("error", error2);
-        self.removeSocket(placeholder);
+        self2.removeSocket(placeholder);
       }
     };
     TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
@@ -487,15 +487,15 @@ var require_tunnel = __commonJS({
       }
     };
     function createSecureSocket(options, cb) {
-      var self = this;
-      TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
+      var self2 = this;
+      TunnelingAgent.prototype.createSocket.call(self2, options, function(socket) {
         var hostHeader = options.request.getHeader("host");
-        var tlsOptions = mergeOptions({}, self.options, {
+        var tlsOptions = mergeOptions({}, self2.options, {
           socket,
           servername: hostHeader ? hostHeader.replace(/:.*$/, "") : options.host
         });
         var secureSocket = tls.connect(0, tlsOptions);
-        self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+        self2.sockets[self2.sockets.indexOf(socket)] = secureSocket;
         cb(secureSocket);
       });
     }
@@ -1021,14 +1021,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`;
-        let path2 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path4 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin.endsWith("/")) {
           origin = origin.substring(0, origin.length - 1);
         }
-        if (path2 && !path2.startsWith("/")) {
-          path2 = `/${path2}`;
+        if (path4 && !path4.startsWith("/")) {
+          path4 = `/${path4}`;
         }
-        url = new URL(origin + path2);
+        url = new URL(origin + path4);
       }
       return url;
     }
@@ -1610,7 +1610,7 @@ var require_HeaderParser = __commonJS({
     function HeaderParser(cfg) {
       EventEmitter.call(this);
       cfg = cfg || {};
-      const self = this;
+      const self2 = this;
       this.nread = 0;
       this.maxed = false;
       this.npairs = 0;
@@ -1621,18 +1621,18 @@ var require_HeaderParser = __commonJS({
       this.finished = false;
       this.ss = new StreamSearch(B_DCRLF);
       this.ss.on("info", function(isMatch, data, start, end) {
-        if (data && !self.maxed) {
-          if (self.nread + end - start >= self.maxHeaderSize) {
-            end = self.maxHeaderSize - self.nread + start;
-            self.nread = self.maxHeaderSize;
-            self.maxed = true;
+        if (data && !self2.maxed) {
+          if (self2.nread + end - start >= self2.maxHeaderSize) {
+            end = self2.maxHeaderSize - self2.nread + start;
+            self2.nread = self2.maxHeaderSize;
+            self2.maxed = true;
           } else {
-            self.nread += end - start;
+            self2.nread += end - start;
           }
-          self.buffer += data.toString("binary", start, end);
+          self2.buffer += data.toString("binary", start, end);
         }
         if (isMatch) {
-          self._finish();
+          self2._finish();
         }
       });
     }
@@ -1738,34 +1738,34 @@ var require_Dicer = __commonJS({
       this._ignoreData = false;
       this._partOpts = { highWaterMark: cfg.partHwm };
       this._pause = false;
-      const self = this;
+      const self2 = this;
       this._hparser = new HeaderParser(cfg);
       this._hparser.on("header", function(header) {
-        self._inHeader = false;
-        self._part.emit("header", header);
+        self2._inHeader = false;
+        self2._part.emit("header", header);
       });
     }
     inherits(Dicer, WritableStream);
     Dicer.prototype.emit = function(ev) {
       if (ev === "finish" && !this._realFinish) {
         if (!this._finished) {
-          const self = this;
+          const self2 = this;
           process.nextTick(function() {
-            self.emit("error", new Error("Unexpected end of multipart data"));
-            if (self._part && !self._ignoreData) {
-              const type = self._isPreamble ? "Preamble" : "Part";
-              self._part.emit("error", new Error(type + " terminated early due to unexpected end of multipart data"));
-              self._part.push(null);
+            self2.emit("error", new Error("Unexpected end of multipart data"));
+            if (self2._part && !self2._ignoreData) {
+              const type = self2._isPreamble ? "Preamble" : "Part";
+              self2._part.emit("error", new Error(type + " terminated early due to unexpected end of multipart data"));
+              self2._part.push(null);
               process.nextTick(function() {
-                self._realFinish = true;
-                self.emit("finish");
-                self._realFinish = false;
+                self2._realFinish = true;
+                self2.emit("finish");
+                self2._realFinish = false;
               });
               return;
             }
-            self._realFinish = true;
-            self.emit("finish");
-            self._realFinish = false;
+            self2._realFinish = true;
+            self2.emit("finish");
+            self2._realFinish = false;
           });
         }
       } else {
@@ -1809,10 +1809,10 @@ var require_Dicer = __commonJS({
       this._hparser = void 0;
     };
     Dicer.prototype.setBoundary = function(boundary) {
-      const self = this;
+      const self2 = this;
       this._bparser = new StreamSearch("\r\n--" + boundary);
       this._bparser.on("info", function(isMatch, data, start, end) {
-        self._oninfo(isMatch, data, start, end);
+        self2._oninfo(isMatch, data, start, end);
       });
     };
     Dicer.prototype._ignore = function() {
@@ -1824,7 +1824,7 @@ var require_Dicer = __commonJS({
     };
     Dicer.prototype._oninfo = function(isMatch, data, start, end) {
       let buf;
-      const self = this;
+      const self2 = this;
       let i = 0;
       let r;
       let shouldWriteMore = true;
@@ -1847,10 +1847,10 @@ var require_Dicer = __commonJS({
           }
           this.reset();
           this._finished = true;
-          if (self._parts === 0) {
-            self._realFinish = true;
-            self.emit("finish");
-            self._realFinish = false;
+          if (self2._parts === 0) {
+            self2._realFinish = true;
+            self2.emit("finish");
+            self2._realFinish = false;
           }
         }
         if (this._dashes) {
@@ -1863,7 +1863,7 @@ var require_Dicer = __commonJS({
       if (!this._part) {
         this._part = new PartStream(this._partOpts);
         this._part._read = function(n) {
-          self._unpause();
+          self2._unpause();
         };
         if (this._isPreamble && this.listenerCount("preamble") !== 0) {
           this.emit("preamble", this._part);
@@ -1903,13 +1903,13 @@ var require_Dicer = __commonJS({
           if (start !== end) {
             ++this._parts;
             this._part.on("end", function() {
-              if (--self._parts === 0) {
-                if (self._finished) {
-                  self._realFinish = true;
-                  self.emit("finish");
-                  self._realFinish = false;
+              if (--self2._parts === 0) {
+                if (self2._finished) {
+                  self2._realFinish = true;
+                  self2.emit("finish");
+                  self2._realFinish = false;
                 } else {
-                  self._unpause();
+                  self2._unpause();
                 }
               }
             });
@@ -2651,20 +2651,20 @@ var require_basename = __commonJS({
   "../../node_modules/.pnpm/@fastify+busboy@2.1.1/node_modules/@fastify/busboy/lib/utils/basename.js"(exports2, module2) {
     "use strict";
     init_cjs_shims();
-    module2.exports = function basename2(path2) {
-      if (typeof path2 !== "string") {
+    module2.exports = function basename2(path4) {
+      if (typeof path4 !== "string") {
         return "";
       }
-      for (var i = path2.length - 1; i >= 0; --i) {
-        switch (path2.charCodeAt(i)) {
+      for (var i = path4.length - 1; i >= 0; --i) {
+        switch (path4.charCodeAt(i)) {
           case 47:
           // '/'
           case 92:
-            path2 = path2.slice(i + 1);
-            return path2 === ".." || path2 === "." ? "" : path2;
+            path4 = path4.slice(i + 1);
+            return path4 === ".." || path4 === "." ? "" : path4;
         }
       }
-      return path2 === ".." || path2 === "." ? "" : path2;
+      return path4 === ".." || path4 === "." ? "" : path4;
     };
   }
 });
@@ -2690,7 +2690,7 @@ var require_multipart = __commonJS({
     function Multipart(boy, cfg) {
       let i;
       let len;
-      const self = this;
+      const self2 = this;
       let boundary;
       const limits = cfg.limits;
       const isPartAFile = cfg.isPartAFile || ((fieldName, contentType, fileName) => contentType === "application/octet-stream" || fileName !== void 0);
@@ -2707,7 +2707,7 @@ var require_multipart = __commonJS({
       function checkFinished() {
         if (nends === 0 && finished && !boy._done) {
           finished = false;
-          self.end();
+          self2.end();
         }
       }
       if (typeof boundary !== "string") {
@@ -2740,16 +2740,16 @@ var require_multipart = __commonJS({
       };
       this.parser = new Dicer(parserCfg);
       this.parser.on("drain", function() {
-        self._needDrain = false;
-        if (self._cb && !self._pause) {
-          const cb = self._cb;
-          self._cb = void 0;
+        self2._needDrain = false;
+        if (self2._cb && !self2._pause) {
+          const cb = self2._cb;
+          self2._cb = void 0;
           cb();
         }
       }).on("part", function onPart(part) {
-        if (++self._nparts > partsLimit) {
-          self.parser.removeListener("part", onPart);
-          self.parser.on("part", skipPart);
+        if (++self2._nparts > partsLimit) {
+          self2.parser.removeListener("part", onPart);
+          self2.parser.on("part", skipPart);
           boy.hitPartsLimit = true;
           boy.emit("partsLimit");
           return skipPart(part);
@@ -2819,7 +2819,7 @@ var require_multipart = __commonJS({
             }
             ++nfiles;
             if (boy.listenerCount("file") === 0) {
-              self.parser._ignore();
+              self2.parser._ignore();
               return;
             }
             ++nends;
@@ -2827,22 +2827,22 @@ var require_multipart = __commonJS({
             curFile = file;
             file.on("end", function() {
               --nends;
-              self._pause = false;
+              self2._pause = false;
               checkFinished();
-              if (self._cb && !self._needDrain) {
-                const cb = self._cb;
-                self._cb = void 0;
+              if (self2._cb && !self2._needDrain) {
+                const cb = self2._cb;
+                self2._cb = void 0;
                 cb();
               }
             });
             file._read = function(n) {
-              if (!self._pause) {
+              if (!self2._pause) {
                 return;
               }
-              self._pause = false;
-              if (self._cb && !self._needDrain) {
-                const cb = self._cb;
-                self._cb = void 0;
+              self2._pause = false;
+              if (self2._cb && !self2._needDrain) {
+                const cb = self2._cb;
+                self2._cb = void 0;
                 cb();
               }
             };
@@ -2859,7 +2859,7 @@ var require_multipart = __commonJS({
                 file.emit("limit");
                 return;
               } else if (!file.push(data)) {
-                self._pause = true;
+                self2._pause = true;
               }
               file.bytesRead = nsize;
             };
@@ -2925,13 +2925,13 @@ var require_multipart = __commonJS({
       }
     };
     Multipart.prototype.end = function() {
-      const self = this;
-      if (self.parser.writable) {
-        self.parser.end();
-      } else if (!self._boy._done) {
+      const self2 = this;
+      if (self2.parser.writable) {
+        self2.parser.end();
+      } else if (!self2._boy._done) {
         process.nextTick(function() {
-          self._boy._done = true;
-          self._boy.emit("finish");
+          self2._boy._done = true;
+          self2._boy.emit("finish");
         });
       }
     };
@@ -4064,8 +4064,8 @@ var require_util2 = __commonJS({
     function createDeferredPromise() {
       let res;
       let rej;
-      const promise2 = new Promise((resolve4, reject) => {
-        res = resolve4;
+      const promise2 = new Promise((resolve6, reject) => {
+        res = resolve6;
         rej = reject;
       });
       return { promise: promise2, resolve: res, reject: rej };
@@ -5576,8 +5576,8 @@ Content-Type: ${value.type || "application/octet-stream"}\r
                 });
               }
             });
-            const busboyResolve = new Promise((resolve4, reject) => {
-              busboy.on("finish", resolve4);
+            const busboyResolve = new Promise((resolve6, reject) => {
+              busboy.on("finish", resolve6);
               busboy.on("error", (err) => reject(new TypeError(err)));
             });
             if (this.body !== null) for await (const chunk of consumeBody(this[kState].body)) busboy.write(chunk);
@@ -5707,9 +5707,9 @@ var require_request = __commonJS({
       channels.trailers = { hasSubscribers: false };
       channels.error = { hasSubscribers: false };
     }
-    var Request = class _Request {
+    var Request2 = class _Request {
       constructor(origin, {
-        path: path2,
+        path: path4,
         method,
         body,
         headers,
@@ -5723,11 +5723,11 @@ var require_request = __commonJS({
         throwOnError,
         expectContinue
       }, handler2) {
-        if (typeof path2 !== "string") {
+        if (typeof path4 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path2[0] !== "/" && !(path2.startsWith("http://") || path2.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path4[0] !== "/" && !(path4.startsWith("http://") || path4.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.exec(path2) !== null) {
+        } else if (invalidPathRegex.exec(path4) !== null) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -5790,7 +5790,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? util2.buildURL(path2, query) : path2;
+        this.path = query ? util2.buildURL(path4, query) : path4;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6042,7 +6042,7 @@ var require_request = __commonJS({
         }
       }
     }
-    module2.exports = Request;
+    module2.exports = Request2;
   }
 });
 
@@ -6114,9 +6114,9 @@ var require_dispatcher_base = __commonJS({
       }
       close(callback2) {
         if (callback2 === void 0) {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             this.close((err, data) => {
-              return err ? reject(err) : resolve4(data);
+              return err ? reject(err) : resolve6(data);
             });
           });
         }
@@ -6154,12 +6154,12 @@ var require_dispatcher_base = __commonJS({
           err = null;
         }
         if (callback2 === void 0) {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             this.destroy(err, (err2, data) => {
               return err2 ? (
                 /* istanbul ignore next: should never error */
                 reject(err2)
-              ) : resolve4(data);
+              ) : resolve6(data);
             });
           });
         }
@@ -6804,9 +6804,9 @@ var require_RedirectHandler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util2.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path2 = search ? `${pathname}${search}` : pathname;
+        const path4 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path2;
+        this.opts.path = path4;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -6934,7 +6934,7 @@ var require_client = __commonJS({
     var { pipeline } = require("stream");
     var util2 = require_util();
     var timers = require_timers();
-    var Request = require_request();
+    var Request2 = require_request();
     var DispatcherBase = require_dispatcher_base();
     var {
       RequestContentLengthMismatchError,
@@ -7214,7 +7214,7 @@ var require_client = __commonJS({
       }
       [kDispatch](opts, handler2) {
         const origin = opts.origin || this[kUrl].origin;
-        const request2 = this[kHTTPConnVersion] === "h2" ? Request[kHTTP2BuildRequest](origin, opts, handler2) : Request[kHTTP1BuildRequest](origin, opts, handler2);
+        const request2 = this[kHTTPConnVersion] === "h2" ? Request2[kHTTP2BuildRequest](origin, opts, handler2) : Request2[kHTTP1BuildRequest](origin, opts, handler2);
         this[kQueue].push(request2);
         if (this[kResuming]) {
         } else if (util2.bodyLength(request2.body) == null && util2.isIterable(request2.body)) {
@@ -7229,16 +7229,16 @@ var require_client = __commonJS({
         return this[kNeedDrain] < 2;
       }
       async [kClose]() {
-        return new Promise((resolve4) => {
+        return new Promise((resolve6) => {
           if (!this[kSize]) {
-            resolve4(null);
+            resolve6(null);
           } else {
-            this[kClosedResolve] = resolve4;
+            this[kClosedResolve] = resolve6;
           }
         });
       }
       async [kDestroy](err) {
-        return new Promise((resolve4) => {
+        return new Promise((resolve6) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
           for (let i = 0; i < requests.length; i++) {
             const request2 = requests[i];
@@ -7249,7 +7249,7 @@ var require_client = __commonJS({
               this[kClosedResolve]();
               this[kClosedResolve] = null;
             }
-            resolve4();
+            resolve6();
           };
           if (this[kHTTP2Session] != null) {
             util2.destroy(this[kHTTP2Session], err);
@@ -7829,7 +7829,7 @@ var require_client = __commonJS({
         });
       }
       try {
-        const socket = await new Promise((resolve4, reject) => {
+        const socket = await new Promise((resolve6, reject) => {
           client[kConnector]({
             host,
             hostname,
@@ -7841,7 +7841,7 @@ var require_client = __commonJS({
             if (err) {
               reject(err);
             } else {
-              resolve4(socket2);
+              resolve6(socket2);
             }
           });
         });
@@ -8052,7 +8052,7 @@ var require_client = __commonJS({
         writeH2(client, client[kHTTP2Session], request2);
         return;
       }
-      const { body, method, path: path2, host, upgrade, headers, blocking, reset } = request2;
+      const { body, method, path: path4, host, upgrade, headers, blocking, reset } = request2;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
         body.read(0);
@@ -8102,7 +8102,7 @@ var require_client = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path2} HTTP/1.1\r
+      let header = `${method} ${path4} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -8165,9 +8165,9 @@ upgrade: ${upgrade}\r
       return true;
     }
     function writeH2(client, session, request2) {
-      const { body, method, path: path2, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
+      const { body, method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
       let headers;
-      if (typeof reqHeaders === "string") headers = Request[kHTTP2CopyHeaders](reqHeaders.trim());
+      if (typeof reqHeaders === "string") headers = Request2[kHTTP2CopyHeaders](reqHeaders.trim());
       else headers = reqHeaders;
       if (upgrade) {
         errorRequest(client, request2, new Error("Upgrade not supported for H2"));
@@ -8208,7 +8208,7 @@ upgrade: ${upgrade}\r
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path2;
+      headers[HTTP2_HEADER_PATH] = path4;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -8465,12 +8465,12 @@ upgrade: ${upgrade}\r
           cb();
         }
       }
-      const waitForDrain = () => new Promise((resolve4, reject) => {
+      const waitForDrain = () => new Promise((resolve6, reject) => {
         assert(callback2 === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback2 = resolve4;
+          callback2 = resolve6;
         }
       });
       if (client[kHTTPConnVersion] === "h2") {
@@ -8819,8 +8819,8 @@ var require_pool_base = __commonJS({
         if (this[kQueue].isEmpty()) {
           return Promise.all(this[kClients].map((c) => c.close()));
         } else {
-          return new Promise((resolve4) => {
-            this[kClosedResolve] = resolve4;
+          return new Promise((resolve6) => {
+            this[kClosedResolve] = resolve6;
           });
         }
       }
@@ -9161,7 +9161,7 @@ var require_agent = __commonJS({
     var Client = require_client();
     var util2 = require_util();
     var createRedirectInterceptor = require_redirectInterceptor();
-    var { WeakRef: WeakRef2, FinalizationRegistry } = require_dispatcher_weakref()();
+    var { WeakRef: WeakRef2, FinalizationRegistry: FinalizationRegistry2 } = require_dispatcher_weakref()();
     var kOnConnect = /* @__PURE__ */ Symbol("onConnect");
     var kOnDisconnect = /* @__PURE__ */ Symbol("onDisconnect");
     var kOnConnectionError = /* @__PURE__ */ Symbol("onConnectionError");
@@ -9194,7 +9194,7 @@ var require_agent = __commonJS({
         this[kMaxRedirections] = maxRedirections;
         this[kFactory] = factory;
         this[kClients] = /* @__PURE__ */ new Map();
-        this[kFinalizer] = new FinalizationRegistry(
+        this[kFinalizer] = new FinalizationRegistry2(
           /* istanbul ignore next: gc is undeterministic */
           (key) => {
             const ref = this[kClients].get(key);
@@ -9403,7 +9403,7 @@ var require_readable = __commonJS({
         if (this.closed) {
           return Promise.resolve(null);
         }
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           const signalListenerCleanup = signal ? util2.addAbortListener(signal, () => {
             this.destroy();
           }) : noop2;
@@ -9412,7 +9412,7 @@ var require_readable = __commonJS({
             if (signal && signal.aborted) {
               reject(signal.reason || Object.assign(new Error("The operation was aborted"), { name: "AbortError" }));
             } else {
-              resolve4(null);
+              resolve6(null);
             }
           }).on("error", noop2).on("data", function(chunk) {
             limit -= chunk.length;
@@ -9423,22 +9423,22 @@ var require_readable = __commonJS({
         });
       }
     };
-    function isLocked(self) {
-      return self[kBody] && self[kBody].locked === true || self[kConsume];
+    function isLocked(self2) {
+      return self2[kBody] && self2[kBody].locked === true || self2[kConsume];
     }
-    function isUnusable(self) {
-      return util2.isDisturbed(self) || isLocked(self);
+    function isUnusable(self2) {
+      return util2.isDisturbed(self2) || isLocked(self2);
     }
     async function consume(stream, type) {
       if (isUnusable(stream)) {
         throw new TypeError("unusable");
       }
       assert(!stream[kConsume]);
-      return new Promise((resolve4, reject) => {
+      return new Promise((resolve6, reject) => {
         stream[kConsume] = {
           type,
           stream,
-          resolve: resolve4,
+          resolve: resolve6,
           reject,
           length: 0,
           body: []
@@ -9473,12 +9473,12 @@ var require_readable = __commonJS({
       }
     }
     function consumeEnd(consume2) {
-      const { type, body, resolve: resolve4, stream, length } = consume2;
+      const { type, body, resolve: resolve6, stream, length } = consume2;
       try {
         if (type === "text") {
-          resolve4(toUSVString(Buffer.concat(body)));
+          resolve6(toUSVString(Buffer.concat(body)));
         } else if (type === "json") {
-          resolve4(JSON.parse(Buffer.concat(body)));
+          resolve6(JSON.parse(Buffer.concat(body)));
         } else if (type === "arrayBuffer") {
           const dst = new Uint8Array(length);
           let pos = 0;
@@ -9486,12 +9486,12 @@ var require_readable = __commonJS({
             dst.set(buf, pos);
             pos += buf.byteLength;
           }
-          resolve4(dst.buffer);
+          resolve6(dst.buffer);
         } else if (type === "blob") {
           if (!Blob2) {
             Blob2 = require("buffer").Blob;
           }
-          resolve4(new Blob2(body, { type: stream[kContentType] }));
+          resolve6(new Blob2(body, { type: stream[kContentType] }));
         }
         consumeFinish(consume2);
       } catch (err) {
@@ -9575,40 +9575,40 @@ var require_abort_signal = __commonJS({
     var { RequestAbortedError } = require_errors();
     var kListener = /* @__PURE__ */ Symbol("kListener");
     var kSignal = /* @__PURE__ */ Symbol("kSignal");
-    function abort(self) {
-      if (self.abort) {
-        self.abort();
+    function abort(self2) {
+      if (self2.abort) {
+        self2.abort();
       } else {
-        self.onError(new RequestAbortedError());
+        self2.onError(new RequestAbortedError());
       }
     }
-    function addSignal(self, signal) {
-      self[kSignal] = null;
-      self[kListener] = null;
+    function addSignal(self2, signal) {
+      self2[kSignal] = null;
+      self2[kListener] = null;
       if (!signal) {
         return;
       }
       if (signal.aborted) {
-        abort(self);
+        abort(self2);
         return;
       }
-      self[kSignal] = signal;
-      self[kListener] = () => {
-        abort(self);
+      self2[kSignal] = signal;
+      self2[kListener] = () => {
+        abort(self2);
       };
-      addAbortListener(self[kSignal], self[kListener]);
+      addAbortListener(self2[kSignal], self2[kListener]);
     }
-    function removeSignal(self) {
-      if (!self[kSignal]) {
+    function removeSignal(self2) {
+      if (!self2[kSignal]) {
         return;
       }
-      if ("removeEventListener" in self[kSignal]) {
-        self[kSignal].removeEventListener("abort", self[kListener]);
+      if ("removeEventListener" in self2[kSignal]) {
+        self2[kSignal].removeEventListener("abort", self2[kListener]);
       } else {
-        self[kSignal].removeListener("abort", self[kListener]);
+        self2[kSignal].removeListener("abort", self2[kListener]);
       }
-      self[kSignal] = null;
-      self[kListener] = null;
+      self2[kSignal] = null;
+      self2[kListener] = null;
     }
     module2.exports = {
       addSignal,
@@ -9751,9 +9751,9 @@ var require_api_request = __commonJS({
     };
     function request2(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           request2.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -9927,9 +9927,9 @@ var require_api_stream = __commonJS({
     };
     function stream(opts, factory, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           stream.call(this, opts, factory, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -10212,9 +10212,9 @@ var require_api_upgrade = __commonJS({
     };
     function upgrade(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           upgrade.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -10304,9 +10304,9 @@ var require_api_connect = __commonJS({
     };
     function connect(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           connect.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -10470,20 +10470,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path2) {
-      if (typeof path2 !== "string") {
-        return path2;
+    function safeUrl(path4) {
+      if (typeof path4 !== "string") {
+        return path4;
       }
-      const pathSegments = path2.split("?");
+      const pathSegments = path4.split("?");
       if (pathSegments.length !== 2) {
-        return path2;
+        return path4;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path2, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path2);
+    function matchKey(mockDispatch2, { path: path4, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path4);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10501,7 +10501,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path2 }) => matchValue(safeUrl(path2), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path4 }) => matchValue(safeUrl(path4), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10538,9 +10538,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path2, method, body, headers, query } = opts;
+      const { path: path4, method, body, headers, query } = opts;
       return {
-        path: path2,
+        path: path4,
         method,
         body,
         headers,
@@ -10994,10 +10994,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path2, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path4, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path2,
+            Path: path4,
             "Status code": statusCode,
             Persistent: persist ? "\u2705" : "\u274C",
             Invocations: timesInvoked,
@@ -11793,7 +11793,7 @@ var require_headers = __commonJS({
         return headers;
       }
     };
-    var Headers = class _Headers {
+    var Headers2 = class _Headers {
       constructor(init = void 0) {
         if (init === kConstruct) {
           return;
@@ -11988,8 +11988,8 @@ var require_headers = __commonJS({
         return this[kHeadersList];
       }
     };
-    Headers.prototype[Symbol.iterator] = Headers.prototype.entries;
-    Object.defineProperties(Headers.prototype, {
+    Headers2.prototype[Symbol.iterator] = Headers2.prototype.entries;
+    Object.defineProperties(Headers2.prototype, {
       append: kEnumerableProperty,
       delete: kEnumerableProperty,
       get: kEnumerableProperty,
@@ -12024,7 +12024,7 @@ var require_headers = __commonJS({
     };
     module2.exports = {
       fill,
-      Headers,
+      Headers: Headers2,
       HeadersList
     };
   }
@@ -12035,7 +12035,7 @@ var require_response = __commonJS({
   "../../node_modules/.pnpm/undici@5.29.0/node_modules/undici/lib/fetch/response.js"(exports2, module2) {
     "use strict";
     init_cjs_shims();
-    var { Headers, HeadersList, fill } = require_headers();
+    var { Headers: Headers2, HeadersList, fill } = require_headers();
     var { extractBody, cloneBody, mixinBody } = require_body();
     var util2 = require_util();
     var { kEnumerableProperty } = util2;
@@ -12063,7 +12063,7 @@ var require_response = __commonJS({
     var { types } = require("util");
     var ReadableStream = globalThis.ReadableStream || require("stream/web").ReadableStream;
     var textEncoder = new TextEncoder("utf-8");
-    var Response = class _Response {
+    var Response2 = class _Response {
       // Creates network error Response.
       static error() {
         const relevantRealm = { settingsObject: {} };
@@ -12127,7 +12127,7 @@ var require_response = __commonJS({
         init = webidl.converters.ResponseInit(init);
         this[kRealm] = { settingsObject: {} };
         this[kState] = makeResponse({});
-        this[kHeaders] = new Headers(kConstruct);
+        this[kHeaders] = new Headers2(kConstruct);
         this[kHeaders][kGuard] = "response";
         this[kHeaders][kHeadersList] = this[kState].headersList;
         this[kHeaders][kRealm] = this[kRealm];
@@ -12205,8 +12205,8 @@ var require_response = __commonJS({
         return clonedResponseObject;
       }
     };
-    mixinBody(Response);
-    Object.defineProperties(Response.prototype, {
+    mixinBody(Response2);
+    Object.defineProperties(Response2.prototype, {
       type: kEnumerableProperty,
       url: kEnumerableProperty,
       status: kEnumerableProperty,
@@ -12222,7 +12222,7 @@ var require_response = __commonJS({
         configurable: true
       }
     });
-    Object.defineProperties(Response, {
+    Object.defineProperties(Response2, {
       json: kEnumerableProperty,
       redirect: kEnumerableProperty,
       error: kEnumerableProperty
@@ -12404,7 +12404,7 @@ var require_response = __commonJS({
       makeResponse,
       makeAppropriateNetworkError,
       filterResponse,
-      Response,
+      Response: Response2,
       cloneResponse
     };
   }
@@ -12416,8 +12416,8 @@ var require_request2 = __commonJS({
     "use strict";
     init_cjs_shims();
     var { extractBody, mixinBody, cloneBody } = require_body();
-    var { Headers, fill: fillHeaders, HeadersList } = require_headers();
-    var { FinalizationRegistry } = require_dispatcher_weakref()();
+    var { Headers: Headers2, fill: fillHeaders, HeadersList } = require_headers();
+    var { FinalizationRegistry: FinalizationRegistry2 } = require_dispatcher_weakref()();
     var util2 = require_util();
     var {
       isValidHTTPToken,
@@ -12446,10 +12446,10 @@ var require_request2 = __commonJS({
     var { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = require("events");
     var TransformStream = globalThis.TransformStream;
     var kAbortController = /* @__PURE__ */ Symbol("abortController");
-    var requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
+    var requestFinalizer = new FinalizationRegistry2(({ signal, abort }) => {
       signal.removeEventListener("abort", abort);
     });
-    var Request = class _Request {
+    var Request2 = class _Request {
       // https://fetch.spec.whatwg.org/#dom-request
       constructor(input, init = {}) {
         if (input === kConstruct) {
@@ -12491,15 +12491,15 @@ var require_request2 = __commonJS({
           signal = input[kSignal];
         }
         const origin = this[kRealm].settingsObject.origin;
-        let window = "client";
+        let window2 = "client";
         if (request2.window?.constructor?.name === "EnvironmentSettingsObject" && sameOrigin(request2.window, origin)) {
-          window = request2.window;
+          window2 = request2.window;
         }
         if (init.window != null) {
-          throw new TypeError(`'window' option '${window}' must be null`);
+          throw new TypeError(`'window' option '${window2}' must be null`);
         }
         if ("window" in init) {
-          window = "no-window";
+          window2 = "no-window";
         }
         request2 = makeRequest({
           // URL request’s URL.
@@ -12514,7 +12514,7 @@ var require_request2 = __commonJS({
           // client This’s relevant settings object.
           client: this[kRealm].settingsObject,
           // window window.
-          window,
+          window: window2,
           // priority request’s priority.
           priority: request2.priority,
           // origin request’s origin. The propagation of the origin is only significant for navigation requests
@@ -12660,7 +12660,7 @@ var require_request2 = __commonJS({
             requestFinalizer.register(ac, { signal, abort });
           }
         }
-        this[kHeaders] = new Headers(kConstruct);
+        this[kHeaders] = new Headers2(kConstruct);
         this[kHeaders][kHeadersList] = request2.headersList;
         this[kHeaders][kGuard] = "request";
         this[kHeaders][kRealm] = this[kRealm];
@@ -12859,7 +12859,7 @@ var require_request2 = __commonJS({
         const clonedRequestObject = new _Request(kConstruct);
         clonedRequestObject[kState] = clonedRequest;
         clonedRequestObject[kRealm] = this[kRealm];
-        clonedRequestObject[kHeaders] = new Headers(kConstruct);
+        clonedRequestObject[kHeaders] = new Headers2(kConstruct);
         clonedRequestObject[kHeaders][kHeadersList] = clonedRequest.headersList;
         clonedRequestObject[kHeaders][kGuard] = this[kHeaders][kGuard];
         clonedRequestObject[kHeaders][kRealm] = this[kHeaders][kRealm];
@@ -12878,7 +12878,7 @@ var require_request2 = __commonJS({
         return clonedRequestObject;
       }
     };
-    mixinBody(Request);
+    mixinBody(Request2);
     function makeRequest(init) {
       const request2 = {
         method: "GET",
@@ -12929,7 +12929,7 @@ var require_request2 = __commonJS({
       }
       return newRequest;
     }
-    Object.defineProperties(Request.prototype, {
+    Object.defineProperties(Request2.prototype, {
       method: kEnumerableProperty,
       url: kEnumerableProperty,
       headers: kEnumerableProperty,
@@ -12956,13 +12956,13 @@ var require_request2 = __commonJS({
       }
     });
     webidl.converters.Request = webidl.interfaceConverter(
-      Request
+      Request2
     );
     webidl.converters.RequestInfo = function(V) {
       if (typeof V === "string") {
         return webidl.converters.USVString(V);
       }
-      if (V instanceof Request) {
+      if (V instanceof Request2) {
         return webidl.converters.Request(V);
       }
       return webidl.converters.USVString(V);
@@ -13046,7 +13046,7 @@ var require_request2 = __commonJS({
         allowedValues: requestDuplex
       }
     ]);
-    module2.exports = { Request, makeRequest };
+    module2.exports = { Request: Request2, makeRequest };
   }
 });
 
@@ -13056,14 +13056,14 @@ var require_fetch = __commonJS({
     "use strict";
     init_cjs_shims();
     var {
-      Response,
+      Response: Response2,
       makeNetworkError,
       makeAppropriateNetworkError,
       filterResponse,
       makeResponse
     } = require_response();
-    var { Headers } = require_headers();
-    var { Request, makeRequest } = require_request2();
+    var { Headers: Headers2 } = require_headers();
+    var { Request: Request2, makeRequest } = require_request2();
     var zlib = require("zlib");
     var {
       bytesMatch,
@@ -13149,12 +13149,12 @@ var require_fetch = __commonJS({
         this.emit("terminated", error2);
       }
     };
-    function fetch(input, init = {}) {
+    function fetch2(input, init = {}) {
       webidl.argumentLengthCheck(arguments, 1, { header: "globalThis.fetch" });
       const p = createDeferredPromise();
       let requestObject;
       try {
-        requestObject = new Request(input, init);
+        requestObject = new Request2(input, init);
       } catch (e) {
         p.reject(e);
         return p.promise;
@@ -13196,7 +13196,7 @@ var require_fetch = __commonJS({
           );
           return Promise.resolve();
         }
-        responseObject = new Response();
+        responseObject = new Response2();
         responseObject[kState] = response;
         responseObject[kRealm] = relevantRealm;
         responseObject[kHeaders][kHeadersList] = response.headersList;
@@ -13947,7 +13947,7 @@ var require_fetch = __commonJS({
       async function dispatch({ body }) {
         const url = requestCurrentURL(request2);
         const agent = fetchParams.controller.dispatcher;
-        return new Promise((resolve4, reject) => agent.dispatch(
+        return new Promise((resolve6, reject) => agent.dispatch(
           {
             path: url.pathname + url.search,
             origin: url.origin,
@@ -13975,7 +13975,7 @@ var require_fetch = __commonJS({
               }
               let codings = [];
               let location = "";
-              const headers = new Headers();
+              const headers = new Headers2();
               if (Array.isArray(headersList)) {
                 for (let n = 0; n < headersList.length; n += 2) {
                   const key = headersList[n + 0].toString("latin1");
@@ -14023,7 +14023,7 @@ var require_fetch = __commonJS({
                   }
                 }
               }
-              resolve4({
+              resolve6({
                 status,
                 statusText,
                 headersList: headers[kHeadersList],
@@ -14060,13 +14060,13 @@ var require_fetch = __commonJS({
               if (status !== 101) {
                 return;
               }
-              const headers = new Headers();
+              const headers = new Headers2();
               for (let n = 0; n < headersList.length; n += 2) {
                 const key = headersList[n + 0].toString("latin1");
                 const val = headersList[n + 1].toString("latin1");
                 headers[kHeadersList].append(key, val);
               }
-              resolve4({
+              resolve6({
                 status,
                 statusText: STATUS_CODES[status],
                 headersList: headers[kHeadersList],
@@ -14079,7 +14079,7 @@ var require_fetch = __commonJS({
       }
     }
     module2.exports = {
-      fetch,
+      fetch: fetch2,
       Fetch,
       fetching,
       finalizeAndReportTiming
@@ -14961,8 +14961,8 @@ var require_cache = __commonJS({
     var { kEnumerableProperty, isDisturbed } = require_util();
     var { kHeadersList } = require_symbols();
     var { webidl } = require_webidl();
-    var { Response, cloneResponse } = require_response();
-    var { Request } = require_request2();
+    var { Response: Response2, cloneResponse } = require_response();
+    var { Request: Request2 } = require_request2();
     var { kState, kHeaders, kGuard, kRealm } = require_symbols2();
     var { fetching } = require_fetch();
     var { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = require_util2();
@@ -14997,13 +14997,13 @@ var require_cache = __commonJS({
         options = webidl.converters.CacheQueryOptions(options);
         let r = null;
         if (request2 !== void 0) {
-          if (request2 instanceof Request) {
+          if (request2 instanceof Request2) {
             r = request2[kState];
             if (r.method !== "GET" && !options.ignoreMethod) {
               return [];
             }
           } else if (typeof request2 === "string") {
-            r = new Request(request2)[kState];
+            r = new Request2(request2)[kState];
           }
         }
         const responses = [];
@@ -15019,7 +15019,7 @@ var require_cache = __commonJS({
         }
         const responseList = [];
         for (const response of responses) {
-          const responseObject = new Response(response.body?.source ?? null);
+          const responseObject = new Response2(response.body?.source ?? null);
           const body = responseObject[kState].body;
           responseObject[kState] = response;
           responseObject[kState].body = body;
@@ -15057,7 +15057,7 @@ var require_cache = __commonJS({
         }
         const fetchControllers = [];
         for (const request2 of requests) {
-          const r = new Request(request2)[kState];
+          const r = new Request2(request2)[kState];
           if (!urlIsHttpHttpsScheme(r.url)) {
             throw webidl.errors.exception({
               header: "Cache.addAll",
@@ -15141,10 +15141,10 @@ var require_cache = __commonJS({
         request2 = webidl.converters.RequestInfo(request2);
         response = webidl.converters.Response(response);
         let innerRequest = null;
-        if (request2 instanceof Request) {
+        if (request2 instanceof Request2) {
           innerRequest = request2[kState];
         } else {
-          innerRequest = new Request(request2)[kState];
+          innerRequest = new Request2(request2)[kState];
         }
         if (!urlIsHttpHttpsScheme(innerRequest.url) || innerRequest.method !== "GET") {
           throw webidl.errors.exception({
@@ -15221,14 +15221,14 @@ var require_cache = __commonJS({
         request2 = webidl.converters.RequestInfo(request2);
         options = webidl.converters.CacheQueryOptions(options);
         let r = null;
-        if (request2 instanceof Request) {
+        if (request2 instanceof Request2) {
           r = request2[kState];
           if (r.method !== "GET" && !options.ignoreMethod) {
             return false;
           }
         } else {
           assert(typeof request2 === "string");
-          r = new Request(request2)[kState];
+          r = new Request2(request2)[kState];
         }
         const operations = [];
         const operation = {
@@ -15266,13 +15266,13 @@ var require_cache = __commonJS({
         options = webidl.converters.CacheQueryOptions(options);
         let r = null;
         if (request2 !== void 0) {
-          if (request2 instanceof Request) {
+          if (request2 instanceof Request2) {
             r = request2[kState];
             if (r.method !== "GET" && !options.ignoreMethod) {
               return [];
             }
           } else if (typeof request2 === "string") {
-            r = new Request(request2)[kState];
+            r = new Request2(request2)[kState];
           }
         }
         const promise2 = createDeferredPromise();
@@ -15290,7 +15290,7 @@ var require_cache = __commonJS({
         queueMicrotask(() => {
           const requestList = [];
           for (const request3 of requests) {
-            const requestObject = new Request("https://a");
+            const requestObject = new Request2("https://a");
             requestObject[kState] = request3;
             requestObject[kHeaders][kHeadersList] = request3.headersList;
             requestObject[kHeaders][kGuard] = "immutable";
@@ -15474,7 +15474,7 @@ var require_cache = __commonJS({
         converter: webidl.converters.DOMString
       }
     ]);
-    webidl.converters.Response = webidl.interfaceConverter(Response);
+    webidl.converters.Response = webidl.interfaceConverter(Response2);
     webidl.converters["sequence<RequestInfo>"] = webidl.sequenceConverter(
       webidl.converters.RequestInfo
     );
@@ -15638,8 +15638,8 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path2) {
-      for (const char of path2) {
+    function validateCookiePath(path4) {
+      for (const char of path4) {
         const code = char.charCodeAt(0);
         if (code < 33 || char === ";") {
           throw new Error("Invalid cookie path");
@@ -15900,10 +15900,10 @@ var require_cookies = __commonJS({
     var { parseSetCookie } = require_parse();
     var { stringify: stringify2 } = require_util6();
     var { webidl } = require_webidl();
-    var { Headers } = require_headers();
+    var { Headers: Headers2 } = require_headers();
     function getCookies(headers) {
       webidl.argumentLengthCheck(arguments, 1, { header: "getCookies" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       const cookie = headers.get("cookie");
       const out = {};
       if (!cookie) {
@@ -15917,7 +15917,7 @@ var require_cookies = __commonJS({
     }
     function deleteCookie(headers, name, attributes) {
       webidl.argumentLengthCheck(arguments, 2, { header: "deleteCookie" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       name = webidl.converters.DOMString(name);
       attributes = webidl.converters.DeleteCookieAttributes(attributes);
       setCookie(headers, {
@@ -15929,7 +15929,7 @@ var require_cookies = __commonJS({
     }
     function getSetCookies(headers) {
       webidl.argumentLengthCheck(arguments, 1, { header: "getSetCookies" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       const cookies = headers.getSetCookie();
       if (!cookies) {
         return [];
@@ -15938,7 +15938,7 @@ var require_cookies = __commonJS({
     }
     function setCookie(headers, cookie) {
       webidl.argumentLengthCheck(arguments, 2, { header: "setCookie" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       cookie = webidl.converters.Cookie(cookie);
       const str = stringify2(cookie);
       if (str) {
@@ -16436,7 +16436,7 @@ var require_connection = __commonJS({
     var { CloseEvent } = require_events();
     var { makeRequest } = require_request2();
     var { fetching } = require_fetch();
-    var { Headers } = require_headers();
+    var { Headers: Headers2 } = require_headers();
     var { getGlobalDispatcher } = require_global2();
     var { kHeadersList } = require_symbols();
     var channels = {};
@@ -16461,7 +16461,7 @@ var require_connection = __commonJS({
         redirect: "error"
       });
       if (options.headers) {
-        const headersList = new Headers(options.headers)[kHeadersList];
+        const headersList = new Headers2(options.headers)[kHeadersList];
         request2.headersList = headersList;
       }
       const keyValue = crypto.randomBytes(16).toString("base64");
@@ -16631,7 +16631,7 @@ var require_receiver = __commonJS({
   "../../node_modules/.pnpm/undici@5.29.0/node_modules/undici/lib/websocket/receiver.js"(exports2, module2) {
     "use strict";
     init_cjs_shims();
-    var { Writable: Writable2 } = require("stream");
+    var { Writable } = require("stream");
     var diagnosticsChannel = require("diagnostics_channel");
     var { parserStates, opcodes, states, emptyBuffer } = require_constants5();
     var { kReadyState, kSentClose, kResponse, kReceivedClose } = require_symbols5();
@@ -16640,7 +16640,7 @@ var require_receiver = __commonJS({
     var channels = {};
     channels.ping = diagnosticsChannel.channel("undici:websocket:ping");
     channels.pong = diagnosticsChannel.channel("undici:websocket:pong");
-    var ByteParser = class extends Writable2 {
+    var ByteParser = class extends Writable {
       #buffers = [];
       #byteOffset = 0;
       #state = parserStates.INFO;
@@ -17330,11 +17330,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path2 = opts.path;
+          let path4 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path2 = `/${path2}`;
+            path4 = `/${path4}`;
           }
-          url = new URL(util2.parseOrigin(url).origin + path2);
+          url = new URL(util2.parseOrigin(url).origin + path4);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -17357,7 +17357,7 @@ var require_undici = __commonJS({
     module2.exports.getGlobalDispatcher = getGlobalDispatcher;
     if (util2.nodeMajor > 16 || util2.nodeMajor === 16 && util2.nodeMinor >= 8) {
       let fetchImpl = null;
-      module2.exports.fetch = async function fetch(resource) {
+      module2.exports.fetch = async function fetch2(resource) {
         if (!fetchImpl) {
           fetchImpl = require_fetch().fetch;
         }
@@ -17443,11 +17443,11 @@ var require_lib = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -17463,7 +17463,7 @@ var require_lib = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -17505,11 +17505,11 @@ var require_lib = __commonJS({
       HttpCodes2[HttpCodes2["ServiceUnavailable"] = 503] = "ServiceUnavailable";
       HttpCodes2[HttpCodes2["GatewayTimeout"] = 504] = "GatewayTimeout";
     })(HttpCodes || (exports2.HttpCodes = HttpCodes = {}));
-    var Headers;
-    (function(Headers2) {
-      Headers2["Accept"] = "accept";
-      Headers2["ContentType"] = "content-type";
-    })(Headers || (exports2.Headers = Headers = {}));
+    var Headers2;
+    (function(Headers3) {
+      Headers3["Accept"] = "accept";
+      Headers3["ContentType"] = "content-type";
+    })(Headers2 || (exports2.Headers = Headers2 = {}));
     var MediaTypes;
     (function(MediaTypes2) {
       MediaTypes2["ApplicationJson"] = "application/json";
@@ -17549,26 +17549,26 @@ var require_lib = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve4(output.toString());
+              resolve6(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve4(Buffer.concat(chunks));
+              resolve6(Buffer.concat(chunks));
             });
           }));
         });
@@ -17664,7 +17664,7 @@ var require_lib = __commonJS({
        */
       getJson(requestUrl, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
           const res = yield this.get(requestUrl, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17672,8 +17672,8 @@ var require_lib = __commonJS({
       postJson(requestUrl, obj, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.ContentType, MediaTypes.ApplicationJson);
           const res = yield this.post(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17681,8 +17681,8 @@ var require_lib = __commonJS({
       putJson(requestUrl, obj, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.ContentType, MediaTypes.ApplicationJson);
           const res = yield this.put(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17690,8 +17690,8 @@ var require_lib = __commonJS({
       patchJson(requestUrl, obj, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.ContentType, MediaTypes.ApplicationJson);
           const res = yield this.patch(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17777,14 +17777,14 @@ var require_lib = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve4(res);
+                resolve6(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -17966,12 +17966,12 @@ var require_lib = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve4) => setTimeout(() => resolve4(), ms2));
+          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -17979,7 +17979,7 @@ var require_lib = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve4(response);
+              resolve6(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -18018,7 +18018,7 @@ var require_lib = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve4(response);
+              resolve6(response);
             }
           }));
         });
@@ -18036,11 +18036,11 @@ var require_auth = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18056,7 +18056,7 @@ var require_auth = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18141,11 +18141,11 @@ var require_oidc_utils = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18161,7 +18161,7 @@ var require_oidc_utils = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18240,11 +18240,11 @@ var require_summary = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18260,7 +18260,7 @@ var require_summary = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18269,7 +18269,7 @@ var require_summary = __commonJS({
     exports2.summary = exports2.markdownSummary = exports2.SUMMARY_DOCS_URL = exports2.SUMMARY_ENV_VAR = void 0;
     var os_1 = require("os");
     var fs_1 = require("fs");
-    var { access: access2, appendFile, writeFile: writeFile3 } = fs_1.promises;
+    var { access: access3, appendFile, writeFile: writeFile4 } = fs_1.promises;
     exports2.SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
     exports2.SUMMARY_DOCS_URL = "https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary";
     var Summary = class {
@@ -18292,7 +18292,7 @@ var require_summary = __commonJS({
             throw new Error(`Unable to find environment variable for $${exports2.SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`);
           }
           try {
-            yield access2(pathFromEnv, fs_1.constants.R_OK | fs_1.constants.W_OK);
+            yield access3(pathFromEnv, fs_1.constants.R_OK | fs_1.constants.W_OK);
           } catch (_a) {
             throw new Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`);
           }
@@ -18327,7 +18327,7 @@ var require_summary = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           const overwrite = !!(options === null || options === void 0 ? void 0 : options.overwrite);
           const filePath = yield this.filePath();
-          const writeFunc = overwrite ? writeFile3 : appendFile;
+          const writeFunc = overwrite ? writeFile4 : appendFile;
           yield writeFunc(filePath, this._buffer, { encoding: "utf8" });
           return this.emptyBuffer();
         });
@@ -18562,7 +18562,7 @@ var require_path_utils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.toPlatformPath = exports2.toWin32Path = exports2.toPosixPath = void 0;
-    var path2 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -18572,7 +18572,7 @@ var require_path_utils = __commonJS({
     }
     exports2.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path2.sep);
+      return pth.replace(/[/\\]/g, path4.sep);
     }
     exports2.toPlatformPath = toPlatformPath;
   }
@@ -18608,11 +18608,11 @@ var require_io_util = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18628,7 +18628,7 @@ var require_io_util = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18636,12 +18636,12 @@ var require_io_util = __commonJS({
     var _a;
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.READONLY = exports2.UV_FS_O_EXLOCK = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rm = exports2.rename = exports2.readlink = exports2.readdir = exports2.open = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
-    var fs3 = __importStar(require("fs"));
-    var path2 = __importStar(require("path"));
-    _a = fs3.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.open = _a.open, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rm = _a.rm, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    var fs4 = __importStar(require("fs"));
+    var path4 = __importStar(require("path"));
+    _a = fs4.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.open = _a.open, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rm = _a.rm, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
     exports2.IS_WINDOWS = process.platform === "win32";
     exports2.UV_FS_O_EXLOCK = 268435456;
-    exports2.READONLY = fs3.constants.O_RDONLY;
+    exports2.READONLY = fs4.constants.O_RDONLY;
     function exists(fsPath) {
       return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -18686,7 +18686,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path2.extname(filePath).toUpperCase();
+            const upperExt = path4.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -18710,11 +18710,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports2.IS_WINDOWS) {
               try {
-                const directory = path2.dirname(filePath);
-                const upperName = path2.basename(filePath).toUpperCase();
+                const directory = path4.dirname(filePath);
+                const upperName = path4.basename(filePath).toUpperCase();
                 for (const actualName of yield exports2.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path2.join(directory, actualName);
+                    filePath = path4.join(directory, actualName);
                     break;
                   }
                 }
@@ -18782,11 +18782,11 @@ var require_io = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18802,7 +18802,7 @@ var require_io = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18810,7 +18810,7 @@ var require_io = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
     var assert_1 = require("assert");
-    var path2 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     var ioUtil = __importStar(require_io_util());
     function cp(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
@@ -18819,7 +18819,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path2.join(dest, path2.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path4.join(dest, path4.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -18831,7 +18831,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path2.relative(source, newDest) === "") {
+          if (path4.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile(source, newDest, force);
@@ -18844,7 +18844,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path2.join(dest, path2.basename(source));
+            dest = path4.join(dest, path4.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -18855,7 +18855,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path2.dirname(dest));
+        yield mkdirP(path4.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -18918,7 +18918,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path2.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path4.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -18931,12 +18931,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path2.sep)) {
+        if (tool.includes(path4.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path2.delimiter)) {
+          for (const p of process.env.PATH.split(path4.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -18944,7 +18944,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path2.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path4.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -19031,11 +19031,11 @@ var require_toolrunner = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19051,17 +19051,17 @@ var require_toolrunner = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.argStringToArray = exports2.ToolRunner = void 0;
-    var os2 = __importStar(require("os"));
+    var os3 = __importStar(require("os"));
     var events = __importStar(require("events"));
     var child = __importStar(require("child_process"));
-    var path2 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     var io = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = require("timers");
@@ -19113,12 +19113,12 @@ var require_toolrunner = __commonJS({
       _processLineBuffer(data, strBuffer, onLine) {
         try {
           let s = strBuffer + data.toString();
-          let n = s.indexOf(os2.EOL);
+          let n = s.indexOf(os3.EOL);
           while (n > -1) {
             const line = s.substring(0, n);
             onLine(line);
-            s = s.substring(n + os2.EOL.length);
-            n = s.indexOf(os2.EOL);
+            s = s.substring(n + os3.EOL.length);
+            n = s.indexOf(os3.EOL);
           }
           return s;
         } catch (err) {
@@ -19276,10 +19276,10 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path2.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path4.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io.which(this.toolPath, true);
-          return new Promise((resolve4, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
             this._debug(`exec tool: ${this.toolPath}`);
             this._debug("arguments:");
             for (const arg of this.args) {
@@ -19287,7 +19287,7 @@ var require_toolrunner = __commonJS({
             }
             const optionsNonNull = this._cloneExecOptions(this.options);
             if (!optionsNonNull.silent && optionsNonNull.outStream) {
-              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os3.EOL);
             }
             const state = new ExecState(optionsNonNull, this.toolPath);
             state.on("debug", (message) => {
@@ -19362,7 +19362,7 @@ var require_toolrunner = __commonJS({
               if (error2) {
                 reject(error2);
               } else {
-                resolve4(exitCode);
+                resolve6(exitCode);
               }
             });
             if (this.options.input) {
@@ -19516,11 +19516,11 @@ var require_exec = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19536,7 +19536,7 @@ var require_exec = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19628,11 +19628,11 @@ var require_platform = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19648,7 +19648,7 @@ var require_platform = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19748,11 +19748,11 @@ var require_core = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19768,7 +19768,7 @@ var require_core = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19778,8 +19778,8 @@ var require_core = __commonJS({
     var command_1 = require_command();
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
-    var os2 = __importStar(require("os"));
-    var path2 = __importStar(require("path"));
+    var os3 = __importStar(require("os"));
+    var path4 = __importStar(require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -19807,7 +19807,7 @@ var require_core = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path2.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path4.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath;
     function getInput2(name, options) {
@@ -19846,7 +19846,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       if (filePath) {
         return (0, file_command_1.issueFileCommand)("OUTPUT", (0, file_command_1.prepareKeyValueMessage)(name, value));
       }
-      process.stdout.write(os2.EOL);
+      process.stdout.write(os3.EOL);
       (0, command_1.issueCommand)("set-output", { name }, (0, utils_1.toCommandValue)(value));
     }
     exports2.setOutput = setOutput2;
@@ -19880,7 +19880,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
     exports2.notice = notice;
     function info2(message) {
-      process.stdout.write(message + os2.EOL);
+      process.stdout.write(message + os3.EOL);
     }
     exports2.info = info2;
     function startGroup2(name) {
@@ -21998,17 +21998,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path2) {
-      const ctrl = callVisitor(key, node, visitor, path2);
+    function visit_(key, node, visitor, path4) {
+      const ctrl = callVisitor(key, node, visitor, path4);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path2, ctrl);
-        return visit_(key, ctrl, visitor, path2);
+        replaceNode(key, path4, ctrl);
+        return visit_(key, ctrl, visitor, path4);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path2 = Object.freeze(path2.concat(node));
+          path4 = Object.freeze(path4.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path2);
+            const ci = visit_(i, node.items[i], visitor, path4);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22019,13 +22019,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path2 = Object.freeze(path2.concat(node));
-          const ck = visit_("key", node.key, visitor, path2);
+          path4 = Object.freeze(path4.concat(node));
+          const ck = visit_("key", node.key, visitor, path4);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path2);
+          const cv = visit_("value", node.value, visitor, path4);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22046,17 +22046,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path2) {
-      const ctrl = await callVisitor(key, node, visitor, path2);
+    async function visitAsync_(key, node, visitor, path4) {
+      const ctrl = await callVisitor(key, node, visitor, path4);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path2, ctrl);
-        return visitAsync_(key, ctrl, visitor, path2);
+        replaceNode(key, path4, ctrl);
+        return visitAsync_(key, ctrl, visitor, path4);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path2 = Object.freeze(path2.concat(node));
+          path4 = Object.freeze(path4.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path2);
+            const ci = await visitAsync_(i, node.items[i], visitor, path4);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22067,13 +22067,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path2 = Object.freeze(path2.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path2);
+          path4 = Object.freeze(path4.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path4);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path2);
+          const cv = await visitAsync_("value", node.value, visitor, path4);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22100,23 +22100,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path2) {
+    function callVisitor(key, node, visitor, path4) {
       if (typeof visitor === "function")
-        return visitor(key, node, path2);
+        return visitor(key, node, path4);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path2);
+        return visitor.Map?.(key, node, path4);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path2);
+        return visitor.Seq?.(key, node, path4);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path2);
+        return visitor.Pair?.(key, node, path4);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path2);
+        return visitor.Scalar?.(key, node, path4);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path2);
+        return visitor.Alias?.(key, node, path4);
       return void 0;
     }
-    function replaceNode(key, path2, node) {
-      const parent = path2[path2.length - 1];
+    function replaceNode(key, path4, node) {
+      const parent = path4[path4.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -22733,10 +22733,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path2, value) {
+    function collectionFromPath(schema, path4, value) {
       let v = value;
-      for (let i = path2.length - 1; i >= 0; --i) {
-        const k = path2[i];
+      for (let i = path4.length - 1; i >= 0; --i) {
+        const k = path4[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -22755,7 +22755,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path2) => path2 == null || typeof path2 === "object" && !!path2[Symbol.iterator]().next().done;
+    var isEmptyPath = (path4) => path4 == null || typeof path4 === "object" && !!path4[Symbol.iterator]().next().done;
     var Collection2 = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -22785,11 +22785,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path2, value) {
-        if (isEmptyPath(path2))
+      addIn(path4, value) {
+        if (isEmptyPath(path4))
           this.add(value);
         else {
-          const [key, ...rest] = path2;
+          const [key, ...rest] = path4;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -22803,8 +22803,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path2) {
-        const [key, ...rest] = path2;
+      deleteIn(path4) {
+        const [key, ...rest] = path4;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -22818,8 +22818,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path2, keepScalar) {
-        const [key, ...rest] = path2;
+      getIn(path4, keepScalar) {
+        const [key, ...rest] = path4;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -22837,8 +22837,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path2) {
-        const [key, ...rest] = path2;
+      hasIn(path4) {
+        const [key, ...rest] = path4;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -22848,8 +22848,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path2, value) {
-        const [key, ...rest] = path2;
+      setIn(path4, value) {
+        const [key, ...rest] = path4;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -24804,8 +24804,8 @@ var require_int2 = __commonJS({
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
     function intResolve(str, offset, radix, { intAsBigInt }) {
-      const sign2 = str[0];
-      if (sign2 === "-" || sign2 === "+")
+      const sign3 = str[0];
+      if (sign3 === "-" || sign3 === "+")
         offset += 1;
       str = str.substring(offset).replace(/_/g, "");
       if (intAsBigInt) {
@@ -24821,10 +24821,10 @@ var require_int2 = __commonJS({
             break;
         }
         const n2 = BigInt(str);
-        return sign2 === "-" ? BigInt(-1) * n2 : n2;
+        return sign3 === "-" ? BigInt(-1) * n2 : n2;
       }
       const n = parseInt(str, radix);
-      return sign2 === "-" ? -1 * n : n;
+      return sign3 === "-" ? -1 * n : n;
     }
     function intStringify(node, radix, prefix) {
       const { value } = node;
@@ -24973,11 +24973,11 @@ var require_timestamp = __commonJS({
     init_cjs_shims();
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
-      const sign2 = str[0];
-      const parts = sign2 === "-" || sign2 === "+" ? str.substring(1) : str;
+      const sign3 = str[0];
+      const parts = sign3 === "-" || sign3 === "+" ? str.substring(1) : str;
       const num = (n) => asBigInt ? BigInt(n) : Number(n);
       const res = parts.replace(/_/g, "").split(":").reduce((res2, p) => res2 * num(60) + num(p), num(0));
-      return sign2 === "-" ? num(-1) * res : res;
+      return sign3 === "-" ? num(-1) * res : res;
     }
     function stringifySexagesimal(node) {
       let { value } = node;
@@ -24986,9 +24986,9 @@ var require_timestamp = __commonJS({
         num = (n) => BigInt(n);
       else if (isNaN(value) || !isFinite(value))
         return stringifyNumber.stringifyNumber(node);
-      let sign2 = "";
+      let sign3 = "";
       if (value < 0) {
-        sign2 = "-";
+        sign3 = "-";
         value *= num(-1);
       }
       const _60 = num(60);
@@ -25003,7 +25003,7 @@ var require_timestamp = __commonJS({
           parts.unshift(value);
         }
       }
-      return sign2 + parts.map((n) => String(n).padStart(2, "0")).join(":").replace(/000000\d*$/, "");
+      return sign3 + parts.map((n) => String(n).padStart(2, "0")).join(":").replace(/000000\d*$/, "");
     }
     var intTime = {
       identify: (value) => typeof value === "bigint" || Number.isInteger(value),
@@ -25388,9 +25388,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path2, value) {
+      addIn(path4, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path2, value);
+          this.contents.addIn(path4, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -25465,14 +25465,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path2) {
-        if (Collection2.isEmptyPath(path2)) {
+      deleteIn(path4) {
+        if (Collection2.isEmptyPath(path4)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path2) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path4) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -25487,10 +25487,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path2, keepScalar) {
-        if (Collection2.isEmptyPath(path2))
+      getIn(path4, keepScalar) {
+        if (Collection2.isEmptyPath(path4))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path2, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path4, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -25501,10 +25501,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path2) {
-        if (Collection2.isEmptyPath(path2))
+      hasIn(path4) {
+        if (Collection2.isEmptyPath(path4))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path2) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path4) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -25521,13 +25521,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path2, value) {
-        if (Collection2.isEmptyPath(path2)) {
+      setIn(path4, value) {
+        if (Collection2.isEmptyPath(path4)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path2), value);
+          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path4), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path2, value);
+          this.contents.setIn(path4, value);
         }
       }
       /**
@@ -27499,9 +27499,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path2) => {
+    visit.itemAtPath = (cst, path4) => {
       let item = cst;
-      for (const [field, index] of path2) {
+      for (const [field, index] of path4) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -27510,23 +27510,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path2) => {
-      const parent = visit.itemAtPath(cst, path2.slice(0, -1));
-      const field = path2[path2.length - 1][0];
+    visit.parentCollection = (cst, path4) => {
+      const parent = visit.itemAtPath(cst, path4.slice(0, -1));
+      const field = path4[path4.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path2, item, visitor) {
-      let ctrl = visitor(item, path2);
+    function _visit(path4, item, visitor) {
+      let ctrl = visitor(item, path4);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path2.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path4.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -27537,10 +27537,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path2);
+            ctrl = ctrl(item, path4);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path2) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path4) : ctrl;
     }
     exports2.visit = visit;
   }
@@ -28829,14 +28829,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs3 = this.flowScalar(this.type);
+              const fs4 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs3, sep: [] });
+                map.items.push({ start, key: fs4, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs3);
+                this.stack.push(fs4);
               } else {
-                Object.assign(it, { key: fs3, sep: [] });
+                Object.assign(it, { key: fs4, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -28964,13 +28964,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs3 = this.flowScalar(this.type);
+              const fs4 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs3, sep: [] });
+                fc.items.push({ start: [], key: fs4, sep: [] });
               else if (it.sep)
-                this.stack.push(fs3);
+                this.stack.push(fs4);
               else
-                Object.assign(it, { key: fs3, sep: [] });
+                Object.assign(it, { key: fs4, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -29688,8 +29688,8 @@ var require_utils3 = __commonJS({
       }
       return output;
     };
-    exports2.basename = (path2, { windows } = {}) => {
-      const segs = path2.split(windows ? /[\\/]/ : "/");
+    exports2.basename = (path4, { windows } = {}) => {
+      const segs = path4.split(windows ? /[\\/]/ : "/");
       const last = segs[segs.length - 1];
       if (last === "") {
         return segs[segs.length - 2];
@@ -30958,6 +30958,2357 @@ var require_picomatch2 = __commonJS({
   }
 });
 
+// ../../node_modules/.pnpm/@1password+sdk-core@0.4.0/node_modules/@1password/sdk-core/nodejs/core.js
+var require_core2 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk-core@0.4.0/node_modules/@1password/sdk-core/nodejs/core.js"(exports2, module2) {
+    "use strict";
+    init_cjs_shims();
+    var imports = {};
+    imports["__wbindgen_placeholder__"] = module2.exports;
+    var wasm;
+    var { TextDecoder: TextDecoder2, TextEncoder: TextEncoder2 } = require("util");
+    var cachedTextDecoder = new TextDecoder2("utf-8", { ignoreBOM: true, fatal: true });
+    cachedTextDecoder.decode();
+    var cachedUint8ArrayMemory0 = null;
+    function getUint8ArrayMemory0() {
+      if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+      }
+      return cachedUint8ArrayMemory0;
+    }
+    function getStringFromWasm0(ptr, len) {
+      ptr = ptr >>> 0;
+      return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+    }
+    function addToExternrefTable0(obj) {
+      const idx = wasm.__externref_table_alloc();
+      wasm.__wbindgen_export_2.set(idx, obj);
+      return idx;
+    }
+    function handleError(f, args) {
+      try {
+        return f.apply(this, args);
+      } catch (e) {
+        const idx = addToExternrefTable0(e);
+        wasm.__wbindgen_exn_store(idx);
+      }
+    }
+    function isLikeNone(x) {
+      return x === void 0 || x === null;
+    }
+    var WASM_VECTOR_LEN = 0;
+    var cachedTextEncoder = new TextEncoder2("utf-8");
+    var encodeString = typeof cachedTextEncoder.encodeInto === "function" ? function(arg, view) {
+      return cachedTextEncoder.encodeInto(arg, view);
+    } : function(arg, view) {
+      const buf = cachedTextEncoder.encode(arg);
+      view.set(buf);
+      return {
+        read: arg.length,
+        written: buf.length
+      };
+    };
+    function passStringToWasm0(arg, malloc, realloc) {
+      if (realloc === void 0) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr2 = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr2, ptr2 + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr2;
+      }
+      let len = arg.length;
+      let ptr = malloc(len, 1) >>> 0;
+      const mem = getUint8ArrayMemory0();
+      let offset = 0;
+      for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 127) break;
+        mem[ptr + offset] = code;
+      }
+      if (offset !== len) {
+        if (offset !== 0) {
+          arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = encodeString(arg, view);
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+      }
+      WASM_VECTOR_LEN = offset;
+      return ptr;
+    }
+    var cachedDataViewMemory0 = null;
+    function getDataViewMemory0() {
+      if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || cachedDataViewMemory0.buffer.detached === void 0 && cachedDataViewMemory0.buffer !== wasm.memory.buffer) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+      }
+      return cachedDataViewMemory0;
+    }
+    var CLOSURE_DTORS = typeof FinalizationRegistry === "undefined" ? { register: () => {
+    }, unregister: () => {
+    } } : new FinalizationRegistry((state) => {
+      wasm.__wbindgen_export_5.get(state.dtor)(state.a, state.b);
+    });
+    function makeMutClosure(arg0, arg1, dtor, f) {
+      const state = { a: arg0, b: arg1, cnt: 1, dtor };
+      const real = (...args) => {
+        state.cnt++;
+        const a = state.a;
+        state.a = 0;
+        try {
+          return f(a, state.b, ...args);
+        } finally {
+          if (--state.cnt === 0) {
+            wasm.__wbindgen_export_5.get(state.dtor)(a, state.b);
+            CLOSURE_DTORS.unregister(state);
+          } else {
+            state.a = a;
+          }
+        }
+      };
+      real.original = state;
+      CLOSURE_DTORS.register(real, state, state);
+      return real;
+    }
+    function debugString(val) {
+      const type = typeof val;
+      if (type == "number" || type == "boolean" || val == null) {
+        return `${val}`;
+      }
+      if (type == "string") {
+        return `"${val}"`;
+      }
+      if (type == "symbol") {
+        const description = val.description;
+        if (description == null) {
+          return "Symbol";
+        } else {
+          return `Symbol(${description})`;
+        }
+      }
+      if (type == "function") {
+        const name = val.name;
+        if (typeof name == "string" && name.length > 0) {
+          return `Function(${name})`;
+        } else {
+          return "Function";
+        }
+      }
+      if (Array.isArray(val)) {
+        const length = val.length;
+        let debug = "[";
+        if (length > 0) {
+          debug += debugString(val[0]);
+        }
+        for (let i = 1; i < length; i++) {
+          debug += ", " + debugString(val[i]);
+        }
+        debug += "]";
+        return debug;
+      }
+      const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+      let className;
+      if (builtInMatches && builtInMatches.length > 1) {
+        className = builtInMatches[1];
+      } else {
+        return toString.call(val);
+      }
+      if (className == "Object") {
+        try {
+          return "Object(" + JSON.stringify(val) + ")";
+        } catch (_) {
+          return "Object";
+        }
+      }
+      if (val instanceof Error) {
+        return `${val.name}: ${val.message}
+${val.stack}`;
+      }
+      return className;
+    }
+    module2.exports.init_client = function(config) {
+      const ptr0 = passStringToWasm0(config, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len0 = WASM_VECTOR_LEN;
+      const ret = wasm.init_client(ptr0, len0);
+      return ret;
+    };
+    module2.exports.invoke = function(parameters) {
+      const ptr0 = passStringToWasm0(parameters, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len0 = WASM_VECTOR_LEN;
+      const ret = wasm.invoke(ptr0, len0);
+      return ret;
+    };
+    function takeFromExternrefTable0(idx) {
+      const value = wasm.__wbindgen_export_2.get(idx);
+      wasm.__externref_table_dealloc(idx);
+      return value;
+    }
+    module2.exports.invoke_sync = function(parameters) {
+      let deferred3_0;
+      let deferred3_1;
+      try {
+        const ptr0 = passStringToWasm0(parameters, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.invoke_sync(ptr0, len0);
+        var ptr2 = ret[0];
+        var len2 = ret[1];
+        if (ret[3]) {
+          ptr2 = 0;
+          len2 = 0;
+          throw takeFromExternrefTable0(ret[2]);
+        }
+        deferred3_0 = ptr2;
+        deferred3_1 = len2;
+        return getStringFromWasm0(ptr2, len2);
+      } finally {
+        wasm.__wbindgen_free(deferred3_0, deferred3_1, 1);
+      }
+    };
+    module2.exports.release_client = function(client_id) {
+      const ptr0 = passStringToWasm0(client_id, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len0 = WASM_VECTOR_LEN;
+      const ret = wasm.release_client(ptr0, len0);
+      if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+      }
+    };
+    function __wbg_adapter_30(arg0, arg1) {
+      wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h4fa304e9a7297dba(arg0, arg1);
+    }
+    function __wbg_adapter_33(arg0, arg1, arg2) {
+      wasm.closure2484_externref_shim(arg0, arg1, arg2);
+    }
+    function __wbg_adapter_156(arg0, arg1, arg2, arg3) {
+      wasm.closure2632_externref_shim(arg0, arg1, arg2, arg3);
+    }
+    var __wbindgen_enum_RequestCache = ["default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached"];
+    var __wbindgen_enum_RequestCredentials = ["omit", "same-origin", "include"];
+    var __wbindgen_enum_RequestMode = ["same-origin", "no-cors", "cors", "navigate"];
+    module2.exports.__wbg_abort_410ec47a64ac6117 = function(arg0, arg1) {
+      arg0.abort(arg1);
+    };
+    module2.exports.__wbg_abort_775ef1d17fc65868 = function(arg0) {
+      arg0.abort();
+    };
+    module2.exports.__wbg_append_8c7dd8d641a5f01b = function() {
+      return handleError(function(arg0, arg1, arg2, arg3, arg4) {
+        arg0.append(getStringFromWasm0(arg1, arg2), getStringFromWasm0(arg3, arg4));
+      }, arguments);
+    };
+    module2.exports.__wbg_arrayBuffer_d1b44c4390db422f = function() {
+      return handleError(function(arg0) {
+        const ret = arg0.arrayBuffer();
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_buffer_609cc3eee51ed158 = function(arg0) {
+      const ret = arg0.buffer;
+      return ret;
+    };
+    module2.exports.__wbg_call_672a4d21634d4a24 = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = arg0.call(arg1);
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_call_7cccdd69e0791ae2 = function() {
+      return handleError(function(arg0, arg1, arg2) {
+        const ret = arg0.call(arg1, arg2);
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_clearTimeout_42d9ccd50822fd3a = function(arg0) {
+      const ret = clearTimeout(arg0);
+      return ret;
+    };
+    module2.exports.__wbg_crypto_86f2631e91b51511 = function(arg0) {
+      const ret = arg0.crypto;
+      return ret;
+    };
+    module2.exports.__wbg_done_769e5ede4b31c67b = function(arg0) {
+      const ret = arg0.done;
+      return ret;
+    };
+    module2.exports.__wbg_fetch_509096533071c657 = function(arg0, arg1) {
+      const ret = arg0.fetch(arg1);
+      return ret;
+    };
+    module2.exports.__wbg_fetch_6bbc32f991730587 = function(arg0) {
+      const ret = fetch(arg0);
+      return ret;
+    };
+    module2.exports.__wbg_getFullYear_17d3c9e4db748eb7 = function(arg0) {
+      const ret = arg0.getFullYear();
+      return ret;
+    };
+    module2.exports.__wbg_getRandomValues_b3f15fcbfabb0f8b = function() {
+      return handleError(function(arg0, arg1) {
+        arg0.getRandomValues(arg1);
+      }, arguments);
+    };
+    module2.exports.__wbg_getTimezoneOffset_6b5752021c499c47 = function(arg0) {
+      const ret = arg0.getTimezoneOffset();
+      return ret;
+    };
+    module2.exports.__wbg_get_67b2ba62fc30de12 = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = Reflect.get(arg0, arg1);
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_has_a5ea9117f258a0ec = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = Reflect.has(arg0, arg1);
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_headers_9cb51cfd2ac780a4 = function(arg0) {
+      const ret = arg0.headers;
+      return ret;
+    };
+    module2.exports.__wbg_instanceof_Response_f2cc20d9f7dfd644 = function(arg0) {
+      let result;
+      try {
+        result = arg0 instanceof Response;
+      } catch (_) {
+        result = false;
+      }
+      const ret = result;
+      return ret;
+    };
+    module2.exports.__wbg_instanceof_Window_def73ea0955fc569 = function(arg0) {
+      let result;
+      try {
+        result = arg0 instanceof Window;
+      } catch (_) {
+        result = false;
+      }
+      const ret = result;
+      return ret;
+    };
+    module2.exports.__wbg_instanceof_WorkerGlobalScope_dbdbdea7e3b56493 = function(arg0) {
+      let result;
+      try {
+        result = arg0 instanceof WorkerGlobalScope;
+      } catch (_) {
+        result = false;
+      }
+      const ret = result;
+      return ret;
+    };
+    module2.exports.__wbg_iterator_9a24c88df860dc65 = function() {
+      const ret = Symbol.iterator;
+      return ret;
+    };
+    module2.exports.__wbg_languages_2420955220685766 = function(arg0) {
+      const ret = arg0.languages;
+      return ret;
+    };
+    module2.exports.__wbg_languages_d8dad509faf757df = function(arg0) {
+      const ret = arg0.languages;
+      return ret;
+    };
+    module2.exports.__wbg_length_a446193dc22c12f8 = function(arg0) {
+      const ret = arg0.length;
+      return ret;
+    };
+    module2.exports.__wbg_msCrypto_d562bbe83e0d4b91 = function(arg0) {
+      const ret = arg0.msCrypto;
+      return ret;
+    };
+    module2.exports.__wbg_navigator_0a9bf1120e24fec2 = function(arg0) {
+      const ret = arg0.navigator;
+      return ret;
+    };
+    module2.exports.__wbg_navigator_1577371c070c8947 = function(arg0) {
+      const ret = arg0.navigator;
+      return ret;
+    };
+    module2.exports.__wbg_new0_f788a2397c7ca929 = function() {
+      const ret = /* @__PURE__ */ new Date();
+      return ret;
+    };
+    module2.exports.__wbg_new_018dcc2d6c8c2f6a = function() {
+      return handleError(function() {
+        const ret = new Headers();
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_new_23a2665fac83c611 = function(arg0, arg1) {
+      try {
+        var state0 = { a: arg0, b: arg1 };
+        var cb0 = (arg02, arg12) => {
+          const a = state0.a;
+          state0.a = 0;
+          try {
+            return __wbg_adapter_156(a, state0.b, arg02, arg12);
+          } finally {
+            state0.a = a;
+          }
+        };
+        const ret = new Promise(cb0);
+        return ret;
+      } finally {
+        state0.a = state0.b = 0;
+      }
+    };
+    module2.exports.__wbg_new_31a97dac4f10fab7 = function(arg0) {
+      const ret = new Date(arg0);
+      return ret;
+    };
+    module2.exports.__wbg_new_405e22f390576ce2 = function() {
+      const ret = new Object();
+      return ret;
+    };
+    module2.exports.__wbg_new_a12002a7f91c75be = function(arg0) {
+      const ret = new Uint8Array(arg0);
+      return ret;
+    };
+    module2.exports.__wbg_new_e25e5aab09ff45db = function() {
+      return handleError(function() {
+        const ret = new AbortController();
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_newnoargs_105ed471475aaf50 = function(arg0, arg1) {
+      const ret = new Function(getStringFromWasm0(arg0, arg1));
+      return ret;
+    };
+    module2.exports.__wbg_newwithbyteoffsetandlength_d97e637ebe145a9a = function(arg0, arg1, arg2) {
+      const ret = new Uint8Array(arg0, arg1 >>> 0, arg2 >>> 0);
+      return ret;
+    };
+    module2.exports.__wbg_newwithlength_a381634e90c276d4 = function(arg0) {
+      const ret = new Uint8Array(arg0 >>> 0);
+      return ret;
+    };
+    module2.exports.__wbg_newwithstrandinit_06c535e0a867c635 = function() {
+      return handleError(function(arg0, arg1, arg2) {
+        const ret = new Request(getStringFromWasm0(arg0, arg1), arg2);
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_next_25feadfc0913fea9 = function(arg0) {
+      const ret = arg0.next;
+      return ret;
+    };
+    module2.exports.__wbg_next_6574e1a8a62d1055 = function() {
+      return handleError(function(arg0) {
+        const ret = arg0.next();
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_node_e1f24f89a7336c2e = function(arg0) {
+      const ret = arg0.node;
+      return ret;
+    };
+    module2.exports.__wbg_now_807e54c39636c349 = function() {
+      const ret = Date.now();
+      return ret;
+    };
+    module2.exports.__wbg_now_d18023d54d4e5500 = function(arg0) {
+      const ret = arg0.now();
+      return ret;
+    };
+    module2.exports.__wbg_parse_def2e24ef1252aff = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = JSON.parse(getStringFromWasm0(arg0, arg1));
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_process_3975fd6c72f520aa = function(arg0) {
+      const ret = arg0.process;
+      return ret;
+    };
+    module2.exports.__wbg_queueMicrotask_97d92b4fcc8a61c5 = function(arg0) {
+      queueMicrotask(arg0);
+    };
+    module2.exports.__wbg_queueMicrotask_d3219def82552485 = function(arg0) {
+      const ret = arg0.queueMicrotask;
+      return ret;
+    };
+    module2.exports.__wbg_randomFillSync_f8c153b79f285817 = function() {
+      return handleError(function(arg0, arg1) {
+        arg0.randomFillSync(arg1);
+      }, arguments);
+    };
+    module2.exports.__wbg_require_b74f47fc2d022fd6 = function() {
+      return handleError(function() {
+        const ret = module2.require;
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_resolve_4851785c9c5f573d = function(arg0) {
+      const ret = Promise.resolve(arg0);
+      return ret;
+    };
+    module2.exports.__wbg_self_b29ea9f89ecb0567 = function() {
+      return handleError(function() {
+        const ret = self.self;
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_setTimeout_4ec014681668a581 = function(arg0, arg1) {
+      const ret = setTimeout(arg0, arg1);
+      return ret;
+    };
+    module2.exports.__wbg_set_65595bdd868b3009 = function(arg0, arg1, arg2) {
+      arg0.set(arg1, arg2 >>> 0);
+    };
+    module2.exports.__wbg_setbody_5923b78a95eedf29 = function(arg0, arg1) {
+      arg0.body = arg1;
+    };
+    module2.exports.__wbg_setcache_12f17c3a980650e4 = function(arg0, arg1) {
+      arg0.cache = __wbindgen_enum_RequestCache[arg1];
+    };
+    module2.exports.__wbg_setcredentials_c3a22f1cd105a2c6 = function(arg0, arg1) {
+      arg0.credentials = __wbindgen_enum_RequestCredentials[arg1];
+    };
+    module2.exports.__wbg_setheaders_834c0bdb6a8949ad = function(arg0, arg1) {
+      arg0.headers = arg1;
+    };
+    module2.exports.__wbg_setmethod_3c5280fe5d890842 = function(arg0, arg1, arg2) {
+      arg0.method = getStringFromWasm0(arg1, arg2);
+    };
+    module2.exports.__wbg_setmode_5dc300b865044b65 = function(arg0, arg1) {
+      arg0.mode = __wbindgen_enum_RequestMode[arg1];
+    };
+    module2.exports.__wbg_setsignal_75b21ef3a81de905 = function(arg0, arg1) {
+      arg0.signal = arg1;
+    };
+    module2.exports.__wbg_signal_aaf9ad74119f20a4 = function(arg0) {
+      const ret = arg0.signal;
+      return ret;
+    };
+    module2.exports.__wbg_static_accessor_GLOBAL_88a902d13a557d07 = function() {
+      const ret = typeof global === "undefined" ? null : global;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module2.exports.__wbg_static_accessor_GLOBAL_THIS_56578be7e9f832b0 = function() {
+      const ret = typeof globalThis === "undefined" ? null : globalThis;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module2.exports.__wbg_static_accessor_SELF_37c5d418e4bf5819 = function() {
+      const ret = typeof self === "undefined" ? null : self;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module2.exports.__wbg_static_accessor_WINDOW_5de37043a91a9c40 = function() {
+      const ret = typeof window === "undefined" ? null : window;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module2.exports.__wbg_static_accessor_performance_da77b3a901a72934 = function() {
+      const ret = performance;
+      return ret;
+    };
+    module2.exports.__wbg_status_f6360336ca686bf0 = function(arg0) {
+      const ret = arg0.status;
+      return ret;
+    };
+    module2.exports.__wbg_stringify_f7ed6987935b4a24 = function() {
+      return handleError(function(arg0) {
+        const ret = JSON.stringify(arg0);
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbg_subarray_aa9065fa9dc5df96 = function(arg0, arg1, arg2) {
+      const ret = arg0.subarray(arg1 >>> 0, arg2 >>> 0);
+      return ret;
+    };
+    module2.exports.__wbg_then_44b73946d2fb3e7d = function(arg0, arg1) {
+      const ret = arg0.then(arg1);
+      return ret;
+    };
+    module2.exports.__wbg_then_48b406749878a531 = function(arg0, arg1, arg2) {
+      const ret = arg0.then(arg1, arg2);
+      return ret;
+    };
+    module2.exports.__wbg_toLocaleDateString_e5424994746e8415 = function(arg0, arg1, arg2, arg3) {
+      const ret = arg0.toLocaleDateString(getStringFromWasm0(arg1, arg2), arg3);
+      return ret;
+    };
+    module2.exports.__wbg_url_ae10c34ca209681d = function(arg0, arg1) {
+      const ret = arg1.url;
+      const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len1 = WASM_VECTOR_LEN;
+      getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+      getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    module2.exports.__wbg_value_cd1ffa7b1ab794f1 = function(arg0) {
+      const ret = arg0.value;
+      return ret;
+    };
+    module2.exports.__wbg_values_99f7a68c7f313d66 = function(arg0) {
+      const ret = arg0.values();
+      return ret;
+    };
+    module2.exports.__wbg_versions_4e31226f5e8dc909 = function(arg0) {
+      const ret = arg0.versions;
+      return ret;
+    };
+    module2.exports.__wbg_window_aa5515e600e96252 = function() {
+      return handleError(function() {
+        const ret = window.window;
+        return ret;
+      }, arguments);
+    };
+    module2.exports.__wbindgen_cb_drop = function(arg0) {
+      const obj = arg0.original;
+      if (obj.cnt-- == 1) {
+        obj.a = 0;
+        return true;
+      }
+      const ret = false;
+      return ret;
+    };
+    module2.exports.__wbindgen_closure_wrapper9169 = function(arg0, arg1, arg2) {
+      const ret = makeMutClosure(arg0, arg1, 2463, __wbg_adapter_30);
+      return ret;
+    };
+    module2.exports.__wbindgen_closure_wrapper9209 = function(arg0, arg1, arg2) {
+      const ret = makeMutClosure(arg0, arg1, 2485, __wbg_adapter_33);
+      return ret;
+    };
+    module2.exports.__wbindgen_debug_string = function(arg0, arg1) {
+      const ret = debugString(arg1);
+      const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len1 = WASM_VECTOR_LEN;
+      getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+      getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    module2.exports.__wbindgen_init_externref_table = function() {
+      const table = wasm.__wbindgen_export_2;
+      const offset = table.grow(4);
+      table.set(0, void 0);
+      table.set(offset + 0, void 0);
+      table.set(offset + 1, null);
+      table.set(offset + 2, true);
+      table.set(offset + 3, false);
+      ;
+    };
+    module2.exports.__wbindgen_is_function = function(arg0) {
+      const ret = typeof arg0 === "function";
+      return ret;
+    };
+    module2.exports.__wbindgen_is_object = function(arg0) {
+      const val = arg0;
+      const ret = typeof val === "object" && val !== null;
+      return ret;
+    };
+    module2.exports.__wbindgen_is_string = function(arg0) {
+      const ret = typeof arg0 === "string";
+      return ret;
+    };
+    module2.exports.__wbindgen_is_undefined = function(arg0) {
+      const ret = arg0 === void 0;
+      return ret;
+    };
+    module2.exports.__wbindgen_memory = function() {
+      const ret = wasm.memory;
+      return ret;
+    };
+    module2.exports.__wbindgen_number_new = function(arg0) {
+      const ret = arg0;
+      return ret;
+    };
+    module2.exports.__wbindgen_string_get = function(arg0, arg1) {
+      const obj = arg1;
+      const ret = typeof obj === "string" ? obj : void 0;
+      var ptr1 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      var len1 = WASM_VECTOR_LEN;
+      getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+      getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    module2.exports.__wbindgen_string_new = function(arg0, arg1) {
+      const ret = getStringFromWasm0(arg0, arg1);
+      return ret;
+    };
+    module2.exports.__wbindgen_throw = function(arg0, arg1) {
+      throw new Error(getStringFromWasm0(arg0, arg1));
+    };
+    var path4 = require("path").join(__dirname, "core_bg.wasm");
+    var bytes = require("fs").readFileSync(path4);
+    var wasmModule = new WebAssembly.Module(bytes);
+    var wasmInstance = new WebAssembly.Instance(wasmModule, imports);
+    wasm = wasmInstance.exports;
+    module2.exports.__wasm = wasm;
+    wasm.__wbindgen_start();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/types.js
+var require_types = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/types.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.ReplacerFunc = exports2.ReviverFunc = exports2.UPDATE_ITEM_HISTORY = exports2.UPDATE_ITEMS = exports2.SEND_ITEMS = exports2.REVEAL_ITEM_PASSWORD = exports2.RECOVER_VAULT = exports2.READ_ITEMS = exports2.PRINT_ITEMS = exports2.NO_ACCESS = exports2.MANAGE_VAULT = exports2.IMPORT_ITEMS = exports2.EXPORT_ITEMS = exports2.DELETE_ITEMS = exports2.CREATE_ITEMS = exports2.ARCHIVE_ITEMS = exports2.WordListType = exports2.SeparatorType = exports2.VaultType = exports2.AllowedRecipientType = exports2.AllowedType = exports2.ItemShareDuration = exports2.ItemState = exports2.AutofillBehavior = exports2.ItemFieldType = exports2.ItemCategory = exports2.VaultAccessorType = exports2.GroupState = exports2.GroupType = void 0;
+    var GroupType;
+    (function(GroupType2) {
+      GroupType2["Owners"] = "owners";
+      GroupType2["Administrators"] = "administrators";
+      GroupType2["Recovery"] = "recovery";
+      GroupType2["ExternalAccountManagers"] = "externalAccountManagers";
+      GroupType2["TeamMembers"] = "teamMembers";
+      GroupType2["UserDefined"] = "userDefined";
+      GroupType2["Unsupported"] = "unsupported";
+    })(GroupType || (exports2.GroupType = GroupType = {}));
+    var GroupState;
+    (function(GroupState2) {
+      GroupState2["Active"] = "active";
+      GroupState2["Deleted"] = "deleted";
+      GroupState2["Unsupported"] = "unsupported";
+    })(GroupState || (exports2.GroupState = GroupState = {}));
+    var VaultAccessorType;
+    (function(VaultAccessorType2) {
+      VaultAccessorType2["User"] = "user";
+      VaultAccessorType2["Group"] = "group";
+    })(VaultAccessorType || (exports2.VaultAccessorType = VaultAccessorType = {}));
+    var ItemCategory;
+    (function(ItemCategory2) {
+      ItemCategory2["Login"] = "Login";
+      ItemCategory2["SecureNote"] = "SecureNote";
+      ItemCategory2["CreditCard"] = "CreditCard";
+      ItemCategory2["CryptoWallet"] = "CryptoWallet";
+      ItemCategory2["Identity"] = "Identity";
+      ItemCategory2["Password"] = "Password";
+      ItemCategory2["Document"] = "Document";
+      ItemCategory2["ApiCredentials"] = "ApiCredentials";
+      ItemCategory2["BankAccount"] = "BankAccount";
+      ItemCategory2["Database"] = "Database";
+      ItemCategory2["DriverLicense"] = "DriverLicense";
+      ItemCategory2["Email"] = "Email";
+      ItemCategory2["MedicalRecord"] = "MedicalRecord";
+      ItemCategory2["Membership"] = "Membership";
+      ItemCategory2["OutdoorLicense"] = "OutdoorLicense";
+      ItemCategory2["Passport"] = "Passport";
+      ItemCategory2["Rewards"] = "Rewards";
+      ItemCategory2["Router"] = "Router";
+      ItemCategory2["Server"] = "Server";
+      ItemCategory2["SshKey"] = "SshKey";
+      ItemCategory2["SocialSecurityNumber"] = "SocialSecurityNumber";
+      ItemCategory2["SoftwareLicense"] = "SoftwareLicense";
+      ItemCategory2["Person"] = "Person";
+      ItemCategory2["Unsupported"] = "Unsupported";
+    })(ItemCategory || (exports2.ItemCategory = ItemCategory = {}));
+    var ItemFieldType;
+    (function(ItemFieldType2) {
+      ItemFieldType2["Text"] = "Text";
+      ItemFieldType2["Concealed"] = "Concealed";
+      ItemFieldType2["CreditCardType"] = "CreditCardType";
+      ItemFieldType2["CreditCardNumber"] = "CreditCardNumber";
+      ItemFieldType2["Phone"] = "Phone";
+      ItemFieldType2["Url"] = "Url";
+      ItemFieldType2["Totp"] = "Totp";
+      ItemFieldType2["Email"] = "Email";
+      ItemFieldType2["Reference"] = "Reference";
+      ItemFieldType2["SshKey"] = "SshKey";
+      ItemFieldType2["Menu"] = "Menu";
+      ItemFieldType2["MonthYear"] = "MonthYear";
+      ItemFieldType2["Address"] = "Address";
+      ItemFieldType2["Date"] = "Date";
+      ItemFieldType2["Unsupported"] = "Unsupported";
+    })(ItemFieldType || (exports2.ItemFieldType = ItemFieldType = {}));
+    var AutofillBehavior;
+    (function(AutofillBehavior2) {
+      AutofillBehavior2["AnywhereOnWebsite"] = "AnywhereOnWebsite";
+      AutofillBehavior2["ExactDomain"] = "ExactDomain";
+      AutofillBehavior2["Never"] = "Never";
+    })(AutofillBehavior || (exports2.AutofillBehavior = AutofillBehavior = {}));
+    var ItemState;
+    (function(ItemState2) {
+      ItemState2["Active"] = "active";
+      ItemState2["Archived"] = "archived";
+    })(ItemState || (exports2.ItemState = ItemState = {}));
+    var ItemShareDuration;
+    (function(ItemShareDuration2) {
+      ItemShareDuration2["OneHour"] = "OneHour";
+      ItemShareDuration2["OneDay"] = "OneDay";
+      ItemShareDuration2["SevenDays"] = "SevenDays";
+      ItemShareDuration2["FourteenDays"] = "FourteenDays";
+      ItemShareDuration2["ThirtyDays"] = "ThirtyDays";
+    })(ItemShareDuration || (exports2.ItemShareDuration = ItemShareDuration = {}));
+    var AllowedType;
+    (function(AllowedType2) {
+      AllowedType2["Authenticated"] = "Authenticated";
+      AllowedType2["Public"] = "Public";
+    })(AllowedType || (exports2.AllowedType = AllowedType = {}));
+    var AllowedRecipientType;
+    (function(AllowedRecipientType2) {
+      AllowedRecipientType2["Email"] = "Email";
+      AllowedRecipientType2["Domain"] = "Domain";
+    })(AllowedRecipientType || (exports2.AllowedRecipientType = AllowedRecipientType = {}));
+    var VaultType;
+    (function(VaultType2) {
+      VaultType2["Personal"] = "personal";
+      VaultType2["Everyone"] = "everyone";
+      VaultType2["Transfer"] = "transfer";
+      VaultType2["UserCreated"] = "userCreated";
+      VaultType2["Unsupported"] = "unsupported";
+    })(VaultType || (exports2.VaultType = VaultType = {}));
+    var SeparatorType;
+    (function(SeparatorType2) {
+      SeparatorType2["Digits"] = "digits";
+      SeparatorType2["DigitsAndSymbols"] = "digitsAndSymbols";
+      SeparatorType2["Spaces"] = "spaces";
+      SeparatorType2["Hyphens"] = "hyphens";
+      SeparatorType2["Underscores"] = "underscores";
+      SeparatorType2["Periods"] = "periods";
+      SeparatorType2["Commas"] = "commas";
+    })(SeparatorType || (exports2.SeparatorType = SeparatorType = {}));
+    var WordListType;
+    (function(WordListType2) {
+      WordListType2["FullWords"] = "fullWords";
+      WordListType2["Syllables"] = "syllables";
+      WordListType2["ThreeLetters"] = "threeLetters";
+    })(WordListType || (exports2.WordListType = WordListType = {}));
+    exports2.ARCHIVE_ITEMS = 256;
+    exports2.CREATE_ITEMS = 128;
+    exports2.DELETE_ITEMS = 512;
+    exports2.EXPORT_ITEMS = 4194304;
+    exports2.IMPORT_ITEMS = 2097152;
+    exports2.MANAGE_VAULT = 2;
+    exports2.NO_ACCESS = 0;
+    exports2.PRINT_ITEMS = 8388608;
+    exports2.READ_ITEMS = 32;
+    exports2.RECOVER_VAULT = 1;
+    exports2.REVEAL_ITEM_PASSWORD = 16;
+    exports2.SEND_ITEMS = 1048576;
+    exports2.UPDATE_ITEMS = 64;
+    exports2.UPDATE_ITEM_HISTORY = 1024;
+    var ReviverFunc = (key, value) => {
+      if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value) && (key === "createdAt" || key === "updatedAt")) {
+        return new Date(value);
+      }
+      if (Array.isArray(value) && value.every((v) => Number.isInteger(v) && v >= 0 && v <= 255) && value.length > 0) {
+        return new Uint8Array(value);
+      }
+      return value;
+    };
+    exports2.ReviverFunc = ReviverFunc;
+    var ReplacerFunc = (key, value) => {
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      if (value instanceof Uint8Array) {
+        return Array.from(value);
+      }
+      return value;
+    };
+    exports2.ReplacerFunc = ReplacerFunc;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/errors.js
+var require_errors3 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/errors.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.throwError = exports2.RateLimitExceededError = exports2.DesktopSessionExpiredError = void 0;
+    var DesktopSessionExpiredError = class extends Error {
+      constructor(message) {
+        super();
+        this.message = message;
+      }
+    };
+    exports2.DesktopSessionExpiredError = DesktopSessionExpiredError;
+    var RateLimitExceededError = class extends Error {
+      constructor(message) {
+        super();
+        this.message = message;
+      }
+    };
+    exports2.RateLimitExceededError = RateLimitExceededError;
+    var throwError = (errString) => {
+      let err;
+      try {
+        err = JSON.parse(errString);
+      } catch (e) {
+        throw new Error(errString);
+      }
+      switch (err.name) {
+        case "DesktopSessionExpired":
+          throw new DesktopSessionExpiredError(err.message);
+        case "RateLimitExceeded":
+          throw new RateLimitExceededError(err.message);
+        default:
+          throw new Error(err.message);
+      }
+    };
+    exports2.throwError = throwError;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/core.js
+var require_core3 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/core.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.InnerClient = exports2.SharedCore = exports2.WasmCore = void 0;
+    var sdk_core_1 = require_core2();
+    var types_1 = require_types();
+    var errors_1 = require_errors3();
+    var messageLimit = 50 * 1024 * 1024;
+    var WasmCore = class {
+      initClient(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          try {
+            return yield (0, sdk_core_1.init_client)(config);
+          } catch (e) {
+            (0, errors_1.throwError)(e);
+          }
+        });
+      }
+      invoke(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          try {
+            return yield (0, sdk_core_1.invoke)(config);
+          } catch (e) {
+            (0, errors_1.throwError)(e);
+          }
+        });
+      }
+      releaseClient(clientId) {
+        try {
+          (0, sdk_core_1.release_client)(clientId);
+        } catch (e) {
+          console.warn("failed to release client:", e);
+        }
+      }
+    };
+    exports2.WasmCore = WasmCore;
+    var SharedCore = class {
+      constructor() {
+        this.inner = new WasmCore();
+      }
+      setInner(core2) {
+        this.inner = core2;
+      }
+      initClient(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const serializedConfig = JSON.stringify(config);
+          return this.inner.initClient(serializedConfig);
+        });
+      }
+      invoke(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const serializedConfig = JSON.stringify(config, types_1.ReplacerFunc);
+          if (new TextEncoder().encode(serializedConfig).length > messageLimit) {
+            (0, errors_1.throwError)(`message size exceeds the limit of ${messageLimit} bytes, please contact 1Password at support@1password.com or https://developer.1password.com/joinslack if you need help."`);
+          }
+          return this.inner.invoke(serializedConfig);
+        });
+      }
+      invoke_sync(config) {
+        const serializedConfig = JSON.stringify(config, types_1.ReplacerFunc);
+        if (new TextEncoder().encode(serializedConfig).length > messageLimit) {
+          (0, errors_1.throwError)(`message size exceeds the limit of ${messageLimit} bytes, please contact 1Password at support@1password.com or https://developer.1password.com/joinslack if you need help.`);
+        }
+        return (0, sdk_core_1.invoke_sync)(serializedConfig);
+      }
+      releaseClient(clientId) {
+        const serializedId = JSON.stringify(clientId);
+        this.inner.releaseClient(serializedId);
+      }
+    };
+    exports2.SharedCore = SharedCore;
+    var InnerClient = class {
+      constructor(id, core2, config) {
+        this.id = id;
+        this.core = core2;
+        this.config = config;
+      }
+      invoke(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          try {
+            return yield this.core.invoke(config);
+          } catch (err) {
+            if (err instanceof errors_1.DesktopSessionExpiredError) {
+              const newId = yield this.core.initClient(this.config);
+              this.id = parseInt(newId, 10);
+              config.invocation.clientId = this.id;
+              return yield this.core.invoke(config);
+            }
+            throw err;
+          }
+        });
+      }
+    };
+    exports2.InnerClient = InnerClient;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/version.js
+var require_version = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/version.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.SDK_BUILD_NUMBER = exports2.SDK_VERSION = void 0;
+    exports2.SDK_VERSION = "0.4.0";
+    exports2.SDK_BUILD_NUMBER = "0040003";
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/configuration.js
+var require_configuration = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/configuration.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __importDefault = exports2 && exports2.__importDefault || function(mod) {
+      return mod && mod.__esModule ? mod : { "default": mod };
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.getOsName = exports2.clientAuthConfig = exports2.DesktopAuth = exports2.VERSION = exports2.LANGUAGE = void 0;
+    var os_1 = __importDefault(require("os"));
+    var version_js_1 = require_version();
+    exports2.LANGUAGE = "JS";
+    exports2.VERSION = version_js_1.SDK_BUILD_NUMBER;
+    var DesktopAuth = class {
+      constructor(accountName) {
+        this.accountName = accountName;
+      }
+    };
+    exports2.DesktopAuth = DesktopAuth;
+    var clientAuthConfig = (userConfig) => {
+      const defaultOsVersion = "0.0.0";
+      let serviceAccountToken;
+      let accountName;
+      if (typeof userConfig.auth === "string") {
+        serviceAccountToken = userConfig.auth;
+      } else if (userConfig.auth instanceof DesktopAuth) {
+        accountName = userConfig.auth.accountName;
+      }
+      return {
+        serviceAccountToken: serviceAccountToken !== null && serviceAccountToken !== void 0 ? serviceAccountToken : "",
+        accountName,
+        programmingLanguage: exports2.LANGUAGE,
+        sdkVersion: exports2.VERSION,
+        integrationName: userConfig.integrationName,
+        integrationVersion: userConfig.integrationVersion,
+        requestLibraryName: "Fetch API",
+        requestLibraryVersion: "Fetch API",
+        os: (0, exports2.getOsName)(),
+        osVersion: defaultOsVersion,
+        architecture: os_1.default.arch()
+      };
+    };
+    exports2.clientAuthConfig = clientAuthConfig;
+    var getOsName = () => {
+      const os_name = os_1.default.type().toLowerCase();
+      if (os_name === "windows_nt") {
+        return "windows";
+      }
+      return os_name;
+    };
+    exports2.getOsName = getOsName;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/secrets.js
+var require_secrets = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/secrets.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports2 && exports2.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports2 && exports2.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Secrets_inner;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.Secrets = void 0;
+    var core_js_1 = require_core3();
+    var types_js_1 = require_types();
+    var Secrets = class {
+      constructor(inner) {
+        _Secrets_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Secrets_inner, inner, "f");
+      }
+      /**
+       * Resolve returns the secret the provided secret reference points to.
+       */
+      resolve(secretReference) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Secrets_inner, "f").id,
+              parameters: {
+                name: "SecretsResolve",
+                parameters: {
+                  secret_reference: secretReference
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Secrets_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Resolve takes in a list of secret references and returns the secrets they point to or errors if any.
+       */
+      resolveAll(secretReferences) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Secrets_inner, "f").id,
+              parameters: {
+                name: "SecretsResolveAll",
+                parameters: {
+                  secret_references: secretReferences
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Secrets_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Validate the secret reference to ensure there are no syntax errors.
+       */
+      static validateSecretReference(secretReference) {
+        const sharedCore = new core_js_1.SharedCore();
+        const invocationConfig = {
+          invocation: {
+            parameters: {
+              name: "ValidateSecretReference",
+              parameters: {
+                secret_reference: secretReference
+              }
+            }
+          }
+        };
+        sharedCore.invoke_sync(invocationConfig);
+      }
+      /**
+       * Generate a password using the provided recipe.
+       */
+      static generatePassword(recipe) {
+        const sharedCore = new core_js_1.SharedCore();
+        const invocationConfig = {
+          invocation: {
+            parameters: {
+              name: "GeneratePassword",
+              parameters: {
+                recipe
+              }
+            }
+          }
+        };
+        return JSON.parse(sharedCore.invoke_sync(invocationConfig), types_js_1.ReviverFunc);
+      }
+    };
+    exports2.Secrets = Secrets;
+    _Secrets_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_shares.js
+var require_items_shares = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_shares.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports2 && exports2.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports2 && exports2.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _ItemsShares_inner;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.ItemsShares = void 0;
+    var types_js_1 = require_types();
+    var ItemsShares = class {
+      constructor(inner) {
+        _ItemsShares_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _ItemsShares_inner, inner, "f");
+      }
+      /**
+       * Get the item sharing policy of your account.
+       */
+      getAccountPolicy(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsShares_inner, "f").id,
+              parameters: {
+                name: "ItemsSharesGetAccountPolicy",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsShares_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Validate the recipients of an item sharing link.
+       */
+      validateRecipients(policy, recipients) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsShares_inner, "f").id,
+              parameters: {
+                name: "ItemsSharesValidateRecipients",
+                parameters: {
+                  policy,
+                  recipients
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsShares_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Create a new item sharing link.
+       */
+      create(item, policy, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsShares_inner, "f").id,
+              parameters: {
+                name: "ItemsSharesCreate",
+                parameters: {
+                  item,
+                  policy,
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsShares_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports2.ItemsShares = ItemsShares;
+    _ItemsShares_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_files.js
+var require_items_files = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_files.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports2 && exports2.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports2 && exports2.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _ItemsFiles_inner;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.ItemsFiles = void 0;
+    var types_js_1 = require_types();
+    var ItemsFiles = class {
+      constructor(inner) {
+        _ItemsFiles_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _ItemsFiles_inner, inner, "f");
+      }
+      /**
+       * Attach files to Items.
+       */
+      attach(item, fileParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesAttach",
+                parameters: {
+                  item,
+                  file_params: fileParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Read file content from the Item.
+       */
+      read(vaultId, itemId, attr) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesRead",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId,
+                  attr
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Delete a field file from Item using the section and field IDs.
+       */
+      delete(item, sectionId, fieldId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesDelete",
+                parameters: {
+                  item,
+                  section_id: sectionId,
+                  field_id: fieldId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Replace the document file within a document item.
+       */
+      replaceDocument(item, docParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesReplaceDocument",
+                parameters: {
+                  item,
+                  doc_params: docParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports2.ItemsFiles = ItemsFiles;
+    _ItemsFiles_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items.js
+var require_items = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports2 && exports2.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports2 && exports2.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Items_inner;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.Items = void 0;
+    var types_js_1 = require_types();
+    var items_shares_js_1 = require_items_shares();
+    var items_files_js_1 = require_items_files();
+    var Items = class {
+      constructor(inner) {
+        _Items_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Items_inner, inner, "f");
+        this.shares = new items_shares_js_1.ItemsShares(inner);
+        this.files = new items_files_js_1.ItemsFiles(inner);
+      }
+      /**
+       * Create a new item.
+       */
+      create(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsCreate",
+                parameters: {
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Create items in batch, within a single vault.
+       */
+      createAll(vaultId, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsCreateAll",
+                parameters: {
+                  vault_id: vaultId,
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get an item by vault and item ID.
+       */
+      get(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsGet",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get items by vault and their item IDs.
+       */
+      getAll(vaultId, itemIds) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsGetAll",
+                parameters: {
+                  vault_id: vaultId,
+                  item_ids: itemIds
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Update an existing item.
+       */
+      put(item) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsPut",
+                parameters: {
+                  item
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Delete an item.
+       */
+      delete(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsDelete",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Delete items in batch, within a single vault.
+       */
+      deleteAll(vaultId, itemIds) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsDeleteAll",
+                parameters: {
+                  vault_id: vaultId,
+                  item_ids: itemIds
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Archive an item.
+       */
+      archive(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsArchive",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * List items based on filters.
+       */
+      list(vaultId, ...filters) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsList",
+                parameters: {
+                  vault_id: vaultId,
+                  filters
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports2.Items = Items;
+    _Items_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/vaults.js
+var require_vaults = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/vaults.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports2 && exports2.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports2 && exports2.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Vaults_inner;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.Vaults = void 0;
+    var types_js_1 = require_types();
+    var Vaults = class {
+      constructor(inner) {
+        _Vaults_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Vaults_inner, inner, "f");
+      }
+      /**
+       * Create a new user vault.
+       */
+      create(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsCreate",
+                parameters: {
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * List information about vaults that's configurable based on some input parameters.
+       */
+      list(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsList",
+                parameters: {
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get an overview of a vault by its ID.
+       */
+      getOverview(vaultId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsGetOverview",
+                parameters: {
+                  vault_id: vaultId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get detailed vault information by vault ID and parameters.
+       */
+      get(vaultId, vaultParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsGet",
+                parameters: {
+                  vault_id: vaultId,
+                  vault_params: vaultParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Update a vault
+       */
+      update(vaultId, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsUpdate",
+                parameters: {
+                  vault_id: vaultId,
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Delete a vault by its ID.
+       */
+      delete(vaultId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsDelete",
+                parameters: {
+                  vault_id: vaultId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Grant group permissions to a vault.
+       */
+      grantGroupPermissions(vaultId, groupPermissionsList) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsGrantGroupPermissions",
+                parameters: {
+                  vault_id: vaultId,
+                  group_permissions_list: groupPermissionsList
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Update group permissions for vaults.
+       */
+      updateGroupPermissions(groupPermissionsList) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsUpdateGroupPermissions",
+                parameters: {
+                  group_permissions_list: groupPermissionsList
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Revoke group permissions from a vault.
+       */
+      revokeGroupPermissions(vaultId, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsRevokeGroupPermissions",
+                parameters: {
+                  vault_id: vaultId,
+                  group_id: groupId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+    };
+    exports2.Vaults = Vaults;
+    _Vaults_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/groups.js
+var require_groups = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/groups.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports2 && exports2.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports2 && exports2.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Groups_inner;
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.Groups = void 0;
+    var types_js_1 = require_types();
+    var Groups = class {
+      constructor(inner) {
+        _Groups_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Groups_inner, inner, "f");
+      }
+      /**
+       * Get a group by its ID and parameters.
+       */
+      get(groupId, groupParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Groups_inner, "f").id,
+              parameters: {
+                name: "GroupsGet",
+                parameters: {
+                  group_id: groupId,
+                  group_params: groupParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Groups_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports2.Groups = Groups;
+    _Groups_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client.js
+var require_client2 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.Client = void 0;
+    var secrets_js_1 = require_secrets();
+    var items_js_1 = require_items();
+    var vaults_js_1 = require_vaults();
+    var groups_js_1 = require_groups();
+    var Client = class {
+      constructor(innerClient) {
+        this.secrets = new secrets_js_1.Secrets(innerClient);
+        this.items = new items_js_1.Items(innerClient);
+        this.vaults = new vaults_js_1.Vaults(innerClient);
+        this.groups = new groups_js_1.Groups(innerClient);
+      }
+    };
+    exports2.Client = Client;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/shared_lib_core.js
+var require_shared_lib_core = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/shared_lib_core.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      var desc = Object.getOwnPropertyDescriptor(m, k);
+      if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+        desc = { enumerable: true, get: function() {
+          return m[k];
+        } };
+      }
+      Object.defineProperty(o, k2, desc);
+    }) : (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      o[k2] = m[k];
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    }) : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports2 && exports2.__importStar || /* @__PURE__ */ (function() {
+      var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function(o2) {
+          var ar = [];
+          for (var k in o2) if (Object.prototype.hasOwnProperty.call(o2, k)) ar[ar.length] = k;
+          return ar;
+        };
+        return ownKeys(o);
+      };
+      return function(mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) {
+          for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        }
+        __setModuleDefault(result, mod);
+        return result;
+      };
+    })();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.SharedLibCore = void 0;
+    var fs4 = __importStar(require("fs"));
+    var os3 = __importStar(require("os"));
+    var path4 = __importStar(require("path"));
+    var errors_1 = require_errors3();
+    var find1PasswordLibPath = () => {
+      const platform = os3.platform();
+      const appRoot = path4.dirname(process.execPath);
+      let searchPaths = [];
+      switch (platform) {
+        case "darwin":
+          searchPaths = [
+            "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib",
+            path4.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
+          ];
+          break;
+        case "linux":
+          searchPaths = [
+            "/usr/bin/1password/libop_sdk_ipc_client.so",
+            "/opt/1Password/libop_sdk_ipc_client.so",
+            "/snap/bin/1password/libop_sdk_ipc_client.so"
+          ];
+          break;
+        case "win32":
+          searchPaths = [
+            path4.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
+            "C:/Program Files/1Password/app/8/op_sdk_ipc_client.dll",
+            "C:/Program Files (x86)/1Password/app/8/op_sdk_ipc_client.dll",
+            path4.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
+          ];
+          break;
+        default:
+          throw new Error(`Unsupported platform: ${platform}`);
+      }
+      for (const addonPath of searchPaths) {
+        if (fs4.existsSync(addonPath)) {
+          return addonPath;
+        }
+      }
+      throw new Error("1Password desktop application not found");
+    };
+    var SharedLibCore = class {
+      constructor(accountName) {
+        this.lib = null;
+        try {
+          const libPath = find1PasswordLibPath();
+          const moduleStub = { exports: {} };
+          process.dlopen(moduleStub, libPath);
+          if (typeof moduleStub === "object" && moduleStub !== null && typeof moduleStub.exports === "object" && moduleStub.exports !== null && "sendMessage" in moduleStub.exports && typeof moduleStub.exports.sendMessage === "function") {
+            this.lib = moduleStub.exports;
+          } else {
+            throw new Error("Failed to initialize native library: sendMessage function not found on module.");
+          }
+        } catch (e) {
+          console.error("A critical error occurred while loading the native addon:", e);
+          this.lib = null;
+        }
+        this.acccountName = accountName;
+      }
+      /**
+       * callSharedLibrary - send string to native function, receive string back.
+       */
+      callSharedLibrary(input, operation_type) {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (!this.lib) {
+            throw new Error("Native library is not available.");
+          }
+          if (!input || input.length === 0) {
+            throw new Error("internal: empty input");
+          }
+          const inputEncoded = Buffer.from(input, "utf8").toString("base64");
+          const req = {
+            account_name: this.acccountName,
+            kind: operation_type,
+            payload: inputEncoded
+          };
+          const inputBuf = Buffer.from(JSON.stringify(req), "utf8");
+          const nativeResponse = yield this.lib.sendMessage(inputBuf);
+          if (!(nativeResponse instanceof Uint8Array)) {
+            throw new Error(`Native function returned an unexpected type. Expected Uint8Array, got ${typeof nativeResponse}`);
+          }
+          const respString = new TextDecoder().decode(nativeResponse);
+          const response = JSON.parse(respString);
+          if (response.success) {
+            const decodedPayload = Buffer.from(response.payload).toString("utf8");
+            return decodedPayload;
+          } else {
+            const errorMessage = Array.isArray(response.payload) ? String.fromCharCode(...response.payload) : JSON.stringify(response.payload);
+            (0, errors_1.throwError)(errorMessage);
+          }
+        });
+      }
+      // Core interface implementation
+      initClient(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.callSharedLibrary(config, "init_client");
+        });
+      }
+      invoke(invokeConfigBytes) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.callSharedLibrary(invokeConfigBytes, "invoke");
+        });
+      }
+      releaseClient(clientId) {
+        this.callSharedLibrary(clientId, "release_client").catch((err) => {
+          console.warn("failed to release client:", err);
+        });
+      }
+    };
+    exports2.SharedLibCore = SharedLibCore;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client_builder.js
+var require_client_builder = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client_builder.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.createClientWithCore = void 0;
+    var core_js_1 = require_core3();
+    var configuration_js_1 = require_configuration();
+    var client_js_1 = require_client2();
+    var shared_lib_core_js_1 = require_shared_lib_core();
+    var finalizationRegistry = new FinalizationRegistry((heldClient) => {
+      heldClient.core.releaseClient(heldClient.id);
+    });
+    var createClientWithCore = (config, core2) => __awaiter(void 0, void 0, void 0, function* () {
+      const authConfig = (0, configuration_js_1.clientAuthConfig)(config);
+      if (authConfig.accountName) {
+        core2.setInner(new shared_lib_core_js_1.SharedLibCore(authConfig.accountName));
+      }
+      const clientId = yield core2.initClient(authConfig);
+      const inner = new core_js_1.InnerClient(parseInt(clientId, 10), core2, authConfig);
+      const client = new client_js_1.Client(inner);
+      finalizationRegistry.register(client, inner);
+      return client;
+    });
+    exports2.createClientWithCore = createClientWithCore;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/sdk.js
+var require_sdk = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/sdk.js"(exports2) {
+    "use strict";
+    init_cjs_shims();
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      var desc = Object.getOwnPropertyDescriptor(m, k);
+      if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+        desc = { enumerable: true, get: function() {
+          return m[k];
+        } };
+      }
+      Object.defineProperty(o, k2, desc);
+    }) : (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      o[k2] = m[k];
+    }));
+    var __exportStar = exports2 && exports2.__exportStar || function(m, exports3) {
+      for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports3, p)) __createBinding(exports3, m, p);
+    };
+    var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports2, "__esModule", { value: true });
+    exports2.createClient = exports2.DesktopAuth = exports2.Secrets = exports2.DEFAULT_INTEGRATION_VERSION = exports2.DEFAULT_INTEGRATION_NAME = void 0;
+    var core_js_1 = require_core3();
+    var client_builder_js_1 = require_client_builder();
+    exports2.DEFAULT_INTEGRATION_NAME = "Unknown";
+    exports2.DEFAULT_INTEGRATION_VERSION = "Unknown";
+    var secrets_js_1 = require_secrets();
+    Object.defineProperty(exports2, "Secrets", { enumerable: true, get: function() {
+      return secrets_js_1.Secrets;
+    } });
+    var configuration_js_1 = require_configuration();
+    Object.defineProperty(exports2, "DesktopAuth", { enumerable: true, get: function() {
+      return configuration_js_1.DesktopAuth;
+    } });
+    __exportStar(require_client2(), exports2);
+    __exportStar(require_errors3(), exports2);
+    __exportStar(require_types(), exports2);
+    var createClient = (config) => __awaiter(void 0, void 0, void 0, function* () {
+      return (0, client_builder_js_1.createClientWithCore)(config, new core_js_1.SharedCore());
+    });
+    exports2.createClient = createClient;
+  }
+});
+
 // ../../node_modules/.pnpm/@actions+github@7.0.0/node_modules/@actions/github/lib/context.js
 var require_context = __commonJS({
   "../../node_modules/.pnpm/@actions+github@7.0.0/node_modules/@actions/github/lib/context.js"(exports2) {
@@ -30978,8 +33329,8 @@ var require_context = __commonJS({
           if ((0, fs_1.existsSync)(process.env.GITHUB_EVENT_PATH)) {
             this.payload = JSON.parse((0, fs_1.readFileSync)(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
           } else {
-            const path2 = process.env.GITHUB_EVENT_PATH;
-            process.stdout.write(`GITHUB_EVENT_PATH ${path2} does not exist${os_1.EOL}`);
+            const path4 = process.env.GITHUB_EVENT_PATH;
+            process.stdout.write(`GITHUB_EVENT_PATH ${path4} does not exist${os_1.EOL}`);
           }
         }
         this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -31144,11 +33495,11 @@ var require_lib2 = __commonJS({
     })();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -31164,7 +33515,7 @@ var require_lib2 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -31208,11 +33559,11 @@ var require_lib2 = __commonJS({
       HttpCodes2[HttpCodes2["ServiceUnavailable"] = 503] = "ServiceUnavailable";
       HttpCodes2[HttpCodes2["GatewayTimeout"] = 504] = "GatewayTimeout";
     })(HttpCodes || (exports2.HttpCodes = HttpCodes = {}));
-    var Headers;
-    (function(Headers2) {
-      Headers2["Accept"] = "accept";
-      Headers2["ContentType"] = "content-type";
-    })(Headers || (exports2.Headers = Headers = {}));
+    var Headers2;
+    (function(Headers3) {
+      Headers3["Accept"] = "accept";
+      Headers3["ContentType"] = "content-type";
+    })(Headers2 || (exports2.Headers = Headers2 = {}));
     var MediaTypes;
     (function(MediaTypes2) {
       MediaTypes2["ApplicationJson"] = "application/json";
@@ -31251,26 +33602,26 @@ var require_lib2 = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve4(output.toString());
+              resolve6(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve4(Buffer.concat(chunks));
+              resolve6(Buffer.concat(chunks));
             });
           }));
         });
@@ -31365,7 +33716,7 @@ var require_lib2 = __commonJS({
        */
       getJson(requestUrl_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, additionalHeaders = {}) {
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
           const res = yield this.get(requestUrl, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31373,8 +33724,8 @@ var require_lib2 = __commonJS({
       postJson(requestUrl_1, obj_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, obj, additionalHeaders = {}) {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
           const res = yield this.post(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31382,8 +33733,8 @@ var require_lib2 = __commonJS({
       putJson(requestUrl_1, obj_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, obj, additionalHeaders = {}) {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
           const res = yield this.put(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31391,8 +33742,8 @@ var require_lib2 = __commonJS({
       patchJson(requestUrl_1, obj_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, obj, additionalHeaders = {}) {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
           const res = yield this.patch(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31478,14 +33829,14 @@ var require_lib2 = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve4(res);
+                resolve6(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -31622,7 +33973,7 @@ var require_lib2 = __commonJS({
       _getExistingOrDefaultContentTypeHeader(additionalHeaders, _default) {
         let clientHeader;
         if (this.requestOptions && this.requestOptions.headers) {
-          const headerValue = lowercaseKeys2(this.requestOptions.headers)[Headers.ContentType];
+          const headerValue = lowercaseKeys2(this.requestOptions.headers)[Headers2.ContentType];
           if (headerValue) {
             if (typeof headerValue === "number") {
               clientHeader = String(headerValue);
@@ -31633,7 +33984,7 @@ var require_lib2 = __commonJS({
             }
           }
         }
-        const additionalValue = additionalHeaders[Headers.ContentType];
+        const additionalValue = additionalHeaders[Headers2.ContentType];
         if (additionalValue !== void 0) {
           if (typeof additionalValue === "number") {
             return String(additionalValue);
@@ -31729,12 +34080,12 @@ var require_lib2 = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve4) => setTimeout(() => resolve4(), ms2));
+          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -31742,7 +34093,7 @@ var require_lib2 = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve4(response);
+              resolve6(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -31781,7 +34132,7 @@ var require_lib2 = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve4(response);
+              resolve6(response);
             }
           }));
         });
@@ -31836,11 +34187,11 @@ var require_utils4 = __commonJS({
     })();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -31856,7 +34207,7 @@ var require_utils4 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32731,16 +35082,16 @@ function fetchWrapper(requestOptions) {
   let headers = {};
   let status;
   let url;
-  let { fetch } = globalThis;
+  let { fetch: fetch2 } = globalThis;
   if (requestOptions.request?.fetch) {
-    fetch = requestOptions.request.fetch;
+    fetch2 = requestOptions.request.fetch;
   }
-  if (!fetch) {
+  if (!fetch2) {
     throw new Error(
       "fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}). Learn more at https://github.com/octokit/octokit.js/#fetch-missing"
     );
   }
-  return fetch(requestOptions.url, {
+  return fetch2(requestOptions.url, {
     method: requestOptions.method,
     body: requestOptions.body,
     redirect: requestOptions.request?.redirect,
@@ -35929,9 +38280,9 @@ var import_node_path = require("path");
 // ../core/dist/index.js
 init_cjs_shims();
 var fs = __toESM(require("fs"), 1);
-var import_fs2 = require("fs");
+var import_fs3 = require("fs");
 var path3 = __toESM(require("path"), 1);
-var import_path3 = require("path");
+var import_path4 = require("path");
 var import_semver = __toESM(require_semver2(), 1);
 var import_yaml = __toESM(require_dist(), 1);
 
@@ -36428,8 +38779,8 @@ function getErrorMap() {
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js
 init_cjs_shims();
 var makeIssue = (params) => {
-  const { data, path: path2, errorMaps, issueData } = params;
-  const fullPath = [...path2, ...issueData.path || []];
+  const { data, path: path4, errorMaps, issueData } = params;
+  const fullPath = [...path4, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -36549,11 +38900,11 @@ var errorUtil;
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path2, key) {
+  constructor(parent, value, path4, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path2;
+    this._path = path4;
     this._key = key;
   }
   get path() {
@@ -40494,7 +42845,7 @@ var MigrationGraphImpl = class {
         hasIrreversibleStep: false
       };
     }
-    const path2 = findPath(
+    const path4 = findPath(
       normalizedFrom,
       normalizedTo,
       this.adjacencyList,
@@ -40502,10 +42853,10 @@ var MigrationGraphImpl = class {
       this.versionStrategy,
       (from, to) => this.getMigrationKey(from, to)
     );
-    if (!path2) {
+    if (!path4) {
       throw new NoPathError(fromVersion, toVersion);
     }
-    return path2;
+    return path4;
   }
   migrate(data, fromVersion, toVersion, options = {}) {
     const startTime = performance.now();
@@ -40534,12 +42885,12 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path2;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path2 = this.getPath(normalizedFrom, normalizedTo);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path2, pathDuration);
+      this.telemetry?.onPathComputed?.(path4, pathDuration);
     } catch (err) {
       return {
         success: false,
@@ -40549,27 +42900,27 @@ var MigrationGraphImpl = class {
         error: err
       };
     }
-    if (path2.steps.length === 0) {
+    if (path4.steps.length === 0) {
       return {
         success: true,
         data,
-        path: path2,
+        path: path4,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
     }
-    const context = createMigrationContext(path2.steps.length, options.initialStash);
+    const context = createMigrationContext(path4.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path2.steps.length; i++) {
-      const step = path2.steps[i];
+    for (let i = 0; i < path4.steps.length; i++) {
+      const step = path4.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path2.steps.length
+        totalSteps: path4.steps.length
       });
-      this.telemetry?.onStepStart?.(step, i, path2.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
       const stepStartTime = performance.now();
       try {
         if (step.direction === "up") {
@@ -40594,20 +42945,20 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, step, context);
         return {
           success: false,
-          path: path2,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: error2
         };
       }
-      if (options.validateIntermediate && i < path2.steps.length - 1) {
+      if (options.validateIntermediate && i < path4.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             return {
               success: false,
-              path: path2,
+              path: path4,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -40631,7 +42982,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, null, context);
         const result2 = {
           success: false,
-          path: path2,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -40651,7 +43002,7 @@ var MigrationGraphImpl = class {
           this.telemetry?.onError?.(error2, null, context);
           const result2 = {
             success: false,
-            path: path2,
+            path: path4,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -40667,7 +43018,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path2,
+      path: path4,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -40699,11 +43050,11 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path2;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path2 = this.getPath(normalizedFrom, normalizedTo);
-      this.telemetry?.onPathComputed?.(path2, performance.now() - pathStartTime);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
+      this.telemetry?.onPathComputed?.(path4, performance.now() - pathStartTime);
     } catch (err) {
       const result2 = {
         success: false,
@@ -40715,30 +43066,30 @@ var MigrationGraphImpl = class {
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    if (path2.steps.length === 0) {
+    if (path4.steps.length === 0) {
       const result2 = {
         success: true,
         data,
-        path: path2,
+        path: path4,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    const context = createMigrationContext(path2.steps.length, options.initialStash);
+    const context = createMigrationContext(path4.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path2.steps.length; i++) {
-      const step = path2.steps[i];
+    for (let i = 0; i < path4.steps.length; i++) {
+      const step = path4.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path2.steps.length
+        totalSteps: path4.steps.length
       });
       const stepStartTime = performance.now();
-      this.telemetry?.onStepStart?.(step, i, path2.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
       try {
         if (step.direction === "up") {
           const result2 = step.migration.up(currentData, context);
@@ -40753,7 +43104,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(err, step, context);
         const result2 = {
           success: false,
-          path: path2,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: new MigrationError(
@@ -40769,14 +43120,14 @@ var MigrationGraphImpl = class {
         this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
         return result2;
       }
-      if (options.validateIntermediate && i < path2.steps.length - 1) {
+      if (options.validateIntermediate && i < path4.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             const result2 = {
               success: false,
-              path: path2,
+              path: path4,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -40797,7 +43148,7 @@ var MigrationGraphImpl = class {
       if (!validation.success) {
         const result2 = {
           success: false,
-          path: path2,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -40814,7 +43165,7 @@ var MigrationGraphImpl = class {
         if (!validation.success) {
           const result2 = {
             success: false,
-            path: path2,
+            path: path4,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -40832,7 +43183,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path2,
+      path: path4,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -40844,12 +43195,12 @@ var MigrationGraphImpl = class {
   migrateMany(data, fromVersion, toVersion, options = {}) {
     const normalizedFrom = this.normalizeVersion(fromVersion);
     const normalizedTo = this.normalizeVersion(toVersion);
-    let path2;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path2 = this.getPath(normalizedFrom, normalizedTo);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path2, pathDuration);
+      this.telemetry?.onPathComputed?.(path4, pathDuration);
     } catch {
       return {
         total: 0,
@@ -40875,7 +43226,7 @@ var MigrationGraphImpl = class {
           for (let j = i + 1; j < items.length; j++) {
             results.push({
               success: false,
-              path: path2,
+              path: path4,
               stash: { consumed: [], unconsumed: [], lossless: true },
               preservedFields: [],
               error: new MigrationError(
@@ -40896,7 +43247,7 @@ var MigrationGraphImpl = class {
       succeeded,
       failed,
       results,
-      path: path2
+      path: path4
     };
   }
   getVersions() {
@@ -40976,8 +43327,8 @@ function createMigrationGraph(options) {
 
 // ../../node_modules/.pnpm/@migrex+zod@1.0.0-alpha.1_@migrex+core@0.2.0-alpha.1_zod@3.25.76/node_modules/@migrex/zod/dist/index.js
 init_cjs_shims();
-function pathToStringArray(path2) {
-  return path2.map((p) => String(p));
+function pathToStringArray(path4) {
+  return path4.map((p) => String(p));
 }
 function zodErrorToValidationErrors(error2) {
   return error2.issues.map((issue) => ({
@@ -41011,7 +43362,7 @@ function fromZod(version2, zodSchema, options) {
 // ../core/dist/index.js
 var fs2 = __toESM(require("fs/promises"), 1);
 var import_promises = require("fs/promises");
-var crypto3 = __toESM(require("crypto"), 1);
+var crypto22 = __toESM(require("crypto"), 1);
 
 // ../../node_modules/.pnpm/tinyglobby@0.2.15/node_modules/tinyglobby/dist/index.mjs
 init_cjs_shims();
@@ -41025,27 +43376,27 @@ var import_module = require("module");
 var import_path = require("path");
 var nativeFs = __toESM(require("fs"), 1);
 var __require = /* @__PURE__ */ (0, import_module.createRequire)(importMetaUrl);
-function cleanPath(path2) {
-  let normalized = (0, import_path.normalize)(path2);
+function cleanPath(path4) {
+  let normalized = (0, import_path.normalize)(path4);
   if (normalized.length > 1 && normalized[normalized.length - 1] === import_path.sep) normalized = normalized.substring(0, normalized.length - 1);
   return normalized;
 }
 var SLASHES_REGEX = /[\\/]/g;
-function convertSlashes(path2, separator) {
-  return path2.replace(SLASHES_REGEX, separator);
+function convertSlashes(path4, separator) {
+  return path4.replace(SLASHES_REGEX, separator);
 }
 var WINDOWS_ROOT_DIR_REGEX = /^[a-z]:[\\/]$/i;
-function isRootDirectory(path2) {
-  return path2 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path2);
+function isRootDirectory(path4) {
+  return path4 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path4);
 }
-function normalizePath(path2, options) {
+function normalizePath(path4, options) {
   const { resolvePaths, normalizePath: normalizePath$1, pathSeparator } = options;
-  const pathNeedsCleaning = process.platform === "win32" && path2.includes("/") || path2.startsWith(".");
-  if (resolvePaths) path2 = (0, import_path.resolve)(path2);
-  if (normalizePath$1 || pathNeedsCleaning) path2 = cleanPath(path2);
-  if (path2 === ".") return "";
-  const needsSeperator = path2[path2.length - 1] !== pathSeparator;
-  return convertSlashes(needsSeperator ? path2 + pathSeparator : path2, pathSeparator);
+  const pathNeedsCleaning = process.platform === "win32" && path4.includes("/") || path4.startsWith(".");
+  if (resolvePaths) path4 = (0, import_path.resolve)(path4);
+  if (normalizePath$1 || pathNeedsCleaning) path4 = cleanPath(path4);
+  if (path4 === ".") return "";
+  const needsSeperator = path4[path4.length - 1] !== pathSeparator;
+  return convertSlashes(needsSeperator ? path4 + pathSeparator : path4, pathSeparator);
 }
 function joinPathWithBasePath(filename, directoryPath) {
   return directoryPath + filename;
@@ -41082,8 +43433,8 @@ var pushDirectory = (directoryPath, paths) => {
   paths.push(directoryPath || ".");
 };
 var pushDirectoryFilter = (directoryPath, paths, filters) => {
-  const path2 = directoryPath || ".";
-  if (filters.every((filter) => filter(path2, true))) paths.push(path2);
+  const path4 = directoryPath || ".";
+  if (filters.every((filter) => filter(path4, true))) paths.push(path4);
 };
 var empty$2 = () => {
 };
@@ -41135,26 +43486,26 @@ var empty = () => {
 function build$3(options) {
   return options.group ? groupFiles : empty;
 }
-var resolveSymlinksAsync = function(path2, state, callback$1) {
-  const { queue, fs: fs3, options: { suppressErrors } } = state;
+var resolveSymlinksAsync = function(path4, state, callback$1) {
+  const { queue, fs: fs4, options: { suppressErrors } } = state;
   queue.enqueue();
-  fs3.realpath(path2, (error2, resolvedPath) => {
+  fs4.realpath(path4, (error2, resolvedPath) => {
     if (error2) return queue.dequeue(suppressErrors ? null : error2, state);
-    fs3.stat(resolvedPath, (error$1, stat3) => {
+    fs4.stat(resolvedPath, (error$1, stat3) => {
       if (error$1) return queue.dequeue(suppressErrors ? null : error$1, state);
-      if (stat3.isDirectory() && isRecursive(path2, resolvedPath, state)) return queue.dequeue(null, state);
+      if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return queue.dequeue(null, state);
       callback$1(stat3, resolvedPath);
       queue.dequeue(null, state);
     });
   });
 };
-var resolveSymlinks = function(path2, state, callback$1) {
-  const { queue, fs: fs3, options: { suppressErrors } } = state;
+var resolveSymlinks = function(path4, state, callback$1) {
+  const { queue, fs: fs4, options: { suppressErrors } } = state;
   queue.enqueue();
   try {
-    const resolvedPath = fs3.realpathSync(path2);
-    const stat3 = fs3.statSync(resolvedPath);
-    if (stat3.isDirectory() && isRecursive(path2, resolvedPath, state)) return;
+    const resolvedPath = fs4.realpathSync(path4);
+    const stat3 = fs4.statSync(resolvedPath);
+    if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return;
     callback$1(stat3, resolvedPath);
   } catch (e) {
     if (!suppressErrors) throw e;
@@ -41164,9 +43515,9 @@ function build$2(options, isSynchronous) {
   if (!options.resolveSymlinks || options.excludeSymlinks) return null;
   return isSynchronous ? resolveSymlinks : resolveSymlinksAsync;
 }
-function isRecursive(path2, resolved, state) {
+function isRecursive(path4, resolved, state) {
   if (state.options.useRealPaths) return isRecursiveUsingRealPaths(resolved, state);
-  let parent = (0, import_path.dirname)(path2);
+  let parent = (0, import_path.dirname)(path4);
   let depth = 1;
   while (parent !== state.root && depth < 2) {
     const resolvedPath = state.symlinks.get(parent);
@@ -41174,7 +43525,7 @@ function isRecursive(path2, resolved, state) {
     if (isSameRoot) depth++;
     else parent = (0, import_path.dirname)(parent);
   }
-  state.symlinks.set(path2, resolved);
+  state.symlinks.set(path4, resolved);
   return depth > 1;
 }
 function isRecursiveUsingRealPaths(resolved, state) {
@@ -41223,22 +43574,22 @@ var readdirOpts = { withFileTypes: true };
 var walkAsync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
   state.queue.enqueue();
   if (currentDepth < 0) return state.queue.dequeue(null, state);
-  const { fs: fs3 } = state;
+  const { fs: fs4 } = state;
   state.visited.push(crawlPath);
   state.counts.directories++;
-  fs3.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
+  fs4.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
     callback$1(entries, directoryPath, currentDepth);
     state.queue.dequeue(state.options.suppressErrors ? null : error2, state);
   });
 };
 var walkSync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
-  const { fs: fs3 } = state;
+  const { fs: fs4 } = state;
   if (currentDepth < 0) return;
   state.visited.push(crawlPath);
   state.counts.directories++;
   let entries = [];
   try {
-    entries = fs3.readdirSync(crawlPath || ".", readdirOpts);
+    entries = fs4.readdirSync(crawlPath || ".", readdirOpts);
   } catch (e) {
     if (!state.options.suppressErrors) throw e;
   }
@@ -41346,19 +43697,19 @@ var Walker = class {
         const filename = this.joinPath(entry.name, directoryPath);
         this.pushFile(filename, files, this.state.counts, filters);
       } else if (entry.isDirectory()) {
-        let path2 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
-        if (exclude && exclude(entry.name, path2)) continue;
-        this.pushDirectory(path2, paths, filters);
-        this.walkDirectory(this.state, path2, path2, depth - 1, this.walk);
+        let path4 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
+        if (exclude && exclude(entry.name, path4)) continue;
+        this.pushDirectory(path4, paths, filters);
+        this.walkDirectory(this.state, path4, path4, depth - 1, this.walk);
       } else if (this.resolveSymlink && entry.isSymbolicLink()) {
-        let path2 = joinPathWithBasePath(entry.name, directoryPath);
-        this.resolveSymlink(path2, this.state, (stat3, resolvedPath) => {
+        let path4 = joinPathWithBasePath(entry.name, directoryPath);
+        this.resolveSymlink(path4, this.state, (stat3, resolvedPath) => {
           if (stat3.isDirectory()) {
             resolvedPath = normalizePath(resolvedPath, this.state.options);
-            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path2 + pathSeparator)) return;
-            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path2 + pathSeparator, depth - 1, this.walk);
+            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path4 + pathSeparator)) return;
+            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path4 + pathSeparator, depth - 1, this.walk);
           } else {
-            resolvedPath = useRealPaths ? resolvedPath : path2;
+            resolvedPath = useRealPaths ? resolvedPath : path4;
             const filename = (0, import_path.basename)(resolvedPath);
             const directoryPath$1 = normalizePath((0, import_path.dirname)(resolvedPath), this.state.options);
             resolvedPath = this.joinPath(filename, directoryPath$1);
@@ -41524,7 +43875,7 @@ var Builder = class {
       isMatch = globFn(patterns, ...options);
       this.globCache[patterns.join("\0")] = isMatch;
     }
-    this.options.filters.push((path2) => isMatch(path2));
+    this.options.filters.push((path4) => isMatch(path4));
     return this;
   }
 };
@@ -41797,18 +44148,1967 @@ async function glob(patternsOrOptions, options) {
 }
 
 // ../core/dist/index.js
-var import_child_process = require("child_process");
-var import_stream = require("stream");
+var os2 = __toESM(require("os"), 1);
+
+// ../../node_modules/.pnpm/vaultkeeper@0.7.0_@1password+sdk@0.4.0_@types+node@22.19.3/node_modules/vaultkeeper/dist/index.js
+init_cjs_shims();
+var fs3 = __toESM(require("fs/promises"), 1);
+var path2 = __toESM(require("path"), 1);
+var import_path3 = require("path");
 var os = __toESM(require("os"), 1);
-var import_os = require("os");
+var crypto2 = __toESM(require("crypto"), 1);
+var import_child_process = require("child_process");
+var import_url2 = require("url");
+var import_fs2 = require("fs");
+var VaultError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "VaultError";
+  }
+};
+var BackendLockedError = class extends VaultError {
+  /**
+   * Whether the lock can be resolved through an interactive user prompt.
+   * When `true`, callers may retry after prompting the user.
+   */
+  interactive;
+  constructor(message, interactive) {
+    super(message);
+    this.name = "BackendLockedError";
+    this.interactive = interactive;
+  }
+};
+var DeviceNotPresentError = class extends VaultError {
+  /**
+   * How long (in milliseconds) the operation waited for the device before
+   * giving up.
+   */
+  timeoutMs;
+  constructor(message, timeoutMs) {
+    super(message);
+    this.name = "DeviceNotPresentError";
+    this.timeoutMs = timeoutMs;
+  }
+};
+var AuthorizationDeniedError = class extends VaultError {
+  constructor(message) {
+    super(message);
+    this.name = "AuthorizationDeniedError";
+  }
+};
+var PresenceDeclinedError = class extends VaultError {
+  /** The `type` identifier of the backend that requested the presence action. */
+  backendType;
+  constructor(message, backendType) {
+    super(message);
+    this.name = "PresenceDeclinedError";
+    this.backendType = backendType;
+  }
+};
+var PresenceTimeoutError = class extends VaultError {
+  /** The `type` identifier of the backend that requested the presence action. */
+  backendType;
+  /** How long (in milliseconds) the operation waited for the presence action. */
+  timeoutMs;
+  constructor(message, backendType, timeoutMs) {
+    super(message);
+    this.name = "PresenceTimeoutError";
+    this.backendType = backendType;
+    this.timeoutMs = timeoutMs;
+  }
+};
+var BackendUnavailableError = class extends VaultError {
+  /**
+   * Machine-readable reason code describing why the backend is unavailable
+   * (e.g. `'none-enabled'`, `'all-failed'`).
+   */
+  reason;
+  /**
+   * The backend type identifiers that were attempted before this error was
+   * thrown.
+   */
+  attempted;
+  constructor(message, reason, attempted) {
+    super(message);
+    this.name = "BackendUnavailableError";
+    this.reason = reason;
+    this.attempted = attempted;
+  }
+};
+var PluginNotFoundError = class extends VaultError {
+  /**
+   * The plugin package or binary name that was not found.
+   */
+  plugin;
+  /**
+   * A URL pointing to installation instructions for the missing plugin.
+   */
+  installUrl;
+  constructor(message, plugin, installUrl) {
+    super(message);
+    this.name = "PluginNotFoundError";
+    this.plugin = plugin;
+    this.installUrl = installUrl;
+  }
+};
+var SecretNotFoundError = class extends VaultError {
+  constructor(message) {
+    super(message);
+    this.name = "SecretNotFoundError";
+  }
+};
+var ExecError = class extends VaultError {
+  /**
+   * The command that failed to execute.
+   */
+  command;
+  constructor(message, command) {
+    super(message);
+    this.name = "ExecError";
+    this.command = command;
+  }
+};
+var InvalidAlgorithmError = class extends VaultError {
+  /**
+   * The algorithm that was requested.
+   */
+  algorithm;
+  /**
+   * The set of algorithms that are allowed.
+   */
+  allowed;
+  constructor(message, algorithm, allowed) {
+    super(message);
+    this.name = "InvalidAlgorithmError";
+    this.algorithm = algorithm;
+    this.allowed = allowed;
+  }
+};
+var InvalidKeyMaterialError = class extends VaultError {
+  constructor(message) {
+    super(message);
+    this.name = "InvalidKeyMaterialError";
+  }
+};
+var SigningKeyNotFoundError = class extends VaultError {
+  /**
+   * The signing-key name that was requested (the caller-facing `--name`, not
+   * the internal namespaced identifier).
+   */
+  keyName;
+  constructor(message, keyName) {
+    super(message);
+    this.name = "SigningKeyNotFoundError";
+    this.keyName = keyName;
+  }
+};
+var SigningKeyAlreadyExistsError = class extends VaultError {
+  /**
+   * The signing-key name that already exists (the caller-facing `--name`, not
+   * the internal namespaced identifier).
+   */
+  keyName;
+  constructor(message, keyName) {
+    super(message);
+    this.name = "SigningKeyAlreadyExistsError";
+    this.keyName = keyName;
+  }
+};
+var DecryptionError = class extends VaultError {
+  /**
+   * The path of the encrypted entry that failed to decrypt.
+   */
+  path;
+  constructor(message, path9) {
+    super(message);
+    this.name = "DecryptionError";
+    this.path = path9;
+  }
+};
+var ConfigValidationError = class extends VaultError {
+  /**
+   * The dotted/bracketed path to the offending config field (e.g.
+   * `'backends[0].path'`).
+   */
+  field;
+  /**
+   * The path of the config file that failed validation, when the error
+   * originated from loading a file on disk (via `loadConfig`) rather than
+   * from validating an in-memory value directly. This is `configDir` joined
+   * with `config.json` exactly as provided to `loadConfig` — it is not
+   * guaranteed to be absolute (`loadConfig` does not resolve a relative
+   * `configDir`).
+   */
+  configFilePath;
+  constructor(message, field, configFilePath) {
+    super(message);
+    this.name = "ConfigValidationError";
+    this.field = field;
+    this.configFilePath = configFilePath;
+  }
+};
+var SetupError = class extends VaultError {
+  /**
+   * The name of the dependency that caused the setup failure.
+   */
+  dependency;
+  constructor(message, dependency) {
+    super(message);
+    this.name = "SetupError";
+    this.dependency = dependency;
+  }
+};
+var FilesystemError = class extends VaultError {
+  /**
+   * The path of the file or directory that caused the error, as provided by
+   * the caller. Not guaranteed to be absolute — e.g. `loadConfig` throws this
+   * with `configDir` joined with `config.json` exactly as given, without
+   * resolving a relative `configDir`.
+   */
+  path;
+  /**
+   * The file operation or access mode that was being attempted when the
+   * failure occurred, for example 'read', 'write', 'delete', or 'rwx' for a
+   * directory create/access check. Despite the field name, this does not
+   * imply the failure was itself a permission problem — it names the
+   * attempted operation regardless of the underlying errno, which may be a
+   * non-permission code such as ENOSPC or EISDIR.
+   */
+  permission;
+  /**
+   * The Node.js errno code from the underlying filesystem failure, for
+   * example EACCES, EPERM, ENOSPC, or EISDIR. Undefined when the error was
+   * constructed without an underlying cause, or when that cause did not
+   * expose a string errno code. Prefer this over parsing the message text,
+   * which is not a contractual format.
+   */
+  code;
+  /**
+   * @param message - Human-readable description of the failure.
+   * @param filePath - The path of the file or directory that caused the error.
+   * @param permission - The file operation or access mode being attempted,
+   * for example 'read', 'write', 'delete', or 'rwx'. See the `permission`
+   * property for why this need not indicate an actual permission problem.
+   * @param cause - The underlying error that was caught, if any. Recorded as
+   * the standard `Error.cause` and used to populate `code` when it exposes a
+   * string errno code.
+   */
+  constructor(message, filePath, permission, cause) {
+    super(message);
+    this.name = "FilesystemError";
+    this.path = filePath;
+    this.permission = permission;
+    this.code = hasErrnoCode(cause) ? cause.code : void 0;
+    if (cause !== void 0) {
+      Object.defineProperty(this, "cause", {
+        value: cause,
+        writable: true,
+        enumerable: false,
+        configurable: true
+      });
+    }
+  }
+};
+function hasErrnoCode(err) {
+  return err instanceof Error && "code" in err && typeof err.code === "string";
+}
+function toFilesystemError(err, resourceLabel, filePath, permission) {
+  const detail = err instanceof Error ? err.message : String(err);
+  return new FilesystemError(
+    `Failed to ${permission} ${resourceLabel} at ${filePath}: ${detail}`,
+    filePath,
+    permission,
+    err
+  );
+}
+var BackendRegistry = class {
+  static backends = /* @__PURE__ */ new Map();
+  static setups = /* @__PURE__ */ new Map();
+  /**
+   * Register a backend factory.
+   * @param type - Backend type identifier
+   * @param factory - Factory function to create backend instances
+   */
+  static register(type, factory) {
+    this.backends.set(type, factory);
+  }
+  /**
+   * Create a backend instance by type.
+   * @param type - Backend type identifier
+   * @param config - Optional backend configuration forwarded to the factory
+   * @param configDir - Optional resolved config directory forwarded to the
+   *   factory, so file-based backends can default their storage under it
+   * @returns A SecretBackend instance
+   * @throws {@link BackendUnavailableError} if the backend type is not registered
+   */
+  static create(type, config, configDir) {
+    const factory = this.backends.get(type);
+    if (factory === void 0) {
+      throw new BackendUnavailableError(
+        `Unknown backend type: ${type}. Available types: ${Array.from(this.backends.keys()).join(", ")}`,
+        "unknown-type",
+        Array.from(this.backends.keys())
+      );
+    }
+    return factory(config, configDir);
+  }
+  /**
+   * Get all registered backend type identifiers.
+   * @returns Array of backend type identifiers
+   */
+  static getTypes() {
+    return Array.from(this.backends.keys());
+  }
+  /**
+   * Returns backend types that are available on the current system.
+   *
+   * @remarks
+   * Creates each registered backend via its factory, calls `isAvailable()`,
+   * and returns only the type identifiers whose backend reports availability.
+   * If a backend's `isAvailable()` call throws, that backend is excluded from
+   * the result rather than propagating the error.
+   *
+   * @returns Promise resolving to an array of available backend type identifiers
+   * @public
+   */
+  static async getAvailableTypes() {
+    const entries = Array.from(this.backends.entries());
+    const results = await Promise.all(
+      entries.map(async ([type, factory]) => {
+        try {
+          const backend = factory();
+          const available = await backend.isAvailable();
+          return available ? type : null;
+        } catch {
+          return null;
+        }
+      })
+    );
+    return results.filter((type) => type !== null);
+  }
+  /**
+   * Register a setup factory for a backend type.
+   * @param type - Backend type identifier
+   * @param factory - Factory function that creates a setup generator
+   */
+  static registerSetup(type, factory) {
+    this.setups.set(type, factory);
+  }
+  /**
+   * Get the setup factory for a backend type, if one is registered.
+   * @param type - Backend type identifier
+   * @returns The setup factory, or `undefined` if none is registered
+   */
+  static getSetup(type) {
+    return this.setups.get(type);
+  }
+  /**
+   * Check whether a setup factory is registered for the given backend type.
+   * @param type - Backend type identifier
+   * @returns `true` if a setup factory is registered
+   */
+  static hasSetup(type) {
+    return this.setups.has(type);
+  }
+  /**
+   * Clear all registered backend factories.
+   * Intended for use in tests only.
+   * @internal
+   */
+  static clearBackends() {
+    this.backends.clear();
+  }
+  /**
+   * Clear all registered setup factories.
+   * Intended for use in tests only.
+   * @internal
+   */
+  static clearSetups() {
+    this.setups.clear();
+  }
+};
+var GCM_IV_BYTES = 12;
+var GCM_KEY_BYTES = 32;
+var GCM_TAG_LENGTH_BITS = 128;
+function encryptGcm(key, plaintext) {
+  const iv = crypto2.randomBytes(GCM_IV_BYTES);
+  const cipher = crypto2.createCipheriv("aes-256-gcm", key, iv, {
+    authTagLength: GCM_TAG_LENGTH_BITS / 8
+  });
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [iv.toString("base64"), authTag.toString("base64"), encrypted.toString("base64")].join(":");
+}
+function decryptGcm(key, encoded, path9 = "") {
+  const parts = encoded.split(":");
+  if (parts.length !== 3) {
+    throw new DecryptionError("Invalid encrypted envelope: expected iv:authTag:ciphertext", path9);
+  }
+  const [ivB64, authTagB64, ciphertextB64] = parts;
+  if (ivB64 === void 0 || authTagB64 === void 0 || ciphertextB64 === void 0) {
+    throw new DecryptionError("Invalid encrypted envelope: missing part", path9);
+  }
+  const iv = Buffer.from(ivB64, "base64");
+  const authTag = Buffer.from(authTagB64, "base64");
+  const ciphertext = Buffer.from(ciphertextB64, "base64");
+  try {
+    const decipher = crypto2.createDecipheriv("aes-256-gcm", key, iv, {
+      authTagLength: GCM_TAG_LENGTH_BITS / 8
+    });
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return decrypted.toString("utf8");
+  } catch (err) {
+    throw new DecryptionError(
+      `Failed to decrypt envelope: ${err instanceof Error ? err.message : String(err)}`,
+      path9
+    );
+  }
+}
+async function getOrCreateWrapKey(keyPath) {
+  let existing;
+  try {
+    existing = await fs3.readFile(keyPath);
+  } catch (err) {
+    if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+      throw toFilesystemError(err, "wrapping key file", keyPath, "read");
+    }
+  }
+  if (existing?.byteLength === GCM_KEY_BYTES) {
+    return existing;
+  }
+  const key = crypto2.randomBytes(GCM_KEY_BYTES);
+  try {
+    await fs3.writeFile(keyPath, key, { mode: 384 });
+  } catch (err) {
+    throw toFilesystemError(err, "wrapping key file", keyPath, "write");
+  }
+  return key;
+}
+function getPlatformDefaultConfigDir() {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA;
+    if (appData !== void 0) {
+      return path2.join(appData, "vaultkeeper");
+    }
+    return path2.join(os.homedir(), "AppData", "Roaming", "vaultkeeper");
+  }
+  return path2.join(os.homedir(), ".config", "vaultkeeper");
+}
+function getDefaultConfigDir() {
+  const envOverride = process.env.VAULTKEEPER_CONFIG_DIR;
+  if (envOverride !== void 0 && envOverride !== "") {
+    return envOverride;
+  }
+  return getPlatformDefaultConfigDir();
+}
+var STORAGE_DIR_NAME = "file";
+var KEY_FILE = ".key";
+var SIGNING_DIR_NAME = "signing-keys";
+var SIGNING_KEY_PREFIX = "signing-key:";
+var SUPPORTED_SIGNING_ALGORITHMS = ["EdDSA"];
+function computeKid(spkiDer) {
+  return crypto2.createHash("sha256").update(spkiDer).digest("base64url");
+}
+function displayKeyName(id) {
+  return id.startsWith(SIGNING_KEY_PREFIX) ? id.slice(SIGNING_KEY_PREFIX.length) : id;
+}
+function legacyStorageDir() {
+  return path2.join(os.homedir(), ".vaultkeeper", "file");
+}
+function resolveStorageDir(configuredPath, configDir) {
+  if (configuredPath !== void 0) {
+    return configuredPath;
+  }
+  return path2.join(configDir ?? getDefaultConfigDir(), STORAGE_DIR_NAME);
+}
+function getEntryPath(storageDir, id) {
+  const safeId = Buffer.from(id, "utf8").toString("hex");
+  return path2.join(storageDir, `${safeId}.enc`);
+}
+async function ensureStorageDir(storageDir) {
+  try {
+    await fs3.mkdir(storageDir, { recursive: true, mode: 448 });
+  } catch (err) {
+    throw new FilesystemError(
+      `Failed to create storage directory: ${storageDir}`,
+      storageDir,
+      "rwx",
+      err
+    );
+  }
+}
+async function getOrCreateKey(storageDir) {
+  return getOrCreateWrapKey(path2.join(storageDir, KEY_FILE));
+}
+var FileBackend = class _FileBackend {
+  type = "file";
+  displayName = "Encrypted File Store";
+  #storageDir;
+  /** Directory holding encrypted signing-key private material. */
+  #signingDir;
+  /**
+   * Pre-#99 default storage directory, consulted as a read-only fallback
+   * when `storageDir` was not explicitly configured. `undefined` when an
+   * explicit `storageDir` was given — an explicit path never falls back.
+   */
+  #legacyStorageDir;
+  /**
+   * @param storageDir - Directory in which encrypted secrets are stored.
+   *   Sourced from `BackendConfig.path`. Defaults to `<configDir>/file`.
+   * @param configDir - Resolved config directory, used to compute the
+   *   default `storageDir` when one is not explicitly provided. Ignored when
+   *   `storageDir` is given. Defaults to `getDefaultConfigDir()`.
+   */
+  constructor(storageDir, configDir) {
+    this.#storageDir = resolveStorageDir(storageDir, configDir);
+    this.#legacyStorageDir = storageDir === void 0 ? legacyStorageDir() : void 0;
+    this.#signingDir = path2.join(this.#storageDir, SIGNING_DIR_NAME);
+  }
+  async isAvailable() {
+    try {
+      await ensureStorageDir(this.#storageDir);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const storageDir = this.#storageDir;
+    await ensureStorageDir(storageDir);
+    const key = await getOrCreateKey(storageDir);
+    const entryPath = getEntryPath(storageDir, id);
+    const encrypted = encryptGcm(key, secret);
+    try {
+      await fs3.writeFile(entryPath, encrypted, { mode: 384 });
+    } catch (err) {
+      throw toFilesystemError(err, "secret file", entryPath, "write");
+    }
+  }
+  /**
+   * Attempt to read and decrypt the entry for `id` from `storageDir`.
+   * Returns `undefined` (rather than throwing) when the entry does not
+   * exist in `storageDir`, so callers can probe a fallback location.
+   */
+  async #tryRetrieveFrom(storageDir, id) {
+    const entryPath = getEntryPath(storageDir, id);
+    let encoded;
+    try {
+      encoded = await fs3.readFile(entryPath, "utf8");
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        return void 0;
+      }
+      throw toFilesystemError(err, "secret file", entryPath, "read");
+    }
+    const key = await getOrCreateKey(storageDir);
+    try {
+      return decryptGcm(key, encoded, entryPath);
+    } catch (err) {
+      throw new DecryptionError(
+        `Failed to decrypt secret: ${err instanceof Error ? err.message : String(err)}`,
+        entryPath
+      );
+    }
+  }
+  async retrieve(id) {
+    const fromPrimary = await this.#tryRetrieveFrom(this.#storageDir, id);
+    if (fromPrimary !== void 0) {
+      return fromPrimary;
+    }
+    if (this.#legacyStorageDir !== void 0) {
+      const fromLegacy = await this.#tryRetrieveFrom(this.#legacyStorageDir, id);
+      if (fromLegacy !== void 0) {
+        return fromLegacy;
+      }
+    }
+    throw new SecretNotFoundError(`Secret not found in file store: ${id}`);
+  }
+  async delete(id) {
+    const entryPath = getEntryPath(this.#storageDir, id);
+    try {
+      await fs3.unlink(entryPath);
+      return;
+    } catch (err) {
+      if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+        throw toFilesystemError(err, "secret file", entryPath, "delete");
+      }
+    }
+    if (this.#legacyStorageDir !== void 0) {
+      const legacyEntryPath = getEntryPath(this.#legacyStorageDir, id);
+      try {
+        await fs3.unlink(legacyEntryPath);
+        return;
+      } catch (err) {
+        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+          throw toFilesystemError(err, "secret file", legacyEntryPath, "delete");
+        }
+      }
+    }
+    throw new SecretNotFoundError(`Secret not found in file store: ${id}`);
+  }
+  async exists(id) {
+    if (await _FileBackend.#entryExists(this.#storageDir, id)) {
+      return true;
+    }
+    if (this.#legacyStorageDir !== void 0) {
+      return _FileBackend.#entryExists(this.#legacyStorageDir, id);
+    }
+    return false;
+  }
+  static async #entryExists(storageDir, id) {
+    try {
+      await fs3.access(getEntryPath(storageDir, id));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async list() {
+    const ids = /* @__PURE__ */ new Set();
+    for (const storageDir of [this.#storageDir, this.#legacyStorageDir].filter(
+      (dir) => dir !== void 0
+    )) {
+      for (const id of await _FileBackend.#listEntries(storageDir)) {
+        ids.add(id);
+      }
+    }
+    return Array.from(ids);
+  }
+  static async #listEntries(storageDir) {
+    let entries;
+    try {
+      entries = await fs3.readdir(storageDir);
+    } catch {
+      return [];
+    }
+    return entries.filter((f) => f.endsWith(".enc")).map((f) => Buffer.from(f.slice(0, -4), "hex").toString("utf8"));
+  }
+  // --- Signing contract (SigningBackend) ---
+  /** On-disk path of the encrypted private key for a signing-key id. */
+  #signingKeyPath(id) {
+    const safeId = Buffer.from(id, "utf8").toString("hex");
+    return path2.join(this.#signingDir, `${safeId}.pem.enc`);
+  }
+  /**
+   * Load and decrypt the PKCS#8 private key PEM for `id`, or throw
+   * {@link SigningKeyNotFoundError} when no signing key exists under `id`.
+   */
+  async #loadSigningKeyPem(id) {
+    const keyPath = this.#signingKeyPath(id);
+    let encoded;
+    try {
+      encoded = await fs3.readFile(keyPath, "utf8");
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        throw new SigningKeyNotFoundError(
+          `Signing key not found: ${displayKeyName(id)}`,
+          displayKeyName(id)
+        );
+      }
+      throw toFilesystemError(err, "signing key", keyPath, "read");
+    }
+    const wrapKey = await getOrCreateKey(this.#storageDir);
+    try {
+      return decryptGcm(wrapKey, encoded);
+    } catch (err) {
+      throw new DecryptionError(
+        `Failed to decrypt signing key: ${err instanceof Error ? err.message : String(err)}`,
+        keyPath
+      );
+    }
+  }
+  async generateSigningKey(id, algorithm) {
+    if (!SUPPORTED_SIGNING_ALGORITHMS.includes(algorithm)) {
+      throw new InvalidAlgorithmError(
+        `Unsupported signing algorithm '${algorithm}'. Supported: ${SUPPORTED_SIGNING_ALGORITHMS.join(", ")}.`,
+        algorithm,
+        [...SUPPORTED_SIGNING_ALGORITHMS]
+      );
+    }
+    await ensureStorageDir(this.#storageDir);
+    try {
+      await fs3.mkdir(this.#signingDir, { recursive: true, mode: 448 });
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code !== "EEXIST") {
+        throw toFilesystemError(err, "signing-key directory", this.#signingDir, "create");
+      }
+    }
+    const keyPath = this.#signingKeyPath(id);
+    let keyExists = false;
+    try {
+      await fs3.access(keyPath);
+      keyExists = true;
+    } catch (err) {
+      if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+        throw toFilesystemError(err, "signing key", keyPath, "read");
+      }
+    }
+    if (keyExists) {
+      throw new SigningKeyAlreadyExistsError(
+        `Signing key already exists: ${displayKeyName(id)}`,
+        displayKeyName(id)
+      );
+    }
+    const { privateKey } = crypto2.generateKeyPairSync("ed25519");
+    const pkcs8Pem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    const wrapKey = await getOrCreateKey(this.#storageDir);
+    const encrypted = encryptGcm(wrapKey, pkcs8Pem);
+    try {
+      await fs3.writeFile(keyPath, encrypted, { mode: 384, flag: "wx" });
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "EEXIST") {
+        throw new SigningKeyAlreadyExistsError(
+          `Signing key already exists: ${displayKeyName(id)}`,
+          displayKeyName(id)
+        );
+      }
+      throw toFilesystemError(err, "signing key", keyPath, "write");
+    }
+  }
+  /**
+   * Load, decrypt, and parse the private key for `id` into a `KeyObject`.
+   *
+   * A parse failure means the decrypted-at-rest material is corrupt or tampered
+   * (it decrypted cleanly but is not a valid PKCS#8 private key). It is
+   * translated into a typed {@link InvalidKeyMaterialError} — never allowed to
+   * surface as a raw Node crypto exception — and the message never echoes any
+   * part of the key material.
+   */
+  async #loadSigningKeyObject(id) {
+    const pkcs8Pem = await this.#loadSigningKeyPem(id);
+    try {
+      return crypto2.createPrivateKey(pkcs8Pem);
+    } catch {
+      throw new InvalidKeyMaterialError(
+        `The stored signing key for "${displayKeyName(id)}" is not valid private key material (it may be corrupt or tampered).`
+      );
+    }
+  }
+  async getPublicKey(id) {
+    const privateKey = await this.#loadSigningKeyObject(id);
+    const publicKey = crypto2.createPublicKey(privateKey);
+    const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    const spkiDer = publicKey.export({ type: "spki", format: "der" });
+    return {
+      publicKeyPem,
+      algorithm: "EdDSA",
+      kid: computeKid(spkiDer)
+    };
+  }
+  async signWithKey(id, data) {
+    const privateKey = await this.#loadSigningKeyObject(id);
+    return crypto2.sign(null, data, privateKey);
+  }
+};
+async function execCommand(command, args, options) {
+  const result = await execCommandFull(command, args, options);
+  if (result.exitCode !== 0) {
+    throw new ExecError(
+      `Command failed with exit code ${String(result.exitCode)}: ${result.stderr}`,
+      command
+    );
+  }
+  return result.stdout.trim();
+}
+function execCommandFull(command, args, options) {
+  return new Promise((resolve32, reject) => {
+    const proc = (0, import_child_process.spawn)(command, args, {
+      stdio: [options?.stdin !== void 0 ? "pipe" : "ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    let timeoutHandle;
+    proc.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+    if (options?.stdin !== void 0 && proc.stdin) {
+      proc.stdin.write(options.stdin);
+      proc.stdin.end();
+    }
+    if (options?.timeoutMs !== void 0) {
+      timeoutHandle = setTimeout(() => {
+        timeoutHandle = void 0;
+        proc.kill("SIGTERM");
+        reject(new ExecError(`Command timed out after ${String(options.timeoutMs)}ms`, command));
+      }, options.timeoutMs);
+    }
+    proc.on("close", (code) => {
+      if (timeoutHandle !== void 0) {
+        clearTimeout(timeoutHandle);
+      }
+      resolve32({ stdout, stderr, exitCode: code ?? 1 });
+    });
+    proc.on("error", (error2) => {
+      if (timeoutHandle !== void 0) {
+        clearTimeout(timeoutHandle);
+      }
+      if ("code" in error2 && error2.code === "ENOENT") {
+        reject(
+          new PluginNotFoundError(
+            `'${command}' is not installed or not found in PATH`,
+            command,
+            ""
+          )
+        );
+      } else {
+        reject(new ExecError(`Failed to spawn '${command}': ${error2.message}`, command));
+      }
+    });
+  });
+}
+var ACCOUNT = "vaultkeeper";
+var SERVICE_PREFIX = "vaultkeeper:";
+var KeychainBackend = class {
+  type = "keychain";
+  displayName = "macOS Keychain";
+  async isAvailable() {
+    if (process.platform !== "darwin") {
+      return false;
+    }
+    try {
+      const result = await execCommandFull("security", ["version"]);
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const encoded = Buffer.from(secret, "utf8").toString("base64");
+    await execCommandFull("security", ["delete-generic-password", "-a", ACCOUNT, "-s", service]);
+    await execCommand("security", [
+      "add-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service,
+      "-w",
+      encoded
+    ]);
+  }
+  async retrieve(id) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const result = await execCommandFull("security", [
+      "find-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service,
+      "-w"
+    ]);
+    if (result.exitCode !== 0) {
+      throw new SecretNotFoundError(`Secret not found in macOS Keychain: ${id}`);
+    }
+    const encoded = result.stdout.trim();
+    return Buffer.from(encoded, "base64").toString("utf8");
+  }
+  async delete(id) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const result = await execCommandFull("security", [
+      "delete-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service
+    ]);
+    if (result.exitCode !== 0) {
+      throw new SecretNotFoundError(`Secret not found in macOS Keychain: ${id}`);
+    }
+  }
+  async exists(id) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const result = await execCommandFull("security", [
+      "find-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service
+    ]);
+    return result.exitCode === 0;
+  }
+  async list() {
+    const result = await execCommandFull("security", ["dump-keychain"]);
+    if (result.exitCode !== 0) {
+      return [];
+    }
+    const ids = [];
+    const servicePattern = /0x00000007 <blob>="vaultkeeper:([^"]+)"/g;
+    let match = servicePattern.exec(result.stdout);
+    while (match !== null) {
+      const id = match[1];
+      if (id !== void 0) {
+        ids.push(id);
+      }
+      match = servicePattern.exec(result.stdout);
+    }
+    return ids;
+  }
+};
+function resolveStorageDir2(configuredPath) {
+  if (configuredPath !== void 0) {
+    return configuredPath;
+  }
+  return path2.join(os.homedir(), ".vaultkeeper", "dpapi");
+}
+function getEntryPath2(storageDir, id) {
+  const safeId = Buffer.from(id, "utf8").toString("hex");
+  return path2.join(storageDir, `${safeId}.enc`);
+}
+var DpapiBackend = class {
+  type = "dpapi";
+  displayName = "Windows DPAPI";
+  #storageDir;
+  /**
+   * @param storageDir - Directory in which encrypted blobs are stored.
+   *   Sourced from `BackendConfig.path`. Defaults to `$HOME/.vaultkeeper/dpapi`.
+   */
+  constructor(storageDir) {
+    this.#storageDir = resolveStorageDir2(storageDir);
+  }
+  async isAvailable() {
+    if (process.platform !== "win32") {
+      return false;
+    }
+    try {
+      const result = await execCommandFull("powershell", [
+        "-NoProfile",
+        "-Command",
+        "[System.Security.Cryptography.ProtectedData] | Out-Null; exit 0"
+      ]);
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const storageDir = this.#storageDir;
+    await fs3.mkdir(storageDir, { recursive: true });
+    const entryPath = getEntryPath2(storageDir, id);
+    const script = [
+      "Add-Type -AssemblyName System.Security",
+      `$bytes = [System.Text.Encoding]::UTF8.GetBytes(${JSON.stringify(secret)})`,
+      "$entropy = $null",
+      "$scope = [System.Security.Cryptography.DataProtectionScope]::CurrentUser",
+      "$encrypted = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $entropy, $scope)",
+      `[System.IO.File]::WriteAllBytes(${JSON.stringify(entryPath)}, $encrypted)`
+    ].join("; ");
+    await execCommand("powershell", ["-NoProfile", "-Command", script]);
+  }
+  async retrieve(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath2(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+    } catch {
+      throw new SecretNotFoundError(`Secret not found in Windows DPAPI store: ${id}`);
+    }
+    const script = [
+      "Add-Type -AssemblyName System.Security",
+      `$encrypted = [System.IO.File]::ReadAllBytes(${JSON.stringify(entryPath)})`,
+      "$entropy = $null",
+      "$scope = [System.Security.Cryptography.DataProtectionScope]::CurrentUser",
+      "$bytes = [System.Security.Cryptography.ProtectedData]::Unprotect($encrypted, $entropy, $scope)",
+      "Write-Output ([System.Text.Encoding]::UTF8.GetString($bytes))"
+    ].join("; ");
+    return execCommand("powershell", ["-NoProfile", "-Command", script]);
+  }
+  async delete(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath2(storageDir, id);
+    try {
+      await fs3.unlink(entryPath);
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        throw new SecretNotFoundError(`Secret not found in Windows DPAPI store: ${id}`);
+      }
+      throw toFilesystemError(err, "secret file", entryPath, "delete");
+    }
+  }
+  async exists(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath2(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async list() {
+    const storageDir = this.#storageDir;
+    let entries;
+    try {
+      entries = await fs3.readdir(storageDir);
+    } catch {
+      return [];
+    }
+    return entries.filter((f) => f.endsWith(".enc")).map((f) => Buffer.from(f.slice(0, -4), "hex").toString("utf8"));
+  }
+};
+var ATTRIBUTE_KEY = "vaultkeeper-id";
+var LABEL_PREFIX = "vaultkeeper: ";
+var SecretToolBackend = class {
+  type = "secret-tool";
+  displayName = "Linux Secret Service (secret-tool)";
+  async isAvailable() {
+    if (process.platform !== "linux") {
+      return false;
+    }
+    try {
+      const result = await execCommandFull("secret-tool", ["--version"]);
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const label = `${LABEL_PREFIX}${id}`;
+    await execCommand("secret-tool", ["store", "--label", label, ATTRIBUTE_KEY, id], {
+      stdin: secret
+    });
+  }
+  async retrieve(id) {
+    const result = await execCommandFull("secret-tool", ["lookup", ATTRIBUTE_KEY, id]);
+    if (result.exitCode !== 0 || result.stdout.trim() === "") {
+      throw new SecretNotFoundError(`Secret not found in Secret Service: ${id}`);
+    }
+    return result.stdout.trim();
+  }
+  async delete(id) {
+    const result = await execCommandFull("secret-tool", ["clear", ATTRIBUTE_KEY, id]);
+    if (result.exitCode !== 0) {
+      throw new SecretNotFoundError(`Secret not found in Secret Service: ${id}`);
+    }
+  }
+  async exists(id) {
+    const result = await execCommandFull("secret-tool", ["lookup", ATTRIBUTE_KEY, id]);
+    return result.exitCode === 0 && result.stdout.trim() !== "";
+  }
+  async list() {
+    const result = await execCommandFull("secret-tool", ["search", ATTRIBUTE_KEY, ""]);
+    if (result.exitCode !== 0) {
+      return [];
+    }
+    const ids = [];
+    const attrPattern = new RegExp(`attribute\\.${ATTRIBUTE_KEY} = (.+)`, "g");
+    let match = attrPattern.exec(result.stdout);
+    while (match !== null) {
+      const id = match[1];
+      if (id !== void 0) {
+        ids.push(id);
+      }
+      match = attrPattern.exec(result.stdout);
+    }
+    return ids;
+  }
+};
+var TAG = "vaultkeeper";
+var PASSWORD_FIELD_TITLE = "password";
+async function findItemOverviewByTitle(client, vaultId, title) {
+  const overviews = await client.items.list(vaultId);
+  for (const overview of overviews) {
+    if (overview.title === title && overview.tags.includes(TAG)) {
+      return overview;
+    }
+  }
+  return void 0;
+}
+async function findItemByTitle(client, vaultId, title) {
+  const overview = await findItemOverviewByTitle(client, vaultId, title);
+  if (overview === void 0) return void 0;
+  return client.items.get(vaultId, overview.id);
+}
+function extractPasswordField(item) {
+  for (const field of item.fields) {
+    if (field.title === PASSWORD_FIELD_TITLE) {
+      return field.value;
+    }
+  }
+  return void 0;
+}
+async function storeSecretItem(client, vaultId, title, secret, passwordCategory, concealedFieldType) {
+  const existing = await findItemByTitle(client, vaultId, title);
+  if (existing !== void 0) {
+    const hasPasswordField = existing.fields.some((f) => f.title === PASSWORD_FIELD_TITLE);
+    const updatedFields = hasPasswordField ? existing.fields.map((f) => f.title === PASSWORD_FIELD_TITLE ? { ...f, value: secret } : f) : [
+      ...existing.fields,
+      {
+        id: "password",
+        title: PASSWORD_FIELD_TITLE,
+        fieldType: concealedFieldType,
+        value: secret
+      }
+    ];
+    await client.items.put({ ...existing, fields: updatedFields });
+  } else {
+    await client.items.create({
+      category: passwordCategory,
+      vaultId,
+      title,
+      tags: [TAG],
+      fields: [
+        {
+          id: "password",
+          title: PASSWORD_FIELD_TITLE,
+          fieldType: concealedFieldType,
+          value: secret
+        }
+      ]
+    });
+  }
+}
+async function deleteSecretItem(client, vaultId, title) {
+  const overview = await findItemOverviewByTitle(client, vaultId, title);
+  if (overview === void 0) return false;
+  await client.items.delete(vaultId, overview.id);
+  return true;
+}
+var INTEGRATION_NAME = "vaultkeeper";
+var SDK_PACKAGE = "@1password/sdk";
+var SDK_INSTALL_URL = "https://developer.1password.com/docs/sdks/";
+var SDK_NOT_INSTALLED_MESSAGE = `1Password SDK (${SDK_PACKAGE}) is not installed. Install it to use the 1Password backend.`;
+var PRESENCE_WRITE_TIMEOUT_MS = 3e4;
+function isModuleNotFoundError(error2) {
+  const hasNotFoundCode = (value) => {
+    if (value === null || typeof value !== "object" || !("code" in value)) {
+      return false;
+    }
+    const { code } = value;
+    return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+  };
+  if (hasNotFoundCode(error2)) {
+    return true;
+  }
+  if (error2 !== null && typeof error2 === "object" && "cause" in error2) {
+    return hasNotFoundCode(error2.cause);
+  }
+  return false;
+}
 var cachedVersion;
+function getIntegrationVersion() {
+  if (cachedVersion !== void 0) return cachedVersion;
+  const dir = (0, import_path3.dirname)((0, import_url2.fileURLToPath)(importMetaUrl));
+  const candidates = [(0, import_path3.resolve)(dir, "..", "..", "package.json"), (0, import_path3.resolve)(dir, "..", "package.json")];
+  for (const candidate of candidates) {
+    if (!(0, import_fs2.existsSync)(candidate)) continue;
+    const raw = JSON.parse((0, import_fs2.readFileSync)(candidate, "utf8"));
+    if (raw !== null && typeof raw === "object" && "version" in raw && typeof raw.version === "string") {
+      cachedVersion = raw.version;
+      return cachedVersion;
+    }
+  }
+  throw new SetupError(
+    `Could not read version from vaultkeeper package.json. Tried paths: ${candidates.join(", ")}`,
+    "vaultkeeper package.json"
+  );
+}
+var SESSION_TIMEOUT_MS = 3e4;
+function isWorkerSuccess(res) {
+  return "value" in res;
+}
+function isWorkerResponse(value) {
+  if (value === null || typeof value !== "object") return false;
+  if ("value" in value && typeof value.value === "string") return true;
+  if ("error" in value && typeof value.error === "string" && "code" in value && typeof value.code === "string")
+    return true;
+  return false;
+}
+function isWorkerWriteSuccess(res) {
+  const record = { ...res };
+  return record.ok === true;
+}
+function isWorkerWriteResponse(value) {
+  if (value === null || typeof value !== "object") return false;
+  if ("ok" in value && value.ok === true) return true;
+  if ("error" in value && typeof value.error === "string" && "code" in value && typeof value.code === "string")
+    return true;
+  return false;
+}
+var OnePasswordBackend = class {
+  type = "1password";
+  displayName = "1Password";
+  vaultId;
+  account;
+  serviceAccountToken;
+  accessMode;
+  sessionTimeoutMs;
+  /** In-flight or resolved client promise — prevents duplicate createClient calls. */
+  clientPromise;
+  constructor(options) {
+    if (options.accessMode === "per-access" && options.serviceAccountToken !== void 0) {
+      throw new ConfigValidationError(
+        "per-access mode requires desktop biometric authentication and cannot be used with a service account token",
+        "options.accessMode"
+      );
+    }
+    if (options.account !== void 0 && options.serviceAccountToken !== void 0) {
+      throw new ConfigValidationError(
+        "account and serviceAccountToken are mutually exclusive \u2014 provide one or the other, not both",
+        "options.serviceAccountToken"
+      );
+    }
+    this.vaultId = options.vault;
+    this.sessionTimeoutMs = options.sessionTimeoutMs ?? SESSION_TIMEOUT_MS;
+    if (options.account !== void 0) {
+      this.account = options.account;
+    }
+    if (options.serviceAccountToken !== void 0) {
+      this.serviceAccountToken = options.serviceAccountToken;
+    }
+    this.accessMode = options.accessMode ?? "session";
+  }
+  async isAvailable() {
+    const sdk = await this.tryLoadSdk();
+    return sdk !== null;
+  }
+  /**
+   * Report this instance's capabilities.
+   *
+   * @remarks
+   * `presencePerUse` is `true` only in `per-access` mode, where every keyed
+   * operation (`retrieve()`, `store()`, `delete()`) spawns a fresh worker
+   * process that creates a new SDK client and triggers a per-operation
+   * biometric approval that cannot be satisfied from the cached session
+   * client. In the default `session` mode a single client is cached for all
+   * operations, so operations ride one earlier unlock — that mode reports
+   * `false`.
+   *
+   * **Operation coverage:** the per-access biometric path gates `retrieve()`,
+   * `store()`, and `delete()` — every keyed operation reachable from
+   * `presenceEnforcedOperations`. `exists()`/`list()` are read-only probes,
+   * not keyed operations the presence contract covers, so they continue to
+   * use the cached session client. This reports
+   * `presenceEnforcedOperations: ['read', 'store', 'delete']` (issue #211
+   * closed the earlier `store`/`delete` gap — see
+   * {@link https://github.com/mike-north/vaultkeeper/issues/211}).
+   *
+   * **Truth-basis / cached-OS-unlock caveat:** even for a covered operation
+   * the fresh action is "a fresh SDK client plus whatever the OS enforces at
+   * that moment" — a "fresh process/SDK client" is **not** the same as a
+   * guaranteed fresh hardware action. A per-access call can still ride a
+   * cached OS-level Touch ID / Windows Hello unlock if the OS does not
+   * re-prompt. The strongest per-use hardware guarantee comes from a touch
+   * device (YubiKey / gpg smartcard).
+   */
+  getCapabilities() {
+    if (this.accessMode === "per-access") {
+      return Promise.resolve({
+        presencePerUse: true,
+        presenceEnforcedOperations: ["read", "store", "delete"]
+      });
+    }
+    return Promise.resolve({ presencePerUse: false });
+  }
+  // ---- Session client management ----
+  /**
+   * Dynamically import the SDK. Returns `null` if the SDK is not installed or
+   * the native library cannot be loaded. Used by {@link isAvailable}, which
+   * only needs a yes/no answer; call {@link loadSdkOrThrow} on paths that must
+   * report *why* the SDK could not be loaded.
+   */
+  async tryLoadSdk() {
+    try {
+      const sdk = await Promise.resolve().then(() => __toESM(require_sdk(), 1));
+      return sdk;
+    } catch {
+      return null;
+    }
+  }
+  /**
+   * Dynamically import the SDK, throwing a typed {@link PluginNotFoundError}
+   * only when the module cannot be resolved (the optional peer is not
+   * installed). A present-but-broken SDK (native binding failure, init throw,
+   * incompatible Node) surfaces its real error instead of a misleading
+   * "not installed" message.
+   */
+  async loadSdkOrThrow() {
+    try {
+      return await Promise.resolve().then(() => __toESM(require_sdk(), 1));
+    } catch (error2) {
+      if (isModuleNotFoundError(error2)) {
+        throw new PluginNotFoundError(SDK_NOT_INSTALLED_MESSAGE, SDK_PACKAGE, SDK_INSTALL_URL);
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Acquire (or create) a cached SDK client.
+   * Wraps `createClient` with a configurable timeout (default 30 s) to handle
+   * the known beta SDK hang after session expiry.
+   */
+  acquireClient() {
+    this.clientPromise ??= this.createClientInternal().catch((err) => {
+      this.clientPromise = void 0;
+      throw err;
+    });
+    return this.clientPromise;
+  }
+  async createClientInternal() {
+    const sdk = await this.loadSdkOrThrow();
+    const auth2 = this.buildAuth(sdk);
+    let timerId;
+    const timeoutPromise = new Promise((_resolve, reject) => {
+      timerId = setTimeout(() => {
+        reject(
+          new BackendLockedError("1Password session timed out waiting for authentication", true)
+        );
+      }, this.sessionTimeoutMs);
+    });
+    try {
+      const client = await Promise.race([
+        sdk.createClient({
+          auth: auth2,
+          integrationName: INTEGRATION_NAME,
+          integrationVersion: getIntegrationVersion()
+        }),
+        timeoutPromise
+      ]);
+      return client;
+    } catch (err) {
+      if (err instanceof BackendLockedError) {
+        throw err;
+      }
+      if (err instanceof sdk.DesktopSessionExpiredError) {
+        throw new BackendLockedError("1Password session has expired. Please unlock the app.", true);
+      }
+      throw new AuthorizationDeniedError(`1Password authentication failed: ${String(err)}`);
+    } finally {
+      if (timerId !== void 0) {
+        clearTimeout(timerId);
+      }
+    }
+  }
+  buildAuth(sdk) {
+    if (this.serviceAccountToken !== void 0) {
+      return this.serviceAccountToken;
+    }
+    const accountName = this.account ?? "";
+    return new sdk.DesktopAuth(accountName);
+  }
+  // ---- SecretBackend / ListableBackend implementation ----
+  async store(id, secret) {
+    if (this.accessMode === "per-access") {
+      return this.writeViaWorker("store", id, secret);
+    }
+    const { ItemCategory, ItemFieldType } = await this.requireSdk();
+    const client = await this.acquireClient();
+    await storeSecretItem(
+      client,
+      this.vaultId,
+      id,
+      secret,
+      ItemCategory.Password,
+      ItemFieldType.Concealed
+    );
+  }
+  async retrieve(id) {
+    if (this.accessMode === "per-access") {
+      return this.retrieveViaWorker(id);
+    }
+    return this.retrieveViaSession(id);
+  }
+  async retrieveViaSession(id) {
+    const client = await this.acquireClient();
+    const item = await findItemByTitle(client, this.vaultId, id);
+    if (item === void 0) {
+      throw new SecretNotFoundError(`Secret not found in 1Password: ${id}`);
+    }
+    const value = extractPasswordField(item);
+    if (value === void 0) {
+      throw new SecretNotFoundError(`Secret found in 1Password but missing password field: ${id}`);
+    }
+    return value;
+  }
+  /**
+   * Spawn the per-access worker script that triggers a fresh biometric prompt
+   * for each retrieval, then returns the secret from its stdout.
+   */
+  retrieveViaWorker(id) {
+    return new Promise((resolve32, reject) => {
+      const workerPath = (0, import_path3.join)((0, import_path3.dirname)((0, import_url2.fileURLToPath)(importMetaUrl)), "one-password-worker.js");
+      const accountArg = this.account ?? "";
+      const child = (0, import_child_process.spawn)(process.execPath, [workerPath, accountArg, this.vaultId, id], {
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+      const stdoutChunks = [];
+      const stderrChunks = [];
+      child.stdout.on("data", (chunk) => {
+        stdoutChunks.push(chunk);
+      });
+      child.stderr.on("data", (chunk) => {
+        stderrChunks.push(chunk);
+      });
+      child.on("close", (code, signal) => {
+        const raw = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        if (raw === "") {
+          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+          const exitDescription = typeof signal === "string" ? `terminated by signal ${signal}` : `exit code ${String(code)}`;
+          const detail = stderr !== "" ? stderr : exitDescription;
+          reject(
+            new BackendUnavailableError(
+              `1Password per-access worker crashed for secret ${id}: ${detail}`,
+              "worker-crashed",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        let parsed;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          reject(new SecretNotFoundError(`Worker returned unparseable output for secret: ${id}`));
+          return;
+        }
+        if (!isWorkerResponse(parsed)) {
+          reject(
+            new SecretNotFoundError(`Worker returned unexpected response shape for secret: ${id}`)
+          );
+          return;
+        }
+        if (isWorkerSuccess(parsed)) {
+          resolve32(parsed.value);
+        } else {
+          switch (parsed.code) {
+            case "PLUGIN_NOT_FOUND":
+              reject(
+                new PluginNotFoundError(SDK_NOT_INSTALLED_MESSAGE, SDK_PACKAGE, SDK_INSTALL_URL)
+              );
+              break;
+            case "NOT_FOUND":
+              reject(new SecretNotFoundError(`Secret not found in 1Password: ${id}`));
+              break;
+            case "AUTH_DENIED":
+              reject(new AuthorizationDeniedError("1Password authentication was denied"));
+              break;
+            case "LOCKED":
+              reject(new BackendLockedError("1Password is locked. Please unlock and retry.", true));
+              break;
+            case "INTERNAL":
+              reject(
+                new BackendUnavailableError(
+                  `1Password per-access worker failed for secret ${id}: ${parsed.error}`,
+                  "worker-internal-error",
+                  ["1password"]
+                )
+              );
+              break;
+            default:
+              reject(new SecretNotFoundError(`Worker failed for secret ${id}: ${parsed.error}`));
+          }
+        }
+      });
+      child.on("error", (err) => {
+        reject(
+          new BackendUnavailableError(
+            `Failed to spawn 1Password per-access worker at ${workerPath}: ${String(err)}`,
+            "worker-spawn-failed",
+            ["1password"]
+          )
+        );
+      });
+    });
+  }
+  /**
+   * Spawn the per-access worker script to perform a `store` or `delete`,
+   * triggering a fresh biometric prompt for this single write (issue #211).
+   *
+   * @remarks
+   * For `store`, `secret` is delivered to the worker over **stdin**, never
+   * argv — it must never appear in a process listing, shell history, or log.
+   * `delete` needs no payload, so no stdin is written and the worker's stdin
+   * is left `'ignore'`d, mirroring the retrieve path's spawn options.
+   */
+  writeViaWorker(op, id, secret) {
+    return new Promise((resolve32, reject) => {
+      const workerPath = (0, import_path3.join)((0, import_path3.dirname)((0, import_url2.fileURLToPath)(importMetaUrl)), "one-password-worker.js");
+      const accountArg = this.account ?? "";
+      const needsStdin = secret !== void 0;
+      const child = (0, import_child_process.spawn)(process.execPath, [workerPath, accountArg, this.vaultId, id, op], {
+        stdio: [needsStdin ? "pipe" : "ignore", "pipe", "pipe"]
+      });
+      if (needsStdin && child.stdin !== null) {
+        child.stdin.on("error", () => {
+        });
+        child.stdin.write(secret, "utf8");
+        child.stdin.end();
+      }
+      const stdoutChunks = [];
+      const stderrChunks = [];
+      child.stdout?.on("data", (chunk) => {
+        stdoutChunks.push(chunk);
+      });
+      child.stderr?.on("data", (chunk) => {
+        stderrChunks.push(chunk);
+      });
+      child.on("close", (code, signal) => {
+        const raw = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        if (raw === "") {
+          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+          const exitDescription = typeof signal === "string" ? `terminated by signal ${signal}` : `exit code ${String(code)}`;
+          const detail = stderr !== "" ? stderr : exitDescription;
+          reject(
+            new BackendUnavailableError(
+              `1Password per-access worker crashed during ${op} of secret ${id}: ${detail}`,
+              "worker-crashed",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        let parsed;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          reject(
+            new BackendUnavailableError(
+              `Worker returned unparseable output during ${op} of secret ${id}`,
+              "worker-internal-error",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        if (!isWorkerWriteResponse(parsed)) {
+          reject(
+            new BackendUnavailableError(
+              `Worker returned unexpected response shape during ${op} of secret ${id}`,
+              "worker-internal-error",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        if (isWorkerWriteSuccess(parsed)) {
+          resolve32();
+          return;
+        }
+        switch (parsed.code) {
+          case "PLUGIN_NOT_FOUND":
+            reject(new PluginNotFoundError(SDK_NOT_INSTALLED_MESSAGE, SDK_PACKAGE, SDK_INSTALL_URL));
+            break;
+          case "NOT_FOUND":
+            reject(new SecretNotFoundError(`Secret not found in 1Password: ${id}`));
+            break;
+          case "LOCKED":
+            reject(new BackendLockedError("1Password is locked. Please unlock and retry.", true));
+            break;
+          case "PRESENCE_DECLINED":
+            reject(
+              new PresenceDeclinedError(
+                `1Password ${op} presence action was declined for secret ${id}`,
+                "1password"
+              )
+            );
+            break;
+          case "PRESENCE_TIMEOUT":
+            reject(
+              new PresenceTimeoutError(
+                `1Password ${op} presence action timed out for secret ${id}`,
+                "1password",
+                PRESENCE_WRITE_TIMEOUT_MS
+              )
+            );
+            break;
+          case "INTERNAL":
+            reject(
+              new BackendUnavailableError(
+                `1Password per-access worker failed during ${op} of secret ${id}: ${parsed.error}`,
+                "worker-internal-error",
+                ["1password"]
+              )
+            );
+            break;
+          default:
+            reject(
+              new BackendUnavailableError(
+                `Worker failed during ${op} of secret ${id}: ${parsed.error}`,
+                "worker-internal-error",
+                ["1password"]
+              )
+            );
+        }
+      });
+      child.on("error", (err) => {
+        reject(
+          new BackendUnavailableError(
+            `Failed to spawn 1Password per-access worker at ${workerPath}: ${String(err)}`,
+            "worker-spawn-failed",
+            ["1password"]
+          )
+        );
+      });
+    });
+  }
+  async delete(id) {
+    if (this.accessMode === "per-access") {
+      return this.writeViaWorker("delete", id);
+    }
+    const client = await this.acquireClient();
+    const deleted = await deleteSecretItem(client, this.vaultId, id);
+    if (!deleted) {
+      throw new SecretNotFoundError(`Secret not found in 1Password: ${id}`);
+    }
+  }
+  async exists(id) {
+    const client = await this.acquireClient();
+    const overview = await findItemOverviewByTitle(client, this.vaultId, id);
+    return overview !== void 0;
+  }
+  async list() {
+    const client = await this.acquireClient();
+    const overviews = await client.items.list(this.vaultId);
+    const ids = [];
+    for (const overview of overviews) {
+      if (overview.tags.includes(TAG)) {
+        ids.push(overview.title);
+      }
+    }
+    return ids;
+  }
+  // ---- Private helpers ----
+  /**
+   * Load SDK, throwing a typed {@link PluginNotFoundError} when it is not
+   * installed and surfacing the real error when it is present but broken.
+   */
+  requireSdk() {
+    return this.loadSdkOrThrow();
+  }
+};
+var YKMAN_INSTALL_URL = "https://developers.yubico.com/yubikey-manager/";
+var STORAGE_DIR_NAME2 = path2.join(".vaultkeeper", "yubikey");
+var METADATA_FILE = "metadata.json";
+var DEVICE_TIMEOUT_MS = 5e3;
+var GCM_IV_BYTES2 = 12;
+var GCM_KEY_BYTES2 = 32;
+var GCM_TAG_LENGTH_BITS2 = 128;
+var FORMAT_VERSION = "1";
+function resolveStorageDir3(configuredPath) {
+  if (configuredPath !== void 0) {
+    return configuredPath;
+  }
+  return path2.join(os.homedir(), STORAGE_DIR_NAME2);
+}
+function getEntryPath3(storageDir, id) {
+  const safeId = Buffer.from(id, "utf8").toString("hex");
+  return path2.join(storageDir, `${safeId}.enc`);
+}
+function isStringRecord(value) {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  return Object.values(value).every((v) => typeof v === "string");
+}
+async function loadMetadata(storageDir) {
+  const metaPath = path2.join(storageDir, METADATA_FILE);
+  try {
+    const raw = await fs3.readFile(metaPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed !== null && typeof parsed === "object" && "entries" in parsed && isStringRecord(parsed.entries)) {
+      return { entries: parsed.entries };
+    }
+    return { entries: {} };
+  } catch {
+    return { entries: {} };
+  }
+}
+async function saveMetadata(storageDir, metadata) {
+  const metaPath = path2.join(storageDir, METADATA_FILE);
+  await fs3.writeFile(metaPath, JSON.stringify(metadata, null, 2), { mode: 384 });
+}
+var HMAC_RESPONSE_HEX_LENGTH = 40;
+var HMAC_RESPONSE_RE = /^[0-9a-fA-F]{40}$/;
+function deriveKey(hmacResponse, id) {
+  const trimmed = hmacResponse.trim();
+  if (!HMAC_RESPONSE_RE.test(trimmed)) {
+    throw new SetupError(
+      `Invalid YubiKey HMAC response: expected exactly ${String(HMAC_RESPONSE_HEX_LENGTH)} hex characters (20 bytes), got ${String(trimmed.length)} characters`,
+      "ykman"
+    );
+  }
+  const ikm = Buffer.from(trimmed, "hex");
+  const info2 = Buffer.from(`vaultkeeper-yubikey:${id}`, "utf8");
+  const keyMaterial = crypto2.hkdfSync("sha256", ikm, Buffer.alloc(0), info2, GCM_KEY_BYTES2);
+  return Buffer.from(keyMaterial);
+}
+function encryptGcm2(key, plaintext) {
+  const iv = crypto2.randomBytes(GCM_IV_BYTES2);
+  let encrypted;
+  let authTag;
+  try {
+    const cipher = crypto2.createCipheriv("aes-256-gcm", key, iv, {
+      authTagLength: GCM_TAG_LENGTH_BITS2 / 8
+    });
+    encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    authTag = cipher.getAuthTag();
+    return [
+      FORMAT_VERSION,
+      iv.toString("base64"),
+      authTag.toString("base64"),
+      encrypted.toString("base64")
+    ].join(":");
+  } finally {
+    key.fill(0);
+    iv.fill(0);
+    encrypted?.fill(0);
+    authTag?.fill(0);
+  }
+}
+function decryptGcm2(key, encoded, path9) {
+  const parts = encoded.split(":");
+  const versionSegment = parts[0] ?? "";
+  const parsedVersion = parseInt(versionSegment, 10);
+  const isNumericVersion = String(parsedVersion) === versionSegment && !Number.isNaN(parsedVersion);
+  if (!isNumericVersion) {
+    key.fill(0);
+    throw new DecryptionError(
+      "Encrypted file uses a legacy format (AES-256-CBC). Delete the secret and re-store it to migrate to AES-256-GCM.",
+      path9
+    );
+  }
+  if (versionSegment !== FORMAT_VERSION) {
+    key.fill(0);
+    throw new DecryptionError(
+      `Unsupported encrypted file version: ${versionSegment}. This vaultkeeper build only supports version ${FORMAT_VERSION}. Upgrade vaultkeeper to read this secret.`,
+      path9
+    );
+  }
+  if (parts.length !== 4) {
+    key.fill(0);
+    throw new DecryptionError(
+      `Invalid encrypted file format: expected ${FORMAT_VERSION}:iv:authTag:ciphertext`,
+      path9
+    );
+  }
+  const [_version, ivB64, authTagB64, ciphertextB64] = parts;
+  if (ivB64 === void 0 || authTagB64 === void 0 || ciphertextB64 === void 0) {
+    key.fill(0);
+    throw new DecryptionError("Invalid encrypted file format: missing part", path9);
+  }
+  let decrypted;
+  try {
+    const iv = Buffer.from(ivB64, "base64");
+    const authTag = Buffer.from(authTagB64, "base64");
+    const ciphertext = Buffer.from(ciphertextB64, "base64");
+    try {
+      const decipher = crypto2.createDecipheriv("aes-256-gcm", key, iv, {
+        authTagLength: GCM_TAG_LENGTH_BITS2 / 8
+      });
+      decipher.setAuthTag(authTag);
+      decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    } catch (err) {
+      throw new DecryptionError(
+        `GCM authentication failed \u2014 ciphertext may be tampered or corrupt: ${err instanceof Error ? err.message : String(err)}`,
+        path9
+      );
+    }
+    const plaintext = decrypted.toString("utf8");
+    return plaintext;
+  } finally {
+    key.fill(0);
+    decrypted?.fill(0);
+  }
+}
+var YubikeyBackend = class {
+  type = "yubikey";
+  displayName = "YubiKey";
+  #storageDir;
+  /**
+   * Whether the configured challenge-response slot enforces a touch for every
+   * operation. When `true`, each `store`/`retrieve`/`delete` requires a fresh
+   * physical tap (see {@link YubikeyBackend.getCapabilities}). Sourced from
+   * configuration, not hardcoded by type — a slot without a touch policy
+   * reports `false`.
+   */
+  #requireTouch;
+  /**
+   * @param storageDir - Directory in which encrypted secrets and metadata are
+   *   stored. Sourced from `BackendConfig.path`. Defaults to
+   *   `$HOME/.vaultkeeper/yubikey`.
+   * @param requireTouch - Whether the configured challenge-response slot
+   *   enforces a touch-per-operation policy. Defaults to `false`. Sourced from
+   *   the operator's configuration and must match the physical slot's policy
+   *   (verify with `ykman otp info`); it governs the value reported by
+   *   {@link YubikeyBackend.getCapabilities}.
+   */
+  constructor(storageDir, requireTouch = false) {
+    this.#storageDir = resolveStorageDir3(storageDir);
+    this.#requireTouch = requireTouch;
+  }
+  /**
+   * Report this instance's capabilities.
+   *
+   * @remarks
+   * `presencePerUse` is `true` only when the configured slot enforces a
+   * touch-per-operation policy (`requireTouch`), in which case every
+   * challenge-response — and therefore every `store`/`retrieve`/`delete` — forces
+   * a fresh physical tap that cannot be satisfied from any cached state. A slot
+   * without a touch policy reports `false`; the answer is never derived from the
+   * backend `type` alone. Truth-basis: the reported value comes from the
+   * operator-declared `touchPolicy` configuration; confirm it matches the
+   * physical slot with `ykman otp info` (a manual verification).
+   */
+  getCapabilities() {
+    return Promise.resolve({ presencePerUse: this.#requireTouch });
+  }
+  async isAvailable() {
+    try {
+      const result = await execCommandFull("ykman", ["--version"]);
+      if (result.exitCode !== 0) {
+        return false;
+      }
+      const listResult = await execCommandFull("ykman", ["list"]);
+      return listResult.exitCode === 0 && listResult.stdout.trim() !== "";
+    } catch {
+      return false;
+    }
+  }
+  async requireDevice() {
+    const available = await this.isAvailable();
+    if (!available) {
+      const hasYkman = await execCommandFull("ykman", ["--version"]).then(
+        (r) => r.exitCode === 0,
+        () => false
+      );
+      if (!hasYkman) {
+        throw new PluginNotFoundError("ykman is not installed", "ykman", YKMAN_INSTALL_URL);
+      }
+      throw new DeviceNotPresentError("No YubiKey device detected", DEVICE_TIMEOUT_MS);
+    }
+  }
+  /**
+   * Perform the YubiKey HMAC-SHA1 challenge-response for `id` and return the
+   * raw hex response string. Throws on device failure.
+   */
+  async challengeResponse(id) {
+    const challenge = Buffer.from(`vaultkeeper:${id}`, "utf8").toString("hex");
+    const responseResult = await execCommandFull("ykman", ["otp", "calculate", "2", challenge]);
+    if (responseResult.exitCode !== 0) {
+      throw new ExecError(`YubiKey challenge-response failed: ${responseResult.stderr}`, "ykman");
+    }
+    return responseResult.stdout.trim();
+  }
+  async store(id, secret) {
+    await this.requireDevice();
+    const storageDir = this.#storageDir;
+    await fs3.mkdir(storageDir, { recursive: true, mode: 448 });
+    const hmacResponse = await this.challengeResponse(id);
+    const key = deriveKey(hmacResponse, id);
+    const encrypted = encryptGcm2(key, secret);
+    const entryPath = getEntryPath3(storageDir, id);
+    await fs3.writeFile(entryPath, encrypted, { mode: 384 });
+    const metadata = await loadMetadata(storageDir);
+    metadata.entries[id] = entryPath;
+    await saveMetadata(storageDir, metadata);
+  }
+  async retrieve(id) {
+    await this.requireDevice();
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath3(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+    } catch {
+      throw new SecretNotFoundError(`Secret not found in YubiKey store: ${id}`);
+    }
+    const encoded = await fs3.readFile(entryPath, "utf8");
+    const hmacResponse = await this.challengeResponse(id);
+    const key = deriveKey(hmacResponse, id);
+    return decryptGcm2(key, encoded, entryPath);
+  }
+  async delete(id) {
+    await this.requireDevice();
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath3(storageDir, id);
+    try {
+      await fs3.unlink(entryPath);
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        throw new SecretNotFoundError(`Secret not found in YubiKey store: ${id}`);
+      }
+      throw err;
+    }
+    const metadata = await loadMetadata(storageDir);
+    delete metadata.entries[id];
+    await saveMetadata(storageDir, metadata);
+  }
+  async exists(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath3(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async list() {
+    const storageDir = this.#storageDir;
+    const metadata = await loadMetadata(storageDir);
+    return Object.keys(metadata.entries);
+  }
+};
+function registerBuiltinBackends() {
+  BackendRegistry.register(
+    "file",
+    (config, configDir) => new FileBackend(config?.path, configDir)
+  );
+  BackendRegistry.register("keychain", () => new KeychainBackend());
+  BackendRegistry.register("dpapi", (config) => new DpapiBackend(config?.path));
+  BackendRegistry.register("secret-tool", () => new SecretToolBackend());
+  BackendRegistry.register("1password", (config) => {
+    const opts = config?.options;
+    const vaultId = opts?.vault ?? "";
+    const opOptions = {
+      vault: vaultId,
+      // 'session' is the safer default — 'per-access' re-prompts on every read.
+      accessMode: opts?.accessMode === "per-access" ? "per-access" : "session"
+    };
+    const account = opts?.account;
+    if (account !== void 0) {
+      opOptions.account = account;
+    }
+    const serviceAccountToken = opts?.serviceAccountToken;
+    if (serviceAccountToken !== void 0) {
+      opOptions.serviceAccountToken = serviceAccountToken;
+    }
+    return new OnePasswordBackend(opOptions);
+  });
+  BackendRegistry.register(
+    "yubikey",
+    (config) => (
+      // `touchPolicy: 'required'` in the backend options declares that the
+      // configured challenge-response slot enforces a touch per operation, which
+      // is what makes the instance presence-per-use capable (see
+      // YubikeyBackend.getCapabilities). Any other value (or absent) reports
+      // false — presence is never assumed from the backend type alone.
+      new YubikeyBackend(config?.path, config?.options?.touchPolicy === "required")
+    )
+  );
+}
+registerBuiltinBackends();
+var INSPECT_CUSTOM = /* @__PURE__ */ Symbol.for("nodejs.util.inspect.custom");
+var SecretAccessorTarget = class {
+  read;
+  [INSPECT_CUSTOM];
+  constructor(readImpl, inspectImpl) {
+    this.read = readImpl;
+    this[INSPECT_CUSTOM] = inspectImpl;
+  }
+};
+
+// ../core/dist/index.js
+var cachedVersion2;
 function getPackageVersion() {
-  if (cachedVersion !== void 0) {
-    return cachedVersion;
+  if (cachedVersion2 !== void 0) {
+    return cachedVersion2;
   }
   {
-    cachedVersion = "0.10.1";
-    return cachedVersion;
+    cachedVersion2 = "0.10.1";
+    return cachedVersion2;
   }
 }
 var VersionIncompatibleError = class _VersionIncompatibleError extends Error {
@@ -41938,12 +46238,88 @@ var localConfigSchemaV1 = external_exports.object({
     message: "At least one identity must be defined"
   })
 }).strict();
+var privateKeyRefSchemaV2 = external_exports.discriminatedUnion("type", [
+  external_exports.object({
+    type: external_exports.literal("file"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty")
+  }),
+  external_exports.object({
+    type: external_exports.literal("keychain"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty")
+  }),
+  external_exports.object({
+    type: external_exports.literal("1password"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty"),
+    vault: external_exports.string().optional()
+  }),
+  external_exports.object({
+    type: external_exports.literal("yubikey"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty")
+  }),
+  external_exports.object({
+    type: external_exports.literal("filesystem"),
+    path: external_exports.string().min(1, "Filesystem path cannot be empty")
+  })
+]);
+var identitySchemaV2 = external_exports.object({
+  name: external_exports.string().min(1, "Identity name cannot be empty"),
+  email: external_exports.string().optional(),
+  github: external_exports.string().optional(),
+  publicKey: external_exports.string().min(1, "Public key cannot be empty"),
+  privateKey: privateKeyRefSchemaV2
+}).strict();
+var localConfigSchemaV2 = external_exports.object({
+  version: external_exports.literal(2),
+  activeIdentity: external_exports.string().min(1, "Active identity name cannot be empty"),
+  identities: external_exports.record(external_exports.string(), identitySchemaV2).refine((identities) => Object.keys(identities).length >= 1, {
+    message: "At least one identity must be defined"
+  })
+}).strict();
 var schemaV1 = fromZod("1", localConfigSchemaV1);
+var schemaV2 = fromZod("2", localConfigSchemaV2);
+function migratePrivateKeyRefV1ToV2(v1) {
+  switch (v1.type) {
+    case "file":
+      return { type: "filesystem", path: v1.path };
+    case "keychain":
+      return { type: "filesystem", path: `keychain://${v1.service}/${v1.account}` };
+    case "1password":
+      return {
+        type: "filesystem",
+        path: `1password://${v1.vault}/${v1.item}`
+      };
+    case "yubikey":
+      return { type: "filesystem", path: v1.encryptedKeyPath };
+  }
+}
 var identityMigrationGraph = createMigrationGraph({
   id: "attest-it-identity-config",
   versionStrategy: integerStrategy,
-  schemas: [schemaV1],
-  migrations: []
+  schemas: [schemaV1, schemaV2],
+  migrations: [
+    {
+      fromVersion: "1",
+      toVersion: "2",
+      irreversibleReason: "V1 private key refs lose provider-specific details when converted to the legacy filesystem fallback format. The original provider-specific fields (service, vault, item, etc.) cannot be fully recovered from the filesystem pseudo-URI paths.",
+      up: (v1Data) => {
+        const identities = {};
+        for (const [key, identity] of Object.entries(v1Data.identities)) {
+          identities[key] = {
+            name: identity.name,
+            publicKey: identity.publicKey,
+            privateKey: migratePrivateKeyRefV1ToV2(identity.privateKey),
+            ...identity.email !== void 0 && { email: identity.email },
+            ...identity.github !== void 0 && { github: identity.github }
+          };
+        }
+        return {
+          version: 2,
+          activeIdentity: v1Data.activeIdentity,
+          identities
+        };
+      }
+    }
+  ]
 });
 function versionSchema(version2) {
   return external_exports.union([external_exports.literal(version2), external_exports.literal(String(version2))]).transform(() => version2);
@@ -42283,12 +46659,12 @@ function isUnifiedShape(parsed) {
   return typeof parsed === "object" && parsed !== null && ("team" in parsed || "gates" in parsed);
 }
 function findUnifiedConfigPath(baseDir) {
-  const configDir = (0, import_path3.join)(baseDir, ".attest-it");
+  const configDir = (0, import_path4.join)(baseDir, ".attest-it");
   const candidates = ["config.yaml", "config.yml", "config.json"];
   for (const candidate of candidates) {
-    const configPath = (0, import_path3.join)(configDir, candidate);
+    const configPath = (0, import_path4.join)(configDir, candidate);
     try {
-      const content = (0, import_fs2.readFileSync)(configPath, "utf8");
+      const content = (0, import_fs3.readFileSync)(configPath, "utf8");
       const parsed = candidate.endsWith(".json") ? JSON.parse(content) : (0, import_yaml.parse)(content);
       if (isUnifiedShape(parsed)) {
         return configPath;
@@ -42299,12 +46675,12 @@ function findUnifiedConfigPath(baseDir) {
   return null;
 }
 function findPolicyPath(startDir = process.cwd()) {
-  const configDir = (0, import_path3.join)(startDir, ".attest-it");
+  const configDir = (0, import_path4.join)(startDir, ".attest-it");
   const candidates = ["policy.yaml", "policy.yml", "policy.json"];
   for (const candidate of candidates) {
-    const configPath = (0, import_path3.join)(configDir, candidate);
+    const configPath = (0, import_path4.join)(configDir, candidate);
     try {
-      (0, import_fs2.readFileSync)(configPath, "utf8");
+      (0, import_fs3.readFileSync)(configPath, "utf8");
       return configPath;
     } catch {
     }
@@ -42312,12 +46688,12 @@ function findPolicyPath(startDir = process.cwd()) {
   return null;
 }
 function findOperationalPath(startDir = process.cwd()) {
-  const configDir = (0, import_path3.join)(startDir, ".attest-it");
+  const configDir = (0, import_path4.join)(startDir, ".attest-it");
   const candidates = ["config.yaml", "config.yml", "config.json"];
   for (const candidate of candidates) {
-    const configPath = (0, import_path3.join)(configDir, candidate);
+    const configPath = (0, import_path4.join)(configDir, candidate);
     try {
-      (0, import_fs2.readFileSync)(configPath, "utf8");
+      (0, import_fs3.readFileSync)(configPath, "utf8");
       return configPath;
     } catch {
     }
@@ -42438,13 +46814,13 @@ function computeFinalFingerprint(fileHashes) {
   });
   const hashes = sorted.map((input) => input.hash);
   const concatenated = Buffer.concat(hashes);
-  const finalHash = crypto3.createHash("sha256").update(concatenated).digest();
+  const finalHash = crypto22.createHash("sha256").update(concatenated).digest();
   return `sha256:${finalHash.toString("hex")}`;
 }
 async function hashFileAsync(realPath, normalizedPath, stats) {
   if (stats.size > LARGE_FILE_THRESHOLD) {
-    return new Promise((resolve6, reject) => {
-      const hash2 = crypto3.createHash("sha256");
+    return new Promise((resolve52, reject) => {
+      const hash2 = crypto22.createHash("sha256");
       hash2.update(normalizedPath);
       hash2.update(":");
       const stream = fs.createReadStream(realPath);
@@ -42452,13 +46828,13 @@ async function hashFileAsync(realPath, normalizedPath, stats) {
         hash2.update(chunk);
       });
       stream.on("end", () => {
-        resolve6(hash2.digest());
+        resolve52(hash2.digest());
       });
       stream.on("error", reject);
     });
   }
   const content = await fs.promises.readFile(realPath);
-  const hash = crypto3.createHash("sha256");
+  const hash = crypto22.createHash("sha256");
   hash.update(normalizedPath);
   hash.update(":");
   hash.update(content);
@@ -42560,153 +46936,6 @@ async function listPackageFiles(packages, ignore = [], baseDir = process.cwd()) 
   }
   return allFiles;
 }
-async function runOpenSSL(args, passphrase) {
-  return new Promise((resolve6, reject) => {
-    const stdio = passphrase ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
-    const child = (0, import_child_process.spawn)("openssl", args, { stdio });
-    const stdoutChunks = [];
-    let stderr = "";
-    child.stdout?.on("data", (chunk) => {
-      stdoutChunks.push(chunk);
-    });
-    child.stderr?.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.on("error", (err) => {
-      reject(new Error(`Failed to spawn OpenSSL: ${err.message}`));
-    });
-    child.on("close", (code) => {
-      resolve6({
-        exitCode: code ?? 1,
-        stdout: Buffer.concat(stdoutChunks),
-        stderr
-      });
-    });
-    if (passphrase) {
-      const passphraseStream = child.stdio[3];
-      if (!(passphraseStream instanceof import_stream.Writable)) {
-        reject(new Error("Expected a writable stream for the passphrase file descriptor"));
-        return;
-      }
-      passphraseStream.on("error", () => {
-      });
-      passphraseStream.write(passphrase + "\n");
-      passphraseStream.end();
-    }
-  });
-}
-async function checkOpenSSL() {
-  const result = await runOpenSSL(["version"]);
-  if (result.exitCode !== 0) {
-    throw new Error(`OpenSSL check failed: ${result.stderr}`);
-  }
-  return result.stdout.toString().trim();
-}
-var openSSLChecked = false;
-async function ensureOpenSSLAvailable() {
-  if (openSSLChecked) {
-    return;
-  }
-  try {
-    await checkOpenSSL();
-    openSSLChecked = true;
-  } catch {
-    throw new Error(
-      "OpenSSL is not installed or not in PATH. Please install OpenSSL to use attest-it. On macOS: brew install openssl. On Ubuntu: apt-get install openssl"
-    );
-  }
-}
-function getDefaultPrivateKeyPath() {
-  const homeDir = os.homedir();
-  if (process.platform === "win32") {
-    const appData = process.env.APPDATA ?? path3.join(homeDir, "AppData", "Roaming");
-    return path3.join(appData, "attest-it", "private.pem");
-  }
-  return path3.join(homeDir, ".config", "attest-it", "private.pem");
-}
-function getDefaultPublicKeyPath() {
-  return path3.join(process.cwd(), "attest-it-public.pem");
-}
-async function ensureDir(dirPath) {
-  try {
-    await fs2.mkdir(dirPath, { recursive: true });
-  } catch (err) {
-    if (err instanceof Error && "code" in err && err.code !== "EEXIST") {
-      throw err;
-    }
-  }
-}
-async function fileExists(filePath) {
-  try {
-    await fs2.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-async function cleanupFiles(...paths) {
-  for (const filePath of paths) {
-    try {
-      await fs2.unlink(filePath);
-    } catch {
-    }
-  }
-}
-async function generateKeyPair(options = {}) {
-  await ensureOpenSSLAvailable();
-  const {
-    privatePath = getDefaultPrivateKeyPath(),
-    publicPath = getDefaultPublicKeyPath(),
-    force = false,
-    passphrase
-  } = options;
-  const privateExists = await fileExists(privatePath);
-  const publicExists = await fileExists(publicPath);
-  if ((privateExists || publicExists) && !force) {
-    const existing = [privateExists ? privatePath : null, publicExists ? publicPath : null].filter(
-      Boolean
-    );
-    throw new Error(
-      `Key files already exist: ${existing.join(", ")}. Use force: true to overwrite.`
-    );
-  }
-  await ensureDir(path3.dirname(privatePath));
-  await ensureDir(path3.dirname(publicPath));
-  try {
-    const genArgs = [
-      "genpkey",
-      "-algorithm",
-      "RSA",
-      "-pkeyopt",
-      "rsa_keygen_bits:2048",
-      "-out",
-      privatePath
-    ];
-    if (passphrase) {
-      genArgs.push("-aes256", "-pass", "fd:3");
-    }
-    const genResult = await runOpenSSL(genArgs, passphrase);
-    if (genResult.exitCode !== 0) {
-      throw new Error(`Failed to generate private key: ${genResult.stderr}`);
-    }
-    await setKeyPermissions(privatePath);
-    const pubArgs = ["pkey", "-in", privatePath, "-pubout", "-out", publicPath];
-    if (passphrase) {
-      pubArgs.push("-passin", "fd:3");
-    }
-    const pubResult = await runOpenSSL(pubArgs, passphrase);
-    if (pubResult.exitCode !== 0) {
-      throw new Error(`Failed to extract public key: ${pubResult.stderr}`);
-    }
-    return {
-      privatePath,
-      publicPath
-    };
-  } catch (err) {
-    await cleanupFiles(privatePath, publicPath);
-    throw err;
-  }
-}
 async function setKeyPermissions(keyPath) {
   if (process.platform === "win32") {
     await fs2.chmod(keyPath, 384);
@@ -42717,9 +46946,21 @@ async function setKeyPermissions(keyPath) {
 function isBuffer(value) {
   return Buffer.isBuffer(value);
 }
-function generateKeyPair2() {
+function generateKeyPair2(options = {}) {
   try {
-    const keyPair = crypto3.generateKeyPairSync("ed25519", {
+    const { passphrase } = options;
+    const keyPair = passphrase !== void 0 && passphrase.length > 0 ? crypto22.generateKeyPairSync("ed25519", {
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem"
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-256-cbc",
+        passphrase
+      }
+    }) : crypto22.generateKeyPairSync("ed25519", {
       publicKeyEncoding: {
         type: "spki",
         format: "pem"
@@ -42733,7 +46974,7 @@ function generateKeyPair2() {
     if (typeof publicKey !== "string" || typeof privateKey !== "string") {
       throw new Error("Expected keypair to have string keys");
     }
-    const publicKeyObj = crypto3.createPublicKey(publicKey);
+    const publicKeyObj = crypto22.createPublicKey(publicKey);
     const publicKeyExport = publicKeyObj.export({
       type: "spki",
       format: "der"
@@ -42782,12 +47023,12 @@ function verify3(data, signature, publicKeyBase64) {
       // BIT STRING, 33 bytes (32 key + 1 padding)
     ]);
     const spkiBuffer = Buffer.concat([spkiHeader, rawPublicKey]);
-    const publicKeyObj = crypto3.createPublicKey({
+    const publicKeyObj = crypto22.createPublicKey({
       key: spkiBuffer,
       format: "der",
       type: "spki"
     });
-    return crypto3.verify(null, dataBuffer, publicKeyObj, signatureBuffer);
+    return crypto22.verify(null, dataBuffer, publicKeyObj, signatureBuffer);
   } catch (err) {
     if (err instanceof Error && err.message.includes("verification failed")) {
       return false;
@@ -42797,27 +47038,133 @@ function verify3(data, signature, publicKeyBase64) {
     );
   }
 }
-var FilesystemKeyProvider = class {
-  type = "filesystem";
-  displayName = "Filesystem";
-  privateKeyPath;
+var VaultKeyProvider = class {
+  type;
+  displayName;
+  backend;
   /**
-   * Create a new FilesystemKeyProvider.
-   * @param options - Provider options
+   * Create a new VaultKeyProvider.
+   * @param options - Provider options including the VaultKeeper backend
    */
-  constructor(options = {}) {
-    this.privateKeyPath = options.privateKeyPath ?? getDefaultPrivateKeyPath();
+  constructor(options) {
+    this.backend = options.backend;
+    this.type = options.backend.type;
+    this.displayName = options.displayName;
   }
   /**
+   * Check if the underlying VaultKeeper backend is available.
+   */
+  async isAvailable() {
+    return this.backend.isAvailable();
+  }
+  /**
+   * Check if a key exists in the VaultKeeper backend.
+   * @param keyRef - Secret identifier in the backend
+   */
+  async keyExists(keyRef) {
+    return this.backend.exists(keyRef);
+  }
+  /**
+   * Retrieve the private key from VaultKeeper for signing.
+   *
+   * @remarks
+   * Downloads the PEM to a secure temporary file (mode 0o600) and returns
+   * a cleanup function that overwrites the file with random bytes before deletion.
+   *
+   * @param keyRef - Secret identifier in the backend
+   * @throws Error if the key does not exist in the backend
+   */
+  async getPrivateKey(keyRef) {
+    const pemContent = await this.backend.retrieve(keyRef);
+    const tempDir = await fs2.mkdtemp(path3.join(os2.tmpdir(), "attest-it-vk-"));
+    const tempKeyPath = path3.join(tempDir, "private.pem");
+    try {
+      await fs2.writeFile(tempKeyPath, pemContent, "utf-8");
+      await setKeyPermissions(tempKeyPath);
+      return {
+        keyPath: tempKeyPath,
+        cleanup: async () => {
+          try {
+            const stat3 = await fs2.stat(tempKeyPath);
+            await fs2.writeFile(tempKeyPath, crypto22.randomBytes(stat3.size));
+            await fs2.unlink(tempKeyPath);
+            await fs2.rmdir(tempDir);
+          } catch (cleanupError) {
+            console.warn(
+              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+            );
+          }
+        }
+      };
+    } catch (error2) {
+      try {
+        await fs2.rm(tempDir, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.warn(
+          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+        );
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Generate a new Ed25519 keypair and store the private key in VaultKeeper.
+   *
+   * @remarks
+   * The public key is written to the filesystem for repository commit.
+   * The private key is stored in the VaultKeeper backend and the local
+   * copy is securely deleted.
+   *
+   * @param options - Key generation options
+   */
+  async generateKeyPair(options) {
+    const { publicKeyPath, force = false } = options;
+    if (!force) {
+      try {
+        await fs2.access(publicKeyPath);
+        throw new Error(
+          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
+        );
+      } catch (err) {
+        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+          throw err;
+        }
+      }
+    }
+    const keyPair = generateKeyPair2();
+    await fs2.mkdir(path3.dirname(publicKeyPath), { recursive: true });
+    await fs2.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
+    const secretId = `attest-it-${crypto22.randomUUID()}`;
+    await this.backend.store(secretId, keyPair.privateKey);
+    return {
+      privateKeyRef: secretId,
+      publicKeyPath,
+      storageDescription: `VaultKeeper (${this.backend.displayName}): ${secretId}`
+    };
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return {
+      type: this.type,
+      options: { backendType: this.backend.type }
+    };
+  }
+};
+var LegacyFilesystemKeyProvider = class {
+  type = "filesystem-legacy";
+  displayName = "Filesystem (Legacy)";
+  /**
    * Check if this provider is available.
-   * Filesystem provider is always available.
+   * The legacy filesystem provider is always available.
    */
   async isAvailable() {
     return Promise.resolve(true);
   }
   /**
-   * Check if a key exists at the given path.
-   * @param keyRef - Path to the private key file
+   * Check if a key exists at the given filesystem path.
+   * @param keyRef - Filesystem path to the private key file
    */
   async keyExists(keyRef) {
     try {
@@ -42830,7 +47177,7 @@ var FilesystemKeyProvider = class {
   /**
    * Get the private key path for signing.
    * Returns the path directly with a no-op cleanup function.
-   * @param keyRef - Path to the private key file
+   * @param keyRef - Filesystem path to the private key file
    */
   async getPrivateKey(keyRef) {
     if (!await this.keyExists(keyRef)) {
@@ -42838,1121 +47185,30 @@ var FilesystemKeyProvider = class {
     }
     return {
       keyPath: keyRef,
-      // No-op cleanup for filesystem provider
+      // No-op cleanup — key stays on filesystem
       cleanup: async () => {
       }
     };
   }
   /**
-   * Generate a new keypair and store on filesystem.
-   * @param options - Key generation options
+   * Not supported — legacy provider does not create new keys.
+   * @param _options - Unused key generation options
+   * @throws Always throws an informative error directing the user to `identity create`
    */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false, passphrase } = options;
-    const cryptoOptions = {
-      privatePath: this.privateKeyPath,
-      publicPath: publicKeyPath,
-      force
-    };
-    if (passphrase !== void 0) {
-      cryptoOptions.passphrase = passphrase;
-    }
-    const result = await generateKeyPair(cryptoOptions);
-    const encrypted = passphrase !== void 0 && passphrase.length > 0;
-    const encryptionStatus = encrypted ? " (passphrase-encrypted)" : "";
-    return {
-      privateKeyRef: result.privatePath,
-      publicKeyPath: result.publicPath,
-      storageDescription: `Filesystem: ${result.privatePath}${encryptionStatus}`,
-      encrypted
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        privateKeyPath: this.privateKeyPath
-      }
-    };
-  }
-};
-var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
-  type = "1password";
-  displayName = "1Password";
-  accountUuid;
-  vault;
-  itemName;
-  /**
-   * Create a new OnePasswordKeyProvider.
-   * @param options - Provider options
-   */
-  constructor(options) {
-    if (options.accountUuid !== void 0) {
-      this.accountUuid = options.accountUuid;
-    }
-    this.vault = options.vault;
-    this.itemName = options.itemName;
-  }
-  /**
-   * Check if the 1Password CLI is installed.
-   * @returns True if `op` command is available
-   */
-  static async isInstalled() {
-    try {
-      await execCommand("op", ["--version"]);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * List all 1Password accounts.
-   * @returns Object containing accessible accounts and inaccessible accounts with reasons
-   */
-  static async listAccounts() {
-    const output = await execCommand("op", ["account", "list", "--format=json"]);
-    const parsed = JSON.parse(output);
-    if (!Array.isArray(parsed)) {
-      throw new Error("Unexpected response from 1Password: account list is not an array");
-    }
-    const basicAccounts = parsed;
-    const accountResults = [];
-    const RETRY_DELAY_MS = 500;
-    const MAX_RETRIES = 2;
-    for (const account of basicAccounts) {
-      if (!account.account_uuid) {
-        accountResults.push({
-          success: false,
-          email: account.email,
-          url: account.url,
-          reason: "Account missing account_uuid field"
-        });
-        continue;
-      }
-      let lastError;
-      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-        if (attempt > 0 || accountResults.length > 0) {
-          await new Promise((resolve6) => setTimeout(resolve6, RETRY_DELAY_MS));
-        }
-        try {
-          const detailOutput = await execCommand("op", [
-            "account",
-            "get",
-            "--account",
-            account.account_uuid,
-            "--format=json"
-          ]);
-          const details = JSON.parse(detailOutput);
-          if (details !== null && typeof details === "object" && "name" in details && typeof details.name === "string") {
-            accountResults.push({
-              success: true,
-              account: { ...account, name: details.name }
-            });
-            lastError = void 0;
-            break;
-          }
-          lastError = "Account details response missing name field";
-          break;
-        } catch (err) {
-          lastError = err instanceof Error ? err.message : String(err);
-        }
-      }
-      if (lastError !== void 0) {
-        accountResults.push({
-          success: false,
-          email: account.email,
-          url: account.url,
-          reason: lastError
-        });
-      }
-    }
-    const accounts = [];
-    const inaccessible = [];
-    for (const result of accountResults) {
-      if (result.success) {
-        accounts.push(result.account);
-      } else {
-        inaccessible.push({
-          email: result.email,
-          url: result.url,
-          reason: result.reason
-        });
-      }
-    }
-    if (accounts.length === 0 && basicAccounts.length > 0) {
-      const reasons = inaccessible.map((a) => `  - ${a.email}: ${a.reason}`).join("\n");
-      throw new Error(
-        `Could not access any 1Password accounts. All ${String(basicAccounts.length)} account(s) failed:
-${reasons}`
-      );
-    }
-    return { accounts, inaccessible };
-  }
-  /**
-   * List vaults in a specific account.
-   * @param accountUuid - Account UUID from listAccounts() (optional if only one account)
-   * @returns Array of vault information
-   */
-  static async listVaults(accountUuid) {
-    const args = ["vault", "list", "--format=json"];
-    if (accountUuid) {
-      args.push("--account", accountUuid);
-    }
-    let output;
-    try {
-      output = await execCommand("op", args);
-    } catch (error2) {
-      throw new Error(
-        `Failed to list 1Password vaults${accountUuid ? ` for account ${accountUuid}` : ""}: ${error2 instanceof Error ? error2.message : String(error2)}`
-      );
-    }
-    const parsed = JSON.parse(output);
-    if (!Array.isArray(parsed)) {
-      throw new Error("Unexpected response from 1Password: vault list is not an array");
-    }
-    return parsed;
-  }
-  /**
-   * Check if this provider is available.
-   * Requires `op` CLI to be installed and authenticated.
-   */
-  async isAvailable() {
-    return _OnePasswordKeyProvider.isInstalled();
-  }
-  /**
-   * Check if a key exists in 1Password.
-   * @param keyRef - Item name in 1Password
-   */
-  async keyExists(keyRef) {
-    try {
-      const args = ["item", "get", keyRef, "--vault", this.vault, "--format=json"];
-      if (this.accountUuid) {
-        args.push("--account", this.accountUuid);
-      }
-      await execCommand("op", args);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key from 1Password for signing.
-   * Downloads to a temporary file and returns a cleanup function.
-   *
-   * @remarks
-   * For security, this runs in a new PTY which requires the user to authenticate
-   * (via Touch ID, password, etc.) each time. This prevents automated agents
-   * from using cached credentials.
-   *
-   * @param keyRef - Item name in 1Password
-   * @throws Error if the key does not exist in 1Password
-   */
-  async getPrivateKey(keyRef) {
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(
-        `Key not found in 1Password: "${keyRef}" (vault: ${this.vault})` + (this.accountUuid ? ` (accountUuid: ${this.accountUuid})` : "")
-      );
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      const args = ["document", "get", keyRef, "--vault", this.vault, "--out-file", tempKeyPath];
-      if (this.accountUuid) {
-        args.push("--account", this.accountUuid);
-      }
-      await execInteractiveCommand("op", args);
-      await setKeyPermissions(tempKeyPath);
-      return {
-        keyPath: tempKeyPath,
-        cleanup: async () => {
-          try {
-            await fs2.unlink(tempKeyPath);
-            await fs2.rmdir(tempDir);
-          } catch (cleanupError) {
-            console.warn(
-              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-            );
-          }
-        }
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new Ed25519 keypair and store private key in 1Password.
-   * Public key is written to filesystem for repository commit.
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    if (!force) {
-      try {
-        await fs2.access(publicKeyPath);
-        throw new Error(
-          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
-        );
-      } catch (err) {
-        if (err instanceof Error && !err.message.includes("already exists")) ;
-        else {
-          throw err;
-        }
-      }
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-keygen-"));
-    const tempPrivateKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      const keyPair = generateKeyPair2();
-      await fs2.writeFile(tempPrivateKeyPath, keyPair.privateKey, "utf-8");
-      await setKeyPermissions(tempPrivateKeyPath);
-      await fs2.mkdir(path3.dirname(publicKeyPath), { recursive: true });
-      await fs2.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
-      const args = [
-        "document",
-        "create",
-        tempPrivateKeyPath,
-        "--title",
-        this.itemName,
-        "--vault",
-        this.vault
-      ];
-      if (this.accountUuid) {
-        args.push("--account", this.accountUuid);
-      }
-      await execCommand("op", args);
-      await fs2.unlink(tempPrivateKeyPath);
-      await fs2.rmdir(tempDir);
-      return {
-        privateKeyRef: this.itemName,
-        publicKeyPath,
-        storageDescription: `1Password: ${this.vault}/${this.itemName}`
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        ...this.accountUuid && { accountUuid: this.accountUuid },
-        vault: this.vault,
-        itemName: this.itemName
-      }
-    };
-  }
-};
-function getCleanEnvironment() {
-  const env = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (!key.startsWith("OP_SESSION_") && key !== "OP_SERVICE_ACCOUNT_TOKEN") {
-      env[key] = value;
-    }
-  }
-  return env;
-}
-async function execCommand(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = (0, import_child_process.spawn)(command, args, {
-      stdio: ["inherit", "pipe", "pipe"],
-      env: getCleanEnvironment()
-    });
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-async function execInteractiveCommand(command, args) {
-  return new Promise((resolve6, reject) => {
-    const platform = process.platform;
-    let proc;
-    if (platform === "win32") {
-      proc = (0, import_child_process.spawn)(command, args, {
-        stdio: ["inherit", "pipe", "pipe"],
-        env: getCleanEnvironment()
-      });
-    } else if (platform === "darwin") {
-      proc = (0, import_child_process.spawn)("script", ["-q", "/dev/null", command, ...args], {
-        stdio: ["inherit", "pipe", "pipe"],
-        env: getCleanEnvironment()
-      });
-    } else {
-      const quotedArgs = args.map((arg) => `'${arg.replace(/'/g, "'\\''")}'`).join(" ");
-      const fullCommand = `${command} ${quotedArgs}`;
-      proc = (0, import_child_process.spawn)("script", ["-q", "/dev/null", "-c", fullCommand], {
-        stdio: ["inherit", "pipe", "pipe"],
-        env: getCleanEnvironment()
-      });
-    }
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-var MacOSKeychainKeyProvider = class _MacOSKeychainKeyProvider {
-  type = "macos-keychain";
-  displayName = "macOS Keychain";
-  itemName;
-  keychain;
-  static ACCOUNT = "attest-it";
-  /**
-   * Create a new MacOSKeychainKeyProvider.
-   * @param options - Provider options
-   */
-  constructor(options) {
-    this.itemName = options.itemName;
-    if (options.keychain !== void 0) {
-      this.keychain = options.keychain;
-    }
-  }
-  /**
-   * Check if this provider is available.
-   * Only available on macOS platforms.
-   */
-  static isAvailable() {
-    return process.platform === "darwin";
-  }
-  /**
-   * List available keychains on the system.
-   * @returns Array of keychain information
-   */
-  static async listKeychains() {
-    if (!_MacOSKeychainKeyProvider.isAvailable()) {
-      return [];
-    }
-    try {
-      const output = await execCommand2("security", ["list-keychains"]);
-      const keychains = [];
-      const lines = output.split("\n");
-      for (const line of lines) {
-        const match = /"(.+)"/.exec(line.trim());
-        if (match?.[1]) {
-          const fullPath = match[1];
-          const filename = fullPath.split("/").pop() ?? fullPath;
-          const name = filename.replace(/\.keychain(-db)?$/, "");
-          keychains.push({ path: fullPath, name });
-        }
-      }
-      return keychains;
-    } catch {
-      return [];
-    }
-  }
-  /**
-   * Check if this provider is available on the current system.
-   */
-  isAvailable() {
-    return Promise.resolve(_MacOSKeychainKeyProvider.isAvailable());
-  }
-  /**
-   * Check if a key exists in the keychain.
-   * @param keyRef - Item name in keychain
-   */
-  async keyExists(keyRef) {
-    try {
-      const args = ["find-generic-password", "-a", _MacOSKeychainKeyProvider.ACCOUNT, "-s", keyRef];
-      if (this.keychain) {
-        args.push(this.keychain);
-      }
-      await execCommand2("security", args);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key from keychain for signing.
-   * Downloads to a temporary file and returns a cleanup function.
-   * @param keyRef - Item name in keychain
-   * @throws Error if the key does not exist in keychain
-   */
-  async getPrivateKey(keyRef) {
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(
-        `Key not found in macOS Keychain: "${keyRef}" (account: ${_MacOSKeychainKeyProvider.ACCOUNT})`
-      );
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      const findArgs = [
-        "find-generic-password",
-        "-a",
-        _MacOSKeychainKeyProvider.ACCOUNT,
-        "-s",
-        keyRef,
-        "-w"
-      ];
-      if (this.keychain) {
-        findArgs.push(this.keychain);
-      }
-      const base64Key = await execCommand2("security", findArgs);
-      const keyContent = Buffer.from(base64Key, "base64").toString("utf8");
-      await fs2.writeFile(tempKeyPath, keyContent, { mode: 384 });
-      await setKeyPermissions(tempKeyPath);
-      return {
-        keyPath: tempKeyPath,
-        cleanup: async () => {
-          try {
-            await fs2.unlink(tempKeyPath);
-            await fs2.rmdir(tempDir);
-          } catch (cleanupError) {
-            console.warn(
-              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-            );
-          }
-        }
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new Ed25519 keypair and store private key in keychain.
-   * Public key is written to filesystem for repository commit.
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    let publicKeyExists = false;
-    try {
-      await fs2.access(publicKeyPath);
-      publicKeyExists = true;
-    } catch (error2) {
-      if (error2 instanceof Error && "code" in error2 && error2.code !== "ENOENT") {
-        throw error2;
-      }
-    }
-    if (publicKeyExists && !force) {
-      throw new Error(
-        `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
-      );
-    }
-    const { publicKey: publicKeyBase64, privateKey: privateKeyPem } = generateKeyPair2();
-    const publicKeyDir = path3.dirname(publicKeyPath);
-    await fs2.mkdir(publicKeyDir, { recursive: true });
-    const publicKeyPem = `-----BEGIN PUBLIC KEY-----
-${publicKeyBase64}
------END PUBLIC KEY-----
-`;
-    await fs2.writeFile(publicKeyPath, publicKeyPem, { mode: 420 });
-    const base64Key = Buffer.from(privateKeyPem, "utf8").toString("base64");
-    const addArgs = [
-      "add-generic-password",
-      "-a",
-      _MacOSKeychainKeyProvider.ACCOUNT,
-      "-s",
-      this.itemName,
-      "-w",
-      base64Key,
-      "-T",
-      "",
-      "-U"
-    ];
-    if (this.keychain) {
-      addArgs.push(this.keychain);
-    }
-    await execCommand2("security", addArgs);
-    return {
-      privateKeyRef: this.itemName,
-      publicKeyPath,
-      storageDescription: `macOS Keychain: ${this.itemName}`
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        itemName: this.itemName
-      }
-    };
-  }
-};
-async function execCommand2(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = (0, import_child_process.spawn)(command, args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-var ATTEST_IT_HOME_ENV = "ATTEST_IT_HOME";
-var homeDirOverride = null;
-function getAttestItHomeDir() {
-  const envOverride = process.env[ATTEST_IT_HOME_ENV];
-  if (envOverride) {
-    return envOverride;
-  }
-  return homeDirOverride;
-}
-function getIdentityConfigDir(homeDir) {
-  if (homeDir) {
-    return homeDir;
-  }
-  const override = getAttestItHomeDir();
-  if (override) {
-    return override;
-  }
-  return (0, import_path3.join)((0, import_os.homedir)(), ".config", "attest-it");
-}
-var EncryptedKeyFileSchema = external_exports.object({
-  version: external_exports.literal(1),
-  iv: external_exports.string().min(1),
-  authTag: external_exports.string().min(1),
-  salt: external_exports.string().min(1),
-  challenge: external_exports.string().min(1),
-  ciphertext: external_exports.string().min(1),
-  slot: external_exports.union([external_exports.literal(1), external_exports.literal(2)]),
-  serial: external_exports.string().optional(),
-  aad: external_exports.string().optional()
-});
-var activeCleanupHandlers = /* @__PURE__ */ new Set();
-var processHandlersInstalled = false;
-function installProcessHandlers() {
-  if (processHandlersInstalled) return;
-  processHandlersInstalled = true;
-  const runCleanup = async () => {
-    const handlers = Array.from(activeCleanupHandlers);
-    await Promise.allSettled(handlers.map((h) => h()));
-  };
-  process.once("beforeExit", () => {
-    void runCleanup();
-  });
-  process.once("SIGINT", () => {
-    void runCleanup().finally(() => process.exit(130));
-  });
-  process.once("SIGTERM", () => {
-    void runCleanup().finally(() => process.exit(143));
-  });
-}
-function validateEncryptedKeyFile(data) {
-  const parsed = EncryptedKeyFileSchema.parse(data);
-  const iv = Buffer.from(parsed.iv, "base64");
-  if (iv.length !== 12) {
-    throw new Error(`Invalid IV size: expected 12 bytes, got ${String(iv.length)}`);
-  }
-  const authTag = Buffer.from(parsed.authTag, "base64");
-  if (authTag.length !== 16) {
-    throw new Error(`Invalid auth tag size: expected 16 bytes, got ${String(authTag.length)}`);
-  }
-  const salt = Buffer.from(parsed.salt, "base64");
-  if (salt.length !== 32) {
-    throw new Error(`Invalid salt size: expected 32 bytes, got ${String(salt.length)}`);
-  }
-  const challenge = Buffer.from(parsed.challenge, "base64");
-  if (challenge.length !== 32) {
-    throw new Error(`Invalid challenge size: expected 32 bytes, got ${String(challenge.length)}`);
-  }
-  return parsed;
-}
-function constructAAD(version2, slot, serial) {
-  const aadObject = {
-    version: version2,
-    slot,
-    serial: serial ?? "unspecified"
-  };
-  return Buffer.from(JSON.stringify(aadObject), "utf8");
-}
-var YubiKeyProvider = class _YubiKeyProvider {
-  type = "yubikey";
-  displayName = "YubiKey";
-  encryptedKeyPath;
-  slot;
-  serial;
-  /**
-   * Create a new YubiKeyProvider.
-   * @param options - Provider options
-   * @throws Error if encryptedKeyPath is outside the attest-it config directory
-   */
-  constructor(options) {
-    const resolvedPath = path3.resolve(options.encryptedKeyPath);
-    const configDir = getIdentityConfigDir();
-    if (!resolvedPath.startsWith(configDir)) {
-      throw new Error(
-        `Encrypted key path must be within attest-it config directory (${configDir}). Got: ${resolvedPath}`
-      );
-    }
-    this.encryptedKeyPath = resolvedPath;
-    this.slot = options.slot ?? 2;
-    if (options.serial !== void 0) {
-      this.serial = options.serial;
-    }
-  }
-  /**
-   * Check if ykman CLI is installed and available.
-   * @returns true if ykman is available
-   */
-  static async isInstalled() {
-    try {
-      await execCommand3("ykman", ["--version"]);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Check if any YubiKey is connected.
-   * @returns true if at least one YubiKey is connected
-   */
-  static async isConnected() {
-    try {
-      const output = await execCommand3("ykman", ["list", "--serials"]);
-      return output.trim().length > 0;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Check if HMAC challenge-response is configured on a slot.
-   * @param slot - Slot number (1 or 2)
-   * @param serial - Optional YubiKey serial number
-   * @returns true if challenge-response is configured
-   */
-  static async isChallengeResponseConfigured(slot = 2, serial) {
-    try {
-      const testChallenge = Buffer.from("attest-it-test-challenge-12345");
-      const args = ["otp", "calculate", String(slot), testChallenge.toString("hex")];
-      if (serial) {
-        args.unshift("--device", serial);
-      }
-      await execInteractiveCommand2("ykman", args);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * List connected YubiKeys.
-   * @returns Array of YubiKey information
-   */
-  static async listDevices() {
-    if (!await _YubiKeyProvider.isInstalled()) {
-      return [];
-    }
-    try {
-      const output = await execCommand3("ykman", ["list", "--serials"]);
-      const serials = output.trim().split("\n").filter((s) => s.length > 0);
-      const devices = [];
-      for (const serial of serials) {
-        try {
-          const infoOutput = await execCommand3("ykman", ["--device", serial, "info"]);
-          const typeMatch = /Device type:\s+(.+)/i.exec(infoOutput);
-          const fwMatch = /Firmware version:\s+(.+)/i.exec(infoOutput);
-          devices.push({
-            serial,
-            type: typeMatch?.[1]?.trim() ?? "YubiKey",
-            firmware: fwMatch?.[1]?.trim() ?? "Unknown"
-          });
-        } catch {
-          devices.push({
-            serial,
-            type: "YubiKey",
-            firmware: "Unknown"
-          });
-        }
-      }
-      return devices;
-    } catch {
-      return [];
-    }
-  }
-  /**
-   * Check if this provider is available on the current system.
-   * Requires ykman to be installed.
-   */
-  async isAvailable() {
-    return _YubiKeyProvider.isInstalled();
-  }
-  /**
-   * Check if an encrypted key file exists.
-   * @param keyRef - Path to encrypted key file
-   */
-  async keyExists(keyRef) {
-    try {
-      await fs2.access(keyRef);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key by decrypting with YubiKey.
-   * Downloads to a temporary file and returns a cleanup function.
-   *
-   * **Important**: Always call the cleanup function when done to securely delete
-   * the temporary key file. The cleanup is also registered for process exit handlers.
-   *
-   * @param keyRef - Path to encrypted key file
-   * @throws Error if the key cannot be decrypted
-   */
-  async getPrivateKey(keyRef) {
-    installProcessHandlers();
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(`Encrypted key file not found: ${keyRef}`);
-    }
-    const encryptedData = await fs2.readFile(keyRef, "utf8");
-    let keyFile;
-    try {
-      const parsed = JSON.parse(encryptedData);
-      keyFile = validateEncryptedKeyFile(parsed);
-    } catch (err) {
-      if (err instanceof external_exports.ZodError) {
-        throw new Error(
-          `Invalid encrypted key file format: ${err.errors.map((e) => e.message).join(", ")}`
-        );
-      }
-      throw new Error(`Invalid encrypted key file: malformed JSON or structure`);
-    }
-    const expectedSerial = this.serial ?? keyFile.serial;
-    if (!expectedSerial) {
-      console.warn(
-        "WARNING: No YubiKey serial number specified for key verification. Any YubiKey with the correct HMAC secret could decrypt this key. For better security, re-encrypt the key with a serial number specified."
-      );
-    }
-    if (expectedSerial) {
-      const devices = await _YubiKeyProvider.listDevices();
-      const matchingDevice = devices.find((d) => d.serial === expectedSerial);
-      if (!matchingDevice) {
-        throw new Error(
-          `Required YubiKey not found. Expected serial: ${expectedSerial}. Connected devices: ${devices.map((d) => d.serial).join(", ") || "none"}`
-        );
-      }
-    }
-    const challenge = Buffer.from(keyFile.challenge, "base64");
-    const response = await performChallengeResponse(challenge, keyFile.slot, expectedSerial);
-    const salt = Buffer.from(keyFile.salt, "base64");
-    const aesKey = deriveKey(response, salt);
-    const iv = Buffer.from(keyFile.iv, "base64");
-    const authTag = Buffer.from(keyFile.authTag, "base64");
-    const ciphertext = Buffer.from(keyFile.ciphertext, "base64");
-    let privateKeyContent;
-    try {
-      const decipher = crypto3.createDecipheriv("aes-256-gcm", aesKey, iv);
-      if (keyFile.aad) {
-        decipher.setAAD(Buffer.from(keyFile.aad, "base64"));
-      }
-      decipher.setAuthTag(authTag);
-      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-      privateKeyContent = decrypted.toString("utf8");
-    } catch {
-      throw new Error(
-        "Failed to decrypt private key. Verify you are using the correct YubiKey and the encrypted key file has not been corrupted or tampered with."
-      );
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    const cleanup = async () => {
-      activeCleanupHandlers.delete(cleanup);
-      try {
-        const keySize = Buffer.byteLength(privateKeyContent);
-        await fs2.writeFile(tempKeyPath, crypto3.randomBytes(keySize));
-        await fs2.unlink(tempKeyPath);
-        await fs2.rmdir(tempDir);
-      } catch {
-      }
-    };
-    try {
-      await fs2.writeFile(tempKeyPath, privateKeyContent, { mode: 384 });
-      await setKeyPermissions(tempKeyPath);
-      activeCleanupHandlers.add(cleanup);
-      return {
-        keyPath: tempKeyPath,
-        cleanup
-      };
-    } catch (error2) {
-      await cleanup();
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new keypair and store encrypted with YubiKey.
-   * Public key is written to filesystem for repository commit.
-   *
-   * **Security Note**: Always specify a serial number to bind the key to a specific YubiKey.
-   *
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    if (!await _YubiKeyProvider.isChallengeResponseConfigured(this.slot, this.serial)) {
-      throw new Error(
-        `YubiKey slot ${String(this.slot)} is not configured for HMAC challenge-response. Ensure your YubiKey is connected and use "ykman otp chalresp -t --generate 2" to configure it with touch required.`
-      );
-    }
-    if (!force && await this.keyExists(this.encryptedKeyPath)) {
-      throw new Error(
-        `Encrypted key file already exists: ${this.encryptedKeyPath}. Use force: true to overwrite.`
-      );
-    }
-    let serial;
-    if (this.serial) {
-      serial = this.serial;
-    } else {
-      const devices = await _YubiKeyProvider.listDevices();
-      if (devices.length === 1 && devices[0]) {
-        serial = devices[0].serial;
-      } else if (devices.length > 1) {
-        console.warn(
-          "WARNING: Multiple YubiKeys detected but no serial specified. Key will not be bound to a specific device. For better security, specify a serial number."
-        );
-      }
-    }
-    const { publicKey: publicKeyBase64, privateKey: privateKeyPem } = generateKeyPair2();
-    const publicKeyDir = path3.dirname(publicKeyPath);
-    await fs2.mkdir(publicKeyDir, { recursive: true });
-    const publicKeyPemFile = `-----BEGIN PUBLIC KEY-----
-${publicKeyBase64}
------END PUBLIC KEY-----
-`;
-    await fs2.writeFile(publicKeyPath, publicKeyPemFile, { mode: 420 });
-    const privateKeyContent = privateKeyPem;
-    const challenge = crypto3.randomBytes(32);
-    const salt = crypto3.randomBytes(32);
-    const iv = crypto3.randomBytes(12);
-    const response = await performChallengeResponse(challenge, this.slot, this.serial);
-    const aesKey = deriveKey(response, salt);
-    const aad = constructAAD(1, this.slot, serial);
-    const cipher = crypto3.createCipheriv("aes-256-gcm", aesKey, iv);
-    cipher.setAAD(aad);
-    const ciphertext = Buffer.concat([
-      cipher.update(Buffer.from(privateKeyContent, "utf8")),
-      cipher.final()
-    ]);
-    const authTag = cipher.getAuthTag();
-    const keyFile = {
-      version: 1,
-      iv: iv.toString("base64"),
-      authTag: authTag.toString("base64"),
-      salt: salt.toString("base64"),
-      challenge: challenge.toString("base64"),
-      ciphertext: ciphertext.toString("base64"),
-      slot: this.slot,
-      aad: aad.toString("base64"),
-      ...serial && { serial }
-    };
-    await fs2.mkdir(path3.dirname(this.encryptedKeyPath), { recursive: true });
-    await fs2.writeFile(this.encryptedKeyPath, JSON.stringify(keyFile, null, 2), { mode: 384 });
-    await setKeyPermissions(this.encryptedKeyPath);
-    return {
-      privateKeyRef: this.encryptedKeyPath,
-      publicKeyPath,
-      storageDescription: `YubiKey-encrypted: ${this.encryptedKeyPath}`
-    };
-  }
-  /**
-   * Encrypt an existing private key with YubiKey challenge-response.
-   *
-   * @remarks
-   * This static method allows encrypting a private key that was generated
-   * elsewhere (e.g., by the CLI) without having to create a provider instance first.
-   *
-   * **Security Note**: Always specify a serial number to bind the key to a specific YubiKey.
-   * The serial provides defense-in-depth by ensuring only the intended YubiKey can decrypt.
-   *
-   * @param options - Encryption options
-   * @returns Path to the encrypted key file and storage description
-   * @public
-   */
-  static async encryptPrivateKey(options) {
-    const { privateKey, encryptedKeyPath, slot = 2, serial } = options;
-    const resolvedPath = path3.resolve(encryptedKeyPath);
-    const configDir = getIdentityConfigDir();
-    if (!resolvedPath.startsWith(configDir)) {
-      throw new Error(
-        `Encrypted key path must be within attest-it config directory (${configDir}). Got: ${resolvedPath}`
-      );
-    }
-    if (!serial) {
-      console.warn(
-        "WARNING: No YubiKey serial number specified. Key will not be bound to a specific device. For better security, specify a serial number."
-      );
-    }
-    if (!await _YubiKeyProvider.isChallengeResponseConfigured(slot, serial)) {
-      throw new Error(
-        `YubiKey slot ${String(slot)} is not configured for HMAC challenge-response. Ensure your YubiKey is connected and use "ykman otp chalresp -t --generate 2" to configure it with touch required.`
-      );
-    }
-    const challenge = crypto3.randomBytes(32);
-    const salt = crypto3.randomBytes(32);
-    const iv = crypto3.randomBytes(12);
-    const response = await performChallengeResponse(challenge, slot, serial);
-    const aesKey = deriveKey(response, salt);
-    const aad = constructAAD(1, slot, serial);
-    const cipher = crypto3.createCipheriv("aes-256-gcm", aesKey, iv);
-    cipher.setAAD(aad);
-    const ciphertext = Buffer.concat([
-      cipher.update(Buffer.from(privateKey, "utf8")),
-      cipher.final()
-    ]);
-    const authTag = cipher.getAuthTag();
-    const keyFile = {
-      version: 1,
-      iv: iv.toString("base64"),
-      authTag: authTag.toString("base64"),
-      salt: salt.toString("base64"),
-      challenge: challenge.toString("base64"),
-      ciphertext: ciphertext.toString("base64"),
-      slot,
-      aad: aad.toString("base64"),
-      ...serial && { serial }
-    };
-    await fs2.mkdir(path3.dirname(resolvedPath), { recursive: true });
-    await fs2.writeFile(resolvedPath, JSON.stringify(keyFile, null, 2), { mode: 384 });
-    await setKeyPermissions(resolvedPath);
-    return {
-      encryptedKeyPath: resolvedPath,
-      storageDescription: `YubiKey-encrypted: ${resolvedPath}`
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        encryptedKeyPath: this.encryptedKeyPath,
-        slot: this.slot,
-        ...this.serial && { serial: this.serial }
-      }
-    };
-  }
-};
-async function execCommand3(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = (0, import_child_process.spawn)(command, args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-async function execInteractiveCommand2(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = (0, import_child_process.spawn)(command, args, { stdio: ["inherit", "pipe", "inherit"] });
-    let stdout = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-async function performChallengeResponse(challenge, slot, serial) {
-  const args = ["otp", "calculate", String(slot), challenge.toString("hex")];
-  if (serial) {
-    args.unshift("--device", serial);
-  }
-  try {
-    const output = await execInteractiveCommand2("ykman", args);
-    return Buffer.from(output.trim(), "hex");
-  } catch {
+  // Must stay async so the throw below becomes a rejected Promise, matching the KeyProvider interface contract
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async generateKeyPair(_options) {
     throw new Error(
-      "YubiKey challenge-response failed. Verify your YubiKey is inserted, touch it if prompted, and ensure the slot is configured for challenge-response with touch required (ykman otp chalresp -t --generate <slot>)."
+      'Legacy filesystem provider does not support key generation. Use "attest-it identity create" with a VaultKeeper-backed provider.'
     );
   }
-}
-function deriveKey(response, salt) {
-  const derived = crypto3.hkdfSync("sha256", response, salt, "attest-it-yubikey-v1", 32);
-  return Buffer.from(derived);
-}
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return { type: this.type, options: {} };
+  }
+};
 var KeyProviderRegistry = class {
   static providers = /* @__PURE__ */ new Map();
   /**
@@ -43986,52 +47242,24 @@ var KeyProviderRegistry = class {
     return Array.from(this.providers.keys());
   }
 };
-KeyProviderRegistry.register("filesystem", (config) => {
-  const privateKeyPath = typeof config.options.privateKeyPath === "string" ? config.options.privateKeyPath : void 0;
-  if (privateKeyPath !== void 0) {
-    return new FilesystemKeyProvider({ privateKeyPath });
-  }
-  return new FilesystemKeyProvider();
+KeyProviderRegistry.register("filesystem", (_config) => {
+  const backend = BackendRegistry.create("file");
+  return new VaultKeyProvider({ backend, displayName: "Filesystem" });
 });
-KeyProviderRegistry.register("1password", (config) => {
-  const { options } = config;
-  const accountUuid = typeof options.accountUuid === "string" ? options.accountUuid : void 0;
-  const vault = typeof options.vault === "string" ? options.vault : "";
-  const itemName = typeof options.itemName === "string" ? options.itemName : "";
-  if (!vault || !itemName) {
-    throw new Error("1Password provider requires vault and itemName options");
-  }
-  if (accountUuid !== void 0) {
-    return new OnePasswordKeyProvider({ accountUuid, vault, itemName });
-  }
-  return new OnePasswordKeyProvider({ vault, itemName });
+KeyProviderRegistry.register("1password", (_config) => {
+  const backend = BackendRegistry.create("1password");
+  return new VaultKeyProvider({ backend, displayName: "1Password" });
 });
-KeyProviderRegistry.register("macos-keychain", (config) => {
-  const { options } = config;
-  const itemName = typeof options.itemName === "string" ? options.itemName : "";
-  if (!itemName) {
-    throw new Error("macOS Keychain provider requires itemName option");
-  }
-  return new MacOSKeychainKeyProvider({ itemName });
+KeyProviderRegistry.register("macos-keychain", (_config) => {
+  const backend = BackendRegistry.create("keychain");
+  return new VaultKeyProvider({ backend, displayName: "macOS Keychain" });
 });
-KeyProviderRegistry.register("yubikey", (config) => {
-  const { options } = config;
-  const encryptedKeyPath = typeof options.encryptedKeyPath === "string" ? options.encryptedKeyPath : "";
-  if (!encryptedKeyPath) {
-    throw new Error("YubiKey provider requires encryptedKeyPath option");
-  }
-  const slot = typeof options.slot === "number" && (options.slot === 1 || options.slot === 2) ? options.slot : void 0;
-  const serial = typeof options.serial === "string" ? options.serial : void 0;
-  const providerOptions = {
-    encryptedKeyPath
-  };
-  if (slot !== void 0) {
-    providerOptions.slot = slot;
-  }
-  if (serial !== void 0) {
-    providerOptions.serial = serial;
-  }
-  return new YubiKeyProvider(providerOptions);
+KeyProviderRegistry.register("yubikey", (_config) => {
+  const backend = BackendRegistry.create("yubikey");
+  return new VaultKeyProvider({ backend, displayName: "YubiKey" });
+});
+KeyProviderRegistry.register("filesystem-legacy", (_config) => {
+  return new LegacyFilesystemKeyProvider();
 });
 var cliExperienceSchema = external_exports.object({
   declinedCompletionInstall: external_exports.boolean().optional()

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -41,9 +41,13 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 // ../../node_modules/.pnpm/tsup@8.5.1_@microsoft+api-extractor@7.55.2_@types+node@22.19.3__jiti@2.6.1_postcss@8.5._65dab1016c61d0c054da0a70acdf15cb/node_modules/tsup/assets/esm_shims.js
 import path from "path";
 import { fileURLToPath } from "url";
+var getFilename, getDirname, __dirname;
 var init_esm_shims = __esm({
   "../../node_modules/.pnpm/tsup@8.5.1_@microsoft+api-extractor@7.55.2_@types+node@22.19.3__jiti@2.6.1_postcss@8.5._65dab1016c61d0c054da0a70acdf15cb/node_modules/tsup/assets/esm_shims.js"() {
     "use strict";
+    getFilename = () => fileURLToPath(import.meta.url);
+    getDirname = () => path.dirname(getFilename());
+    __dirname = /* @__PURE__ */ getDirname();
   }
 });
 
@@ -114,11 +118,11 @@ var require_command = __commonJS({
     };
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.issue = exports.issueCommand = void 0;
-    var os2 = __importStar(__require("os"));
+    var os3 = __importStar(__require("os"));
     var utils_1 = require_utils();
     function issueCommand(command, properties, message) {
       const cmd = new Command(command, properties, message);
-      process.stdout.write(cmd.toString() + os2.EOL);
+      process.stdout.write(cmd.toString() + os3.EOL);
     }
     exports.issueCommand = issueCommand;
     function issue(name, message = "") {
@@ -202,18 +206,18 @@ var require_file_command = __commonJS({
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
     var crypto = __importStar(__require("crypto"));
-    var fs3 = __importStar(__require("fs"));
-    var os2 = __importStar(__require("os"));
+    var fs4 = __importStar(__require("fs"));
+    var os3 = __importStar(__require("os"));
     var utils_1 = require_utils();
     function issueFileCommand(command, message) {
       const filePath = process.env[`GITHUB_${command}`];
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
       }
-      if (!fs3.existsSync(filePath)) {
+      if (!fs4.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
       }
-      fs3.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os2.EOL}`, {
+      fs4.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os3.EOL}`, {
         encoding: "utf8"
       });
     }
@@ -227,7 +231,7 @@ var require_file_command = __commonJS({
       if (convertedValue.includes(delimiter)) {
         throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
       }
-      return `${key}<<${delimiter}${os2.EOL}${convertedValue}${os2.EOL}${delimiter}`;
+      return `${key}<<${delimiter}${os3.EOL}${convertedValue}${os3.EOL}${delimiter}`;
     }
     exports.prepareKeyValueMessage = prepareKeyValueMessage;
   }
@@ -357,44 +361,44 @@ var require_tunnel = __commonJS({
       return agent;
     }
     function TunnelingAgent(options) {
-      var self = this;
-      self.options = options || {};
-      self.proxyOptions = self.options.proxy || {};
-      self.maxSockets = self.options.maxSockets || http.Agent.defaultMaxSockets;
-      self.requests = [];
-      self.sockets = [];
-      self.on("free", function onFree(socket, host, port, localAddress) {
+      var self2 = this;
+      self2.options = options || {};
+      self2.proxyOptions = self2.options.proxy || {};
+      self2.maxSockets = self2.options.maxSockets || http.Agent.defaultMaxSockets;
+      self2.requests = [];
+      self2.sockets = [];
+      self2.on("free", function onFree(socket, host, port, localAddress) {
         var options2 = toOptions(host, port, localAddress);
-        for (var i = 0, len = self.requests.length; i < len; ++i) {
-          var pending = self.requests[i];
+        for (var i = 0, len = self2.requests.length; i < len; ++i) {
+          var pending = self2.requests[i];
           if (pending.host === options2.host && pending.port === options2.port) {
-            self.requests.splice(i, 1);
+            self2.requests.splice(i, 1);
             pending.request.onSocket(socket);
             return;
           }
         }
         socket.destroy();
-        self.removeSocket(socket);
+        self2.removeSocket(socket);
       });
     }
     util2.inherits(TunnelingAgent, events.EventEmitter);
     TunnelingAgent.prototype.addRequest = function addRequest(req, host, port, localAddress) {
-      var self = this;
-      var options = mergeOptions({ request: req }, self.options, toOptions(host, port, localAddress));
-      if (self.sockets.length >= this.maxSockets) {
-        self.requests.push(options);
+      var self2 = this;
+      var options = mergeOptions({ request: req }, self2.options, toOptions(host, port, localAddress));
+      if (self2.sockets.length >= this.maxSockets) {
+        self2.requests.push(options);
         return;
       }
-      self.createSocket(options, function(socket) {
+      self2.createSocket(options, function(socket) {
         socket.on("free", onFree);
         socket.on("close", onCloseOrRemove);
         socket.on("agentRemove", onCloseOrRemove);
         req.onSocket(socket);
         function onFree() {
-          self.emit("free", socket, options);
+          self2.emit("free", socket, options);
         }
         function onCloseOrRemove(err) {
-          self.removeSocket(socket);
+          self2.removeSocket(socket);
           socket.removeListener("free", onFree);
           socket.removeListener("close", onCloseOrRemove);
           socket.removeListener("agentRemove", onCloseOrRemove);
@@ -402,10 +406,10 @@ var require_tunnel = __commonJS({
       });
     };
     TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
-      var self = this;
+      var self2 = this;
       var placeholder = {};
-      self.sockets.push(placeholder);
-      var connectOptions = mergeOptions({}, self.proxyOptions, {
+      self2.sockets.push(placeholder);
+      var connectOptions = mergeOptions({}, self2.proxyOptions, {
         method: "CONNECT",
         path: options.host + ":" + options.port,
         agent: false,
@@ -421,7 +425,7 @@ var require_tunnel = __commonJS({
         connectOptions.headers["Proxy-Authorization"] = "Basic " + new Buffer(connectOptions.proxyAuth).toString("base64");
       }
       debug("making CONNECT request");
-      var connectReq = self.request(connectOptions);
+      var connectReq = self2.request(connectOptions);
       connectReq.useChunkedEncodingByDefault = false;
       connectReq.once("response", onResponse);
       connectReq.once("upgrade", onUpgrade);
@@ -448,7 +452,7 @@ var require_tunnel = __commonJS({
           var error2 = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
           error2.code = "ECONNRESET";
           options.request.emit("error", error2);
-          self.removeSocket(placeholder);
+          self2.removeSocket(placeholder);
           return;
         }
         if (head.length > 0) {
@@ -457,11 +461,11 @@ var require_tunnel = __commonJS({
           var error2 = new Error("got illegal response body from proxy");
           error2.code = "ECONNRESET";
           options.request.emit("error", error2);
-          self.removeSocket(placeholder);
+          self2.removeSocket(placeholder);
           return;
         }
         debug("tunneling connection has established");
-        self.sockets[self.sockets.indexOf(placeholder)] = socket;
+        self2.sockets[self2.sockets.indexOf(placeholder)] = socket;
         return cb(socket);
       }
       function onError(cause) {
@@ -474,7 +478,7 @@ var require_tunnel = __commonJS({
         var error2 = new Error("tunneling socket could not be established, cause=" + cause.message);
         error2.code = "ECONNRESET";
         options.request.emit("error", error2);
-        self.removeSocket(placeholder);
+        self2.removeSocket(placeholder);
       }
     };
     TunnelingAgent.prototype.removeSocket = function removeSocket(socket) {
@@ -491,15 +495,15 @@ var require_tunnel = __commonJS({
       }
     };
     function createSecureSocket(options, cb) {
-      var self = this;
-      TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
+      var self2 = this;
+      TunnelingAgent.prototype.createSocket.call(self2, options, function(socket) {
         var hostHeader = options.request.getHeader("host");
-        var tlsOptions = mergeOptions({}, self.options, {
+        var tlsOptions = mergeOptions({}, self2.options, {
           socket,
           servername: hostHeader ? hostHeader.replace(/:.*$/, "") : options.host
         });
         var secureSocket = tls.connect(0, tlsOptions);
-        self.sockets[self.sockets.indexOf(socket)] = secureSocket;
+        self2.sockets[self2.sockets.indexOf(socket)] = secureSocket;
         cb(secureSocket);
       });
     }
@@ -1614,7 +1618,7 @@ var require_HeaderParser = __commonJS({
     function HeaderParser(cfg) {
       EventEmitter.call(this);
       cfg = cfg || {};
-      const self = this;
+      const self2 = this;
       this.nread = 0;
       this.maxed = false;
       this.npairs = 0;
@@ -1625,18 +1629,18 @@ var require_HeaderParser = __commonJS({
       this.finished = false;
       this.ss = new StreamSearch(B_DCRLF);
       this.ss.on("info", function(isMatch, data, start, end) {
-        if (data && !self.maxed) {
-          if (self.nread + end - start >= self.maxHeaderSize) {
-            end = self.maxHeaderSize - self.nread + start;
-            self.nread = self.maxHeaderSize;
-            self.maxed = true;
+        if (data && !self2.maxed) {
+          if (self2.nread + end - start >= self2.maxHeaderSize) {
+            end = self2.maxHeaderSize - self2.nread + start;
+            self2.nread = self2.maxHeaderSize;
+            self2.maxed = true;
           } else {
-            self.nread += end - start;
+            self2.nread += end - start;
           }
-          self.buffer += data.toString("binary", start, end);
+          self2.buffer += data.toString("binary", start, end);
         }
         if (isMatch) {
-          self._finish();
+          self2._finish();
         }
       });
     }
@@ -1742,34 +1746,34 @@ var require_Dicer = __commonJS({
       this._ignoreData = false;
       this._partOpts = { highWaterMark: cfg.partHwm };
       this._pause = false;
-      const self = this;
+      const self2 = this;
       this._hparser = new HeaderParser(cfg);
       this._hparser.on("header", function(header) {
-        self._inHeader = false;
-        self._part.emit("header", header);
+        self2._inHeader = false;
+        self2._part.emit("header", header);
       });
     }
     inherits(Dicer, WritableStream);
     Dicer.prototype.emit = function(ev) {
       if (ev === "finish" && !this._realFinish) {
         if (!this._finished) {
-          const self = this;
+          const self2 = this;
           process.nextTick(function() {
-            self.emit("error", new Error("Unexpected end of multipart data"));
-            if (self._part && !self._ignoreData) {
-              const type = self._isPreamble ? "Preamble" : "Part";
-              self._part.emit("error", new Error(type + " terminated early due to unexpected end of multipart data"));
-              self._part.push(null);
+            self2.emit("error", new Error("Unexpected end of multipart data"));
+            if (self2._part && !self2._ignoreData) {
+              const type = self2._isPreamble ? "Preamble" : "Part";
+              self2._part.emit("error", new Error(type + " terminated early due to unexpected end of multipart data"));
+              self2._part.push(null);
               process.nextTick(function() {
-                self._realFinish = true;
-                self.emit("finish");
-                self._realFinish = false;
+                self2._realFinish = true;
+                self2.emit("finish");
+                self2._realFinish = false;
               });
               return;
             }
-            self._realFinish = true;
-            self.emit("finish");
-            self._realFinish = false;
+            self2._realFinish = true;
+            self2.emit("finish");
+            self2._realFinish = false;
           });
         }
       } else {
@@ -1813,10 +1817,10 @@ var require_Dicer = __commonJS({
       this._hparser = void 0;
     };
     Dicer.prototype.setBoundary = function(boundary) {
-      const self = this;
+      const self2 = this;
       this._bparser = new StreamSearch("\r\n--" + boundary);
       this._bparser.on("info", function(isMatch, data, start, end) {
-        self._oninfo(isMatch, data, start, end);
+        self2._oninfo(isMatch, data, start, end);
       });
     };
     Dicer.prototype._ignore = function() {
@@ -1828,7 +1832,7 @@ var require_Dicer = __commonJS({
     };
     Dicer.prototype._oninfo = function(isMatch, data, start, end) {
       let buf;
-      const self = this;
+      const self2 = this;
       let i = 0;
       let r;
       let shouldWriteMore = true;
@@ -1851,10 +1855,10 @@ var require_Dicer = __commonJS({
           }
           this.reset();
           this._finished = true;
-          if (self._parts === 0) {
-            self._realFinish = true;
-            self.emit("finish");
-            self._realFinish = false;
+          if (self2._parts === 0) {
+            self2._realFinish = true;
+            self2.emit("finish");
+            self2._realFinish = false;
           }
         }
         if (this._dashes) {
@@ -1867,7 +1871,7 @@ var require_Dicer = __commonJS({
       if (!this._part) {
         this._part = new PartStream(this._partOpts);
         this._part._read = function(n) {
-          self._unpause();
+          self2._unpause();
         };
         if (this._isPreamble && this.listenerCount("preamble") !== 0) {
           this.emit("preamble", this._part);
@@ -1907,13 +1911,13 @@ var require_Dicer = __commonJS({
           if (start !== end) {
             ++this._parts;
             this._part.on("end", function() {
-              if (--self._parts === 0) {
-                if (self._finished) {
-                  self._realFinish = true;
-                  self.emit("finish");
-                  self._realFinish = false;
+              if (--self2._parts === 0) {
+                if (self2._finished) {
+                  self2._realFinish = true;
+                  self2.emit("finish");
+                  self2._realFinish = false;
                 } else {
-                  self._unpause();
+                  self2._unpause();
                 }
               }
             });
@@ -2694,7 +2698,7 @@ var require_multipart = __commonJS({
     function Multipart(boy, cfg) {
       let i;
       let len;
-      const self = this;
+      const self2 = this;
       let boundary;
       const limits = cfg.limits;
       const isPartAFile = cfg.isPartAFile || ((fieldName, contentType, fileName) => contentType === "application/octet-stream" || fileName !== void 0);
@@ -2711,7 +2715,7 @@ var require_multipart = __commonJS({
       function checkFinished() {
         if (nends === 0 && finished && !boy._done) {
           finished = false;
-          self.end();
+          self2.end();
         }
       }
       if (typeof boundary !== "string") {
@@ -2744,16 +2748,16 @@ var require_multipart = __commonJS({
       };
       this.parser = new Dicer(parserCfg);
       this.parser.on("drain", function() {
-        self._needDrain = false;
-        if (self._cb && !self._pause) {
-          const cb = self._cb;
-          self._cb = void 0;
+        self2._needDrain = false;
+        if (self2._cb && !self2._pause) {
+          const cb = self2._cb;
+          self2._cb = void 0;
           cb();
         }
       }).on("part", function onPart(part) {
-        if (++self._nparts > partsLimit) {
-          self.parser.removeListener("part", onPart);
-          self.parser.on("part", skipPart);
+        if (++self2._nparts > partsLimit) {
+          self2.parser.removeListener("part", onPart);
+          self2.parser.on("part", skipPart);
           boy.hitPartsLimit = true;
           boy.emit("partsLimit");
           return skipPart(part);
@@ -2823,7 +2827,7 @@ var require_multipart = __commonJS({
             }
             ++nfiles;
             if (boy.listenerCount("file") === 0) {
-              self.parser._ignore();
+              self2.parser._ignore();
               return;
             }
             ++nends;
@@ -2831,22 +2835,22 @@ var require_multipart = __commonJS({
             curFile = file;
             file.on("end", function() {
               --nends;
-              self._pause = false;
+              self2._pause = false;
               checkFinished();
-              if (self._cb && !self._needDrain) {
-                const cb = self._cb;
-                self._cb = void 0;
+              if (self2._cb && !self2._needDrain) {
+                const cb = self2._cb;
+                self2._cb = void 0;
                 cb();
               }
             });
             file._read = function(n) {
-              if (!self._pause) {
+              if (!self2._pause) {
                 return;
               }
-              self._pause = false;
-              if (self._cb && !self._needDrain) {
-                const cb = self._cb;
-                self._cb = void 0;
+              self2._pause = false;
+              if (self2._cb && !self2._needDrain) {
+                const cb = self2._cb;
+                self2._cb = void 0;
                 cb();
               }
             };
@@ -2863,7 +2867,7 @@ var require_multipart = __commonJS({
                 file.emit("limit");
                 return;
               } else if (!file.push(data)) {
-                self._pause = true;
+                self2._pause = true;
               }
               file.bytesRead = nsize;
             };
@@ -2929,13 +2933,13 @@ var require_multipart = __commonJS({
       }
     };
     Multipart.prototype.end = function() {
-      const self = this;
-      if (self.parser.writable) {
-        self.parser.end();
-      } else if (!self._boy._done) {
+      const self2 = this;
+      if (self2.parser.writable) {
+        self2.parser.end();
+      } else if (!self2._boy._done) {
         process.nextTick(function() {
-          self._boy._done = true;
-          self._boy.emit("finish");
+          self2._boy._done = true;
+          self2._boy.emit("finish");
         });
       }
     };
@@ -4068,8 +4072,8 @@ var require_util2 = __commonJS({
     function createDeferredPromise() {
       let res;
       let rej;
-      const promise2 = new Promise((resolve4, reject) => {
-        res = resolve4;
+      const promise2 = new Promise((resolve6, reject) => {
+        res = resolve6;
         rej = reject;
       });
       return { promise: promise2, resolve: res, reject: rej };
@@ -5580,8 +5584,8 @@ Content-Type: ${value.type || "application/octet-stream"}\r
                 });
               }
             });
-            const busboyResolve = new Promise((resolve4, reject) => {
-              busboy.on("finish", resolve4);
+            const busboyResolve = new Promise((resolve6, reject) => {
+              busboy.on("finish", resolve6);
               busboy.on("error", (err) => reject(new TypeError(err)));
             });
             if (this.body !== null) for await (const chunk of consumeBody(this[kState].body)) busboy.write(chunk);
@@ -5711,7 +5715,7 @@ var require_request = __commonJS({
       channels.trailers = { hasSubscribers: false };
       channels.error = { hasSubscribers: false };
     }
-    var Request = class _Request {
+    var Request2 = class _Request {
       constructor(origin, {
         path: path4,
         method,
@@ -6046,7 +6050,7 @@ var require_request = __commonJS({
         }
       }
     }
-    module.exports = Request;
+    module.exports = Request2;
   }
 });
 
@@ -6118,9 +6122,9 @@ var require_dispatcher_base = __commonJS({
       }
       close(callback2) {
         if (callback2 === void 0) {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             this.close((err, data) => {
-              return err ? reject(err) : resolve4(data);
+              return err ? reject(err) : resolve6(data);
             });
           });
         }
@@ -6158,12 +6162,12 @@ var require_dispatcher_base = __commonJS({
           err = null;
         }
         if (callback2 === void 0) {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             this.destroy(err, (err2, data) => {
               return err2 ? (
                 /* istanbul ignore next: should never error */
                 reject(err2)
-              ) : resolve4(data);
+              ) : resolve6(data);
             });
           });
         }
@@ -6938,7 +6942,7 @@ var require_client = __commonJS({
     var { pipeline } = __require("stream");
     var util2 = require_util();
     var timers = require_timers();
-    var Request = require_request();
+    var Request2 = require_request();
     var DispatcherBase = require_dispatcher_base();
     var {
       RequestContentLengthMismatchError,
@@ -7218,7 +7222,7 @@ var require_client = __commonJS({
       }
       [kDispatch](opts, handler2) {
         const origin = opts.origin || this[kUrl].origin;
-        const request2 = this[kHTTPConnVersion] === "h2" ? Request[kHTTP2BuildRequest](origin, opts, handler2) : Request[kHTTP1BuildRequest](origin, opts, handler2);
+        const request2 = this[kHTTPConnVersion] === "h2" ? Request2[kHTTP2BuildRequest](origin, opts, handler2) : Request2[kHTTP1BuildRequest](origin, opts, handler2);
         this[kQueue].push(request2);
         if (this[kResuming]) {
         } else if (util2.bodyLength(request2.body) == null && util2.isIterable(request2.body)) {
@@ -7233,16 +7237,16 @@ var require_client = __commonJS({
         return this[kNeedDrain] < 2;
       }
       async [kClose]() {
-        return new Promise((resolve4) => {
+        return new Promise((resolve6) => {
           if (!this[kSize]) {
-            resolve4(null);
+            resolve6(null);
           } else {
-            this[kClosedResolve] = resolve4;
+            this[kClosedResolve] = resolve6;
           }
         });
       }
       async [kDestroy](err) {
-        return new Promise((resolve4) => {
+        return new Promise((resolve6) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
           for (let i = 0; i < requests.length; i++) {
             const request2 = requests[i];
@@ -7253,7 +7257,7 @@ var require_client = __commonJS({
               this[kClosedResolve]();
               this[kClosedResolve] = null;
             }
-            resolve4();
+            resolve6();
           };
           if (this[kHTTP2Session] != null) {
             util2.destroy(this[kHTTP2Session], err);
@@ -7833,7 +7837,7 @@ var require_client = __commonJS({
         });
       }
       try {
-        const socket = await new Promise((resolve4, reject) => {
+        const socket = await new Promise((resolve6, reject) => {
           client[kConnector]({
             host,
             hostname,
@@ -7845,7 +7849,7 @@ var require_client = __commonJS({
             if (err) {
               reject(err);
             } else {
-              resolve4(socket2);
+              resolve6(socket2);
             }
           });
         });
@@ -8171,7 +8175,7 @@ upgrade: ${upgrade}\r
     function writeH2(client, session, request2) {
       const { body, method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
       let headers;
-      if (typeof reqHeaders === "string") headers = Request[kHTTP2CopyHeaders](reqHeaders.trim());
+      if (typeof reqHeaders === "string") headers = Request2[kHTTP2CopyHeaders](reqHeaders.trim());
       else headers = reqHeaders;
       if (upgrade) {
         errorRequest(client, request2, new Error("Upgrade not supported for H2"));
@@ -8469,12 +8473,12 @@ upgrade: ${upgrade}\r
           cb();
         }
       }
-      const waitForDrain = () => new Promise((resolve4, reject) => {
+      const waitForDrain = () => new Promise((resolve6, reject) => {
         assert(callback2 === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback2 = resolve4;
+          callback2 = resolve6;
         }
       });
       if (client[kHTTPConnVersion] === "h2") {
@@ -8823,8 +8827,8 @@ var require_pool_base = __commonJS({
         if (this[kQueue].isEmpty()) {
           return Promise.all(this[kClients].map((c) => c.close()));
         } else {
-          return new Promise((resolve4) => {
-            this[kClosedResolve] = resolve4;
+          return new Promise((resolve6) => {
+            this[kClosedResolve] = resolve6;
           });
         }
       }
@@ -9165,7 +9169,7 @@ var require_agent = __commonJS({
     var Client = require_client();
     var util2 = require_util();
     var createRedirectInterceptor = require_redirectInterceptor();
-    var { WeakRef: WeakRef2, FinalizationRegistry } = require_dispatcher_weakref()();
+    var { WeakRef: WeakRef2, FinalizationRegistry: FinalizationRegistry2 } = require_dispatcher_weakref()();
     var kOnConnect = /* @__PURE__ */ Symbol("onConnect");
     var kOnDisconnect = /* @__PURE__ */ Symbol("onDisconnect");
     var kOnConnectionError = /* @__PURE__ */ Symbol("onConnectionError");
@@ -9198,7 +9202,7 @@ var require_agent = __commonJS({
         this[kMaxRedirections] = maxRedirections;
         this[kFactory] = factory;
         this[kClients] = /* @__PURE__ */ new Map();
-        this[kFinalizer] = new FinalizationRegistry(
+        this[kFinalizer] = new FinalizationRegistry2(
           /* istanbul ignore next: gc is undeterministic */
           (key) => {
             const ref = this[kClients].get(key);
@@ -9407,7 +9411,7 @@ var require_readable = __commonJS({
         if (this.closed) {
           return Promise.resolve(null);
         }
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           const signalListenerCleanup = signal ? util2.addAbortListener(signal, () => {
             this.destroy();
           }) : noop2;
@@ -9416,7 +9420,7 @@ var require_readable = __commonJS({
             if (signal && signal.aborted) {
               reject(signal.reason || Object.assign(new Error("The operation was aborted"), { name: "AbortError" }));
             } else {
-              resolve4(null);
+              resolve6(null);
             }
           }).on("error", noop2).on("data", function(chunk) {
             limit -= chunk.length;
@@ -9427,22 +9431,22 @@ var require_readable = __commonJS({
         });
       }
     };
-    function isLocked(self) {
-      return self[kBody] && self[kBody].locked === true || self[kConsume];
+    function isLocked(self2) {
+      return self2[kBody] && self2[kBody].locked === true || self2[kConsume];
     }
-    function isUnusable(self) {
-      return util2.isDisturbed(self) || isLocked(self);
+    function isUnusable(self2) {
+      return util2.isDisturbed(self2) || isLocked(self2);
     }
     async function consume(stream, type) {
       if (isUnusable(stream)) {
         throw new TypeError("unusable");
       }
       assert(!stream[kConsume]);
-      return new Promise((resolve4, reject) => {
+      return new Promise((resolve6, reject) => {
         stream[kConsume] = {
           type,
           stream,
-          resolve: resolve4,
+          resolve: resolve6,
           reject,
           length: 0,
           body: []
@@ -9477,12 +9481,12 @@ var require_readable = __commonJS({
       }
     }
     function consumeEnd(consume2) {
-      const { type, body, resolve: resolve4, stream, length } = consume2;
+      const { type, body, resolve: resolve6, stream, length } = consume2;
       try {
         if (type === "text") {
-          resolve4(toUSVString(Buffer.concat(body)));
+          resolve6(toUSVString(Buffer.concat(body)));
         } else if (type === "json") {
-          resolve4(JSON.parse(Buffer.concat(body)));
+          resolve6(JSON.parse(Buffer.concat(body)));
         } else if (type === "arrayBuffer") {
           const dst = new Uint8Array(length);
           let pos = 0;
@@ -9490,12 +9494,12 @@ var require_readable = __commonJS({
             dst.set(buf, pos);
             pos += buf.byteLength;
           }
-          resolve4(dst.buffer);
+          resolve6(dst.buffer);
         } else if (type === "blob") {
           if (!Blob2) {
             Blob2 = __require("buffer").Blob;
           }
-          resolve4(new Blob2(body, { type: stream[kContentType] }));
+          resolve6(new Blob2(body, { type: stream[kContentType] }));
         }
         consumeFinish(consume2);
       } catch (err) {
@@ -9579,40 +9583,40 @@ var require_abort_signal = __commonJS({
     var { RequestAbortedError } = require_errors();
     var kListener = /* @__PURE__ */ Symbol("kListener");
     var kSignal = /* @__PURE__ */ Symbol("kSignal");
-    function abort(self) {
-      if (self.abort) {
-        self.abort();
+    function abort(self2) {
+      if (self2.abort) {
+        self2.abort();
       } else {
-        self.onError(new RequestAbortedError());
+        self2.onError(new RequestAbortedError());
       }
     }
-    function addSignal(self, signal) {
-      self[kSignal] = null;
-      self[kListener] = null;
+    function addSignal(self2, signal) {
+      self2[kSignal] = null;
+      self2[kListener] = null;
       if (!signal) {
         return;
       }
       if (signal.aborted) {
-        abort(self);
+        abort(self2);
         return;
       }
-      self[kSignal] = signal;
-      self[kListener] = () => {
-        abort(self);
+      self2[kSignal] = signal;
+      self2[kListener] = () => {
+        abort(self2);
       };
-      addAbortListener(self[kSignal], self[kListener]);
+      addAbortListener(self2[kSignal], self2[kListener]);
     }
-    function removeSignal(self) {
-      if (!self[kSignal]) {
+    function removeSignal(self2) {
+      if (!self2[kSignal]) {
         return;
       }
-      if ("removeEventListener" in self[kSignal]) {
-        self[kSignal].removeEventListener("abort", self[kListener]);
+      if ("removeEventListener" in self2[kSignal]) {
+        self2[kSignal].removeEventListener("abort", self2[kListener]);
       } else {
-        self[kSignal].removeListener("abort", self[kListener]);
+        self2[kSignal].removeListener("abort", self2[kListener]);
       }
-      self[kSignal] = null;
-      self[kListener] = null;
+      self2[kSignal] = null;
+      self2[kListener] = null;
     }
     module.exports = {
       addSignal,
@@ -9755,9 +9759,9 @@ var require_api_request = __commonJS({
     };
     function request2(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           request2.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -9931,9 +9935,9 @@ var require_api_stream = __commonJS({
     };
     function stream(opts, factory, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           stream.call(this, opts, factory, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -10216,9 +10220,9 @@ var require_api_upgrade = __commonJS({
     };
     function upgrade(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           upgrade.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -10308,9 +10312,9 @@ var require_api_connect = __commonJS({
     };
     function connect(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve4, reject) => {
+        return new Promise((resolve6, reject) => {
           connect.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve4(data);
+            return err ? reject(err) : resolve6(data);
           });
         });
       }
@@ -11797,7 +11801,7 @@ var require_headers = __commonJS({
         return headers;
       }
     };
-    var Headers = class _Headers {
+    var Headers2 = class _Headers {
       constructor(init = void 0) {
         if (init === kConstruct) {
           return;
@@ -11992,8 +11996,8 @@ var require_headers = __commonJS({
         return this[kHeadersList];
       }
     };
-    Headers.prototype[Symbol.iterator] = Headers.prototype.entries;
-    Object.defineProperties(Headers.prototype, {
+    Headers2.prototype[Symbol.iterator] = Headers2.prototype.entries;
+    Object.defineProperties(Headers2.prototype, {
       append: kEnumerableProperty,
       delete: kEnumerableProperty,
       get: kEnumerableProperty,
@@ -12028,7 +12032,7 @@ var require_headers = __commonJS({
     };
     module.exports = {
       fill,
-      Headers,
+      Headers: Headers2,
       HeadersList
     };
   }
@@ -12039,7 +12043,7 @@ var require_response = __commonJS({
   "../../node_modules/.pnpm/undici@5.29.0/node_modules/undici/lib/fetch/response.js"(exports, module) {
     "use strict";
     init_esm_shims();
-    var { Headers, HeadersList, fill } = require_headers();
+    var { Headers: Headers2, HeadersList, fill } = require_headers();
     var { extractBody, cloneBody, mixinBody } = require_body();
     var util2 = require_util();
     var { kEnumerableProperty } = util2;
@@ -12067,7 +12071,7 @@ var require_response = __commonJS({
     var { types } = __require("util");
     var ReadableStream = globalThis.ReadableStream || __require("stream/web").ReadableStream;
     var textEncoder = new TextEncoder("utf-8");
-    var Response = class _Response {
+    var Response2 = class _Response {
       // Creates network error Response.
       static error() {
         const relevantRealm = { settingsObject: {} };
@@ -12131,7 +12135,7 @@ var require_response = __commonJS({
         init = webidl.converters.ResponseInit(init);
         this[kRealm] = { settingsObject: {} };
         this[kState] = makeResponse({});
-        this[kHeaders] = new Headers(kConstruct);
+        this[kHeaders] = new Headers2(kConstruct);
         this[kHeaders][kGuard] = "response";
         this[kHeaders][kHeadersList] = this[kState].headersList;
         this[kHeaders][kRealm] = this[kRealm];
@@ -12209,8 +12213,8 @@ var require_response = __commonJS({
         return clonedResponseObject;
       }
     };
-    mixinBody(Response);
-    Object.defineProperties(Response.prototype, {
+    mixinBody(Response2);
+    Object.defineProperties(Response2.prototype, {
       type: kEnumerableProperty,
       url: kEnumerableProperty,
       status: kEnumerableProperty,
@@ -12226,7 +12230,7 @@ var require_response = __commonJS({
         configurable: true
       }
     });
-    Object.defineProperties(Response, {
+    Object.defineProperties(Response2, {
       json: kEnumerableProperty,
       redirect: kEnumerableProperty,
       error: kEnumerableProperty
@@ -12408,7 +12412,7 @@ var require_response = __commonJS({
       makeResponse,
       makeAppropriateNetworkError,
       filterResponse,
-      Response,
+      Response: Response2,
       cloneResponse
     };
   }
@@ -12420,8 +12424,8 @@ var require_request2 = __commonJS({
     "use strict";
     init_esm_shims();
     var { extractBody, mixinBody, cloneBody } = require_body();
-    var { Headers, fill: fillHeaders, HeadersList } = require_headers();
-    var { FinalizationRegistry } = require_dispatcher_weakref()();
+    var { Headers: Headers2, fill: fillHeaders, HeadersList } = require_headers();
+    var { FinalizationRegistry: FinalizationRegistry2 } = require_dispatcher_weakref()();
     var util2 = require_util();
     var {
       isValidHTTPToken,
@@ -12450,10 +12454,10 @@ var require_request2 = __commonJS({
     var { getMaxListeners, setMaxListeners, getEventListeners, defaultMaxListeners } = __require("events");
     var TransformStream = globalThis.TransformStream;
     var kAbortController = /* @__PURE__ */ Symbol("abortController");
-    var requestFinalizer = new FinalizationRegistry(({ signal, abort }) => {
+    var requestFinalizer = new FinalizationRegistry2(({ signal, abort }) => {
       signal.removeEventListener("abort", abort);
     });
-    var Request = class _Request {
+    var Request2 = class _Request {
       // https://fetch.spec.whatwg.org/#dom-request
       constructor(input, init = {}) {
         if (input === kConstruct) {
@@ -12495,15 +12499,15 @@ var require_request2 = __commonJS({
           signal = input[kSignal];
         }
         const origin = this[kRealm].settingsObject.origin;
-        let window = "client";
+        let window2 = "client";
         if (request2.window?.constructor?.name === "EnvironmentSettingsObject" && sameOrigin(request2.window, origin)) {
-          window = request2.window;
+          window2 = request2.window;
         }
         if (init.window != null) {
-          throw new TypeError(`'window' option '${window}' must be null`);
+          throw new TypeError(`'window' option '${window2}' must be null`);
         }
         if ("window" in init) {
-          window = "no-window";
+          window2 = "no-window";
         }
         request2 = makeRequest({
           // URL request’s URL.
@@ -12518,7 +12522,7 @@ var require_request2 = __commonJS({
           // client This’s relevant settings object.
           client: this[kRealm].settingsObject,
           // window window.
-          window,
+          window: window2,
           // priority request’s priority.
           priority: request2.priority,
           // origin request’s origin. The propagation of the origin is only significant for navigation requests
@@ -12664,7 +12668,7 @@ var require_request2 = __commonJS({
             requestFinalizer.register(ac, { signal, abort });
           }
         }
-        this[kHeaders] = new Headers(kConstruct);
+        this[kHeaders] = new Headers2(kConstruct);
         this[kHeaders][kHeadersList] = request2.headersList;
         this[kHeaders][kGuard] = "request";
         this[kHeaders][kRealm] = this[kRealm];
@@ -12863,7 +12867,7 @@ var require_request2 = __commonJS({
         const clonedRequestObject = new _Request(kConstruct);
         clonedRequestObject[kState] = clonedRequest;
         clonedRequestObject[kRealm] = this[kRealm];
-        clonedRequestObject[kHeaders] = new Headers(kConstruct);
+        clonedRequestObject[kHeaders] = new Headers2(kConstruct);
         clonedRequestObject[kHeaders][kHeadersList] = clonedRequest.headersList;
         clonedRequestObject[kHeaders][kGuard] = this[kHeaders][kGuard];
         clonedRequestObject[kHeaders][kRealm] = this[kHeaders][kRealm];
@@ -12882,7 +12886,7 @@ var require_request2 = __commonJS({
         return clonedRequestObject;
       }
     };
-    mixinBody(Request);
+    mixinBody(Request2);
     function makeRequest(init) {
       const request2 = {
         method: "GET",
@@ -12933,7 +12937,7 @@ var require_request2 = __commonJS({
       }
       return newRequest;
     }
-    Object.defineProperties(Request.prototype, {
+    Object.defineProperties(Request2.prototype, {
       method: kEnumerableProperty,
       url: kEnumerableProperty,
       headers: kEnumerableProperty,
@@ -12960,13 +12964,13 @@ var require_request2 = __commonJS({
       }
     });
     webidl.converters.Request = webidl.interfaceConverter(
-      Request
+      Request2
     );
     webidl.converters.RequestInfo = function(V) {
       if (typeof V === "string") {
         return webidl.converters.USVString(V);
       }
-      if (V instanceof Request) {
+      if (V instanceof Request2) {
         return webidl.converters.Request(V);
       }
       return webidl.converters.USVString(V);
@@ -13050,7 +13054,7 @@ var require_request2 = __commonJS({
         allowedValues: requestDuplex
       }
     ]);
-    module.exports = { Request, makeRequest };
+    module.exports = { Request: Request2, makeRequest };
   }
 });
 
@@ -13060,14 +13064,14 @@ var require_fetch = __commonJS({
     "use strict";
     init_esm_shims();
     var {
-      Response,
+      Response: Response2,
       makeNetworkError,
       makeAppropriateNetworkError,
       filterResponse,
       makeResponse
     } = require_response();
-    var { Headers } = require_headers();
-    var { Request, makeRequest } = require_request2();
+    var { Headers: Headers2 } = require_headers();
+    var { Request: Request2, makeRequest } = require_request2();
     var zlib = __require("zlib");
     var {
       bytesMatch,
@@ -13153,12 +13157,12 @@ var require_fetch = __commonJS({
         this.emit("terminated", error2);
       }
     };
-    function fetch(input, init = {}) {
+    function fetch2(input, init = {}) {
       webidl.argumentLengthCheck(arguments, 1, { header: "globalThis.fetch" });
       const p = createDeferredPromise();
       let requestObject;
       try {
-        requestObject = new Request(input, init);
+        requestObject = new Request2(input, init);
       } catch (e) {
         p.reject(e);
         return p.promise;
@@ -13200,7 +13204,7 @@ var require_fetch = __commonJS({
           );
           return Promise.resolve();
         }
-        responseObject = new Response();
+        responseObject = new Response2();
         responseObject[kState] = response;
         responseObject[kRealm] = relevantRealm;
         responseObject[kHeaders][kHeadersList] = response.headersList;
@@ -13951,7 +13955,7 @@ var require_fetch = __commonJS({
       async function dispatch({ body }) {
         const url = requestCurrentURL(request2);
         const agent = fetchParams.controller.dispatcher;
-        return new Promise((resolve4, reject) => agent.dispatch(
+        return new Promise((resolve6, reject) => agent.dispatch(
           {
             path: url.pathname + url.search,
             origin: url.origin,
@@ -13979,7 +13983,7 @@ var require_fetch = __commonJS({
               }
               let codings = [];
               let location = "";
-              const headers = new Headers();
+              const headers = new Headers2();
               if (Array.isArray(headersList)) {
                 for (let n = 0; n < headersList.length; n += 2) {
                   const key = headersList[n + 0].toString("latin1");
@@ -14027,7 +14031,7 @@ var require_fetch = __commonJS({
                   }
                 }
               }
-              resolve4({
+              resolve6({
                 status,
                 statusText,
                 headersList: headers[kHeadersList],
@@ -14064,13 +14068,13 @@ var require_fetch = __commonJS({
               if (status !== 101) {
                 return;
               }
-              const headers = new Headers();
+              const headers = new Headers2();
               for (let n = 0; n < headersList.length; n += 2) {
                 const key = headersList[n + 0].toString("latin1");
                 const val = headersList[n + 1].toString("latin1");
                 headers[kHeadersList].append(key, val);
               }
-              resolve4({
+              resolve6({
                 status,
                 statusText: STATUS_CODES[status],
                 headersList: headers[kHeadersList],
@@ -14083,7 +14087,7 @@ var require_fetch = __commonJS({
       }
     }
     module.exports = {
-      fetch,
+      fetch: fetch2,
       Fetch,
       fetching,
       finalizeAndReportTiming
@@ -14965,8 +14969,8 @@ var require_cache = __commonJS({
     var { kEnumerableProperty, isDisturbed } = require_util();
     var { kHeadersList } = require_symbols();
     var { webidl } = require_webidl();
-    var { Response, cloneResponse } = require_response();
-    var { Request } = require_request2();
+    var { Response: Response2, cloneResponse } = require_response();
+    var { Request: Request2 } = require_request2();
     var { kState, kHeaders, kGuard, kRealm } = require_symbols2();
     var { fetching } = require_fetch();
     var { urlIsHttpHttpsScheme, createDeferredPromise, readAllBytes } = require_util2();
@@ -15001,13 +15005,13 @@ var require_cache = __commonJS({
         options = webidl.converters.CacheQueryOptions(options);
         let r = null;
         if (request2 !== void 0) {
-          if (request2 instanceof Request) {
+          if (request2 instanceof Request2) {
             r = request2[kState];
             if (r.method !== "GET" && !options.ignoreMethod) {
               return [];
             }
           } else if (typeof request2 === "string") {
-            r = new Request(request2)[kState];
+            r = new Request2(request2)[kState];
           }
         }
         const responses = [];
@@ -15023,7 +15027,7 @@ var require_cache = __commonJS({
         }
         const responseList = [];
         for (const response of responses) {
-          const responseObject = new Response(response.body?.source ?? null);
+          const responseObject = new Response2(response.body?.source ?? null);
           const body = responseObject[kState].body;
           responseObject[kState] = response;
           responseObject[kState].body = body;
@@ -15061,7 +15065,7 @@ var require_cache = __commonJS({
         }
         const fetchControllers = [];
         for (const request2 of requests) {
-          const r = new Request(request2)[kState];
+          const r = new Request2(request2)[kState];
           if (!urlIsHttpHttpsScheme(r.url)) {
             throw webidl.errors.exception({
               header: "Cache.addAll",
@@ -15145,10 +15149,10 @@ var require_cache = __commonJS({
         request2 = webidl.converters.RequestInfo(request2);
         response = webidl.converters.Response(response);
         let innerRequest = null;
-        if (request2 instanceof Request) {
+        if (request2 instanceof Request2) {
           innerRequest = request2[kState];
         } else {
-          innerRequest = new Request(request2)[kState];
+          innerRequest = new Request2(request2)[kState];
         }
         if (!urlIsHttpHttpsScheme(innerRequest.url) || innerRequest.method !== "GET") {
           throw webidl.errors.exception({
@@ -15225,14 +15229,14 @@ var require_cache = __commonJS({
         request2 = webidl.converters.RequestInfo(request2);
         options = webidl.converters.CacheQueryOptions(options);
         let r = null;
-        if (request2 instanceof Request) {
+        if (request2 instanceof Request2) {
           r = request2[kState];
           if (r.method !== "GET" && !options.ignoreMethod) {
             return false;
           }
         } else {
           assert(typeof request2 === "string");
-          r = new Request(request2)[kState];
+          r = new Request2(request2)[kState];
         }
         const operations = [];
         const operation = {
@@ -15270,13 +15274,13 @@ var require_cache = __commonJS({
         options = webidl.converters.CacheQueryOptions(options);
         let r = null;
         if (request2 !== void 0) {
-          if (request2 instanceof Request) {
+          if (request2 instanceof Request2) {
             r = request2[kState];
             if (r.method !== "GET" && !options.ignoreMethod) {
               return [];
             }
           } else if (typeof request2 === "string") {
-            r = new Request(request2)[kState];
+            r = new Request2(request2)[kState];
           }
         }
         const promise2 = createDeferredPromise();
@@ -15294,7 +15298,7 @@ var require_cache = __commonJS({
         queueMicrotask(() => {
           const requestList = [];
           for (const request3 of requests) {
-            const requestObject = new Request("https://a");
+            const requestObject = new Request2("https://a");
             requestObject[kState] = request3;
             requestObject[kHeaders][kHeadersList] = request3.headersList;
             requestObject[kHeaders][kGuard] = "immutable";
@@ -15478,7 +15482,7 @@ var require_cache = __commonJS({
         converter: webidl.converters.DOMString
       }
     ]);
-    webidl.converters.Response = webidl.interfaceConverter(Response);
+    webidl.converters.Response = webidl.interfaceConverter(Response2);
     webidl.converters["sequence<RequestInfo>"] = webidl.sequenceConverter(
       webidl.converters.RequestInfo
     );
@@ -15904,10 +15908,10 @@ var require_cookies = __commonJS({
     var { parseSetCookie } = require_parse();
     var { stringify: stringify2 } = require_util6();
     var { webidl } = require_webidl();
-    var { Headers } = require_headers();
+    var { Headers: Headers2 } = require_headers();
     function getCookies(headers) {
       webidl.argumentLengthCheck(arguments, 1, { header: "getCookies" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       const cookie = headers.get("cookie");
       const out = {};
       if (!cookie) {
@@ -15921,7 +15925,7 @@ var require_cookies = __commonJS({
     }
     function deleteCookie(headers, name, attributes) {
       webidl.argumentLengthCheck(arguments, 2, { header: "deleteCookie" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       name = webidl.converters.DOMString(name);
       attributes = webidl.converters.DeleteCookieAttributes(attributes);
       setCookie(headers, {
@@ -15933,7 +15937,7 @@ var require_cookies = __commonJS({
     }
     function getSetCookies(headers) {
       webidl.argumentLengthCheck(arguments, 1, { header: "getSetCookies" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       const cookies = headers.getSetCookie();
       if (!cookies) {
         return [];
@@ -15942,7 +15946,7 @@ var require_cookies = __commonJS({
     }
     function setCookie(headers, cookie) {
       webidl.argumentLengthCheck(arguments, 2, { header: "setCookie" });
-      webidl.brandCheck(headers, Headers, { strict: false });
+      webidl.brandCheck(headers, Headers2, { strict: false });
       cookie = webidl.converters.Cookie(cookie);
       const str = stringify2(cookie);
       if (str) {
@@ -16440,7 +16444,7 @@ var require_connection = __commonJS({
     var { CloseEvent } = require_events();
     var { makeRequest } = require_request2();
     var { fetching } = require_fetch();
-    var { Headers } = require_headers();
+    var { Headers: Headers2 } = require_headers();
     var { getGlobalDispatcher } = require_global2();
     var { kHeadersList } = require_symbols();
     var channels = {};
@@ -16465,7 +16469,7 @@ var require_connection = __commonJS({
         redirect: "error"
       });
       if (options.headers) {
-        const headersList = new Headers(options.headers)[kHeadersList];
+        const headersList = new Headers2(options.headers)[kHeadersList];
         request2.headersList = headersList;
       }
       const keyValue = crypto.randomBytes(16).toString("base64");
@@ -16635,7 +16639,7 @@ var require_receiver = __commonJS({
   "../../node_modules/.pnpm/undici@5.29.0/node_modules/undici/lib/websocket/receiver.js"(exports, module) {
     "use strict";
     init_esm_shims();
-    var { Writable: Writable2 } = __require("stream");
+    var { Writable } = __require("stream");
     var diagnosticsChannel = __require("diagnostics_channel");
     var { parserStates, opcodes, states, emptyBuffer } = require_constants5();
     var { kReadyState, kSentClose, kResponse, kReceivedClose } = require_symbols5();
@@ -16644,7 +16648,7 @@ var require_receiver = __commonJS({
     var channels = {};
     channels.ping = diagnosticsChannel.channel("undici:websocket:ping");
     channels.pong = diagnosticsChannel.channel("undici:websocket:pong");
-    var ByteParser = class extends Writable2 {
+    var ByteParser = class extends Writable {
       #buffers = [];
       #byteOffset = 0;
       #state = parserStates.INFO;
@@ -17361,7 +17365,7 @@ var require_undici = __commonJS({
     module.exports.getGlobalDispatcher = getGlobalDispatcher;
     if (util2.nodeMajor > 16 || util2.nodeMajor === 16 && util2.nodeMinor >= 8) {
       let fetchImpl = null;
-      module.exports.fetch = async function fetch(resource) {
+      module.exports.fetch = async function fetch2(resource) {
         if (!fetchImpl) {
           fetchImpl = require_fetch().fetch;
         }
@@ -17447,11 +17451,11 @@ var require_lib = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -17467,7 +17471,7 @@ var require_lib = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -17509,11 +17513,11 @@ var require_lib = __commonJS({
       HttpCodes2[HttpCodes2["ServiceUnavailable"] = 503] = "ServiceUnavailable";
       HttpCodes2[HttpCodes2["GatewayTimeout"] = 504] = "GatewayTimeout";
     })(HttpCodes || (exports.HttpCodes = HttpCodes = {}));
-    var Headers;
-    (function(Headers2) {
-      Headers2["Accept"] = "accept";
-      Headers2["ContentType"] = "content-type";
-    })(Headers || (exports.Headers = Headers = {}));
+    var Headers2;
+    (function(Headers3) {
+      Headers3["Accept"] = "accept";
+      Headers3["ContentType"] = "content-type";
+    })(Headers2 || (exports.Headers = Headers2 = {}));
     var MediaTypes;
     (function(MediaTypes2) {
       MediaTypes2["ApplicationJson"] = "application/json";
@@ -17553,26 +17557,26 @@ var require_lib = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve4(output.toString());
+              resolve6(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve4(Buffer.concat(chunks));
+              resolve6(Buffer.concat(chunks));
             });
           }));
         });
@@ -17668,7 +17672,7 @@ var require_lib = __commonJS({
        */
       getJson(requestUrl, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
           const res = yield this.get(requestUrl, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17676,8 +17680,8 @@ var require_lib = __commonJS({
       postJson(requestUrl, obj, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.ContentType, MediaTypes.ApplicationJson);
           const res = yield this.post(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17685,8 +17689,8 @@ var require_lib = __commonJS({
       putJson(requestUrl, obj, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.ContentType, MediaTypes.ApplicationJson);
           const res = yield this.put(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17694,8 +17698,8 @@ var require_lib = __commonJS({
       patchJson(requestUrl, obj, additionalHeaders = {}) {
         return __awaiter(this, void 0, void 0, function* () {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.ContentType, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.ContentType, MediaTypes.ApplicationJson);
           const res = yield this.patch(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -17781,14 +17785,14 @@ var require_lib = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve4(res);
+                resolve6(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -17970,12 +17974,12 @@ var require_lib = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve4) => setTimeout(() => resolve4(), ms2));
+          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -17983,7 +17987,7 @@ var require_lib = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve4(response);
+              resolve6(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -18022,7 +18026,7 @@ var require_lib = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve4(response);
+              resolve6(response);
             }
           }));
         });
@@ -18040,11 +18044,11 @@ var require_auth = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18060,7 +18064,7 @@ var require_auth = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18145,11 +18149,11 @@ var require_oidc_utils = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18165,7 +18169,7 @@ var require_oidc_utils = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18244,11 +18248,11 @@ var require_summary = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18264,7 +18268,7 @@ var require_summary = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18273,7 +18277,7 @@ var require_summary = __commonJS({
     exports.summary = exports.markdownSummary = exports.SUMMARY_DOCS_URL = exports.SUMMARY_ENV_VAR = void 0;
     var os_1 = __require("os");
     var fs_1 = __require("fs");
-    var { access: access2, appendFile, writeFile: writeFile3 } = fs_1.promises;
+    var { access: access3, appendFile, writeFile: writeFile4 } = fs_1.promises;
     exports.SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
     exports.SUMMARY_DOCS_URL = "https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary";
     var Summary = class {
@@ -18296,7 +18300,7 @@ var require_summary = __commonJS({
             throw new Error(`Unable to find environment variable for $${exports.SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`);
           }
           try {
-            yield access2(pathFromEnv, fs_1.constants.R_OK | fs_1.constants.W_OK);
+            yield access3(pathFromEnv, fs_1.constants.R_OK | fs_1.constants.W_OK);
           } catch (_a) {
             throw new Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`);
           }
@@ -18331,7 +18335,7 @@ var require_summary = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           const overwrite = !!(options === null || options === void 0 ? void 0 : options.overwrite);
           const filePath = yield this.filePath();
-          const writeFunc = overwrite ? writeFile3 : appendFile;
+          const writeFunc = overwrite ? writeFile4 : appendFile;
           yield writeFunc(filePath, this._buffer, { encoding: "utf8" });
           return this.emptyBuffer();
         });
@@ -18612,11 +18616,11 @@ var require_io_util = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18632,7 +18636,7 @@ var require_io_util = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18640,12 +18644,12 @@ var require_io_util = __commonJS({
     var _a;
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-    var fs3 = __importStar(__require("fs"));
+    var fs4 = __importStar(__require("fs"));
     var path4 = __importStar(__require("path"));
-    _a = fs3.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
+    _a = fs4.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
     exports.IS_WINDOWS = process.platform === "win32";
     exports.UV_FS_O_EXLOCK = 268435456;
-    exports.READONLY = fs3.constants.O_RDONLY;
+    exports.READONLY = fs4.constants.O_RDONLY;
     function exists(fsPath) {
       return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -18786,11 +18790,11 @@ var require_io = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18806,7 +18810,7 @@ var require_io = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19035,11 +19039,11 @@ var require_toolrunner = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19055,14 +19059,14 @@ var require_toolrunner = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
     };
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.argStringToArray = exports.ToolRunner = void 0;
-    var os2 = __importStar(__require("os"));
+    var os3 = __importStar(__require("os"));
     var events = __importStar(__require("events"));
     var child = __importStar(__require("child_process"));
     var path4 = __importStar(__require("path"));
@@ -19117,12 +19121,12 @@ var require_toolrunner = __commonJS({
       _processLineBuffer(data, strBuffer, onLine) {
         try {
           let s = strBuffer + data.toString();
-          let n = s.indexOf(os2.EOL);
+          let n = s.indexOf(os3.EOL);
           while (n > -1) {
             const line = s.substring(0, n);
             onLine(line);
-            s = s.substring(n + os2.EOL.length);
-            n = s.indexOf(os2.EOL);
+            s = s.substring(n + os3.EOL.length);
+            n = s.indexOf(os3.EOL);
           }
           return s;
         } catch (err) {
@@ -19283,7 +19287,7 @@ var require_toolrunner = __commonJS({
             this.toolPath = path4.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io.which(this.toolPath, true);
-          return new Promise((resolve4, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
             this._debug(`exec tool: ${this.toolPath}`);
             this._debug("arguments:");
             for (const arg of this.args) {
@@ -19291,7 +19295,7 @@ var require_toolrunner = __commonJS({
             }
             const optionsNonNull = this._cloneExecOptions(this.options);
             if (!optionsNonNull.silent && optionsNonNull.outStream) {
-              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os2.EOL);
+              optionsNonNull.outStream.write(this._getCommandString(optionsNonNull) + os3.EOL);
             }
             const state = new ExecState(optionsNonNull, this.toolPath);
             state.on("debug", (message) => {
@@ -19366,7 +19370,7 @@ var require_toolrunner = __commonJS({
               if (error2) {
                 reject(error2);
               } else {
-                resolve4(exitCode);
+                resolve6(exitCode);
               }
             });
             if (this.options.input) {
@@ -19520,11 +19524,11 @@ var require_exec = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19540,7 +19544,7 @@ var require_exec = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19632,11 +19636,11 @@ var require_platform = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19652,7 +19656,7 @@ var require_platform = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19752,11 +19756,11 @@ var require_core = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19772,7 +19776,7 @@ var require_core = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19782,7 +19786,7 @@ var require_core = __commonJS({
     var command_1 = require_command();
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
-    var os2 = __importStar(__require("os"));
+    var os3 = __importStar(__require("os"));
     var path4 = __importStar(__require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
@@ -19850,7 +19854,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       if (filePath) {
         return (0, file_command_1.issueFileCommand)("OUTPUT", (0, file_command_1.prepareKeyValueMessage)(name, value));
       }
-      process.stdout.write(os2.EOL);
+      process.stdout.write(os3.EOL);
       (0, command_1.issueCommand)("set-output", { name }, (0, utils_1.toCommandValue)(value));
     }
     exports.setOutput = setOutput2;
@@ -19884,7 +19888,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
     exports.notice = notice;
     function info2(message) {
-      process.stdout.write(message + os2.EOL);
+      process.stdout.write(message + os3.EOL);
     }
     exports.info = info2;
     function startGroup2(name) {
@@ -24808,8 +24812,8 @@ var require_int2 = __commonJS({
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
     function intResolve(str, offset, radix, { intAsBigInt }) {
-      const sign2 = str[0];
-      if (sign2 === "-" || sign2 === "+")
+      const sign3 = str[0];
+      if (sign3 === "-" || sign3 === "+")
         offset += 1;
       str = str.substring(offset).replace(/_/g, "");
       if (intAsBigInt) {
@@ -24825,10 +24829,10 @@ var require_int2 = __commonJS({
             break;
         }
         const n2 = BigInt(str);
-        return sign2 === "-" ? BigInt(-1) * n2 : n2;
+        return sign3 === "-" ? BigInt(-1) * n2 : n2;
       }
       const n = parseInt(str, radix);
-      return sign2 === "-" ? -1 * n : n;
+      return sign3 === "-" ? -1 * n : n;
     }
     function intStringify(node, radix, prefix) {
       const { value } = node;
@@ -24977,11 +24981,11 @@ var require_timestamp = __commonJS({
     init_esm_shims();
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
-      const sign2 = str[0];
-      const parts = sign2 === "-" || sign2 === "+" ? str.substring(1) : str;
+      const sign3 = str[0];
+      const parts = sign3 === "-" || sign3 === "+" ? str.substring(1) : str;
       const num = (n) => asBigInt ? BigInt(n) : Number(n);
       const res = parts.replace(/_/g, "").split(":").reduce((res2, p) => res2 * num(60) + num(p), num(0));
-      return sign2 === "-" ? num(-1) * res : res;
+      return sign3 === "-" ? num(-1) * res : res;
     }
     function stringifySexagesimal(node) {
       let { value } = node;
@@ -24990,9 +24994,9 @@ var require_timestamp = __commonJS({
         num = (n) => BigInt(n);
       else if (isNaN(value) || !isFinite(value))
         return stringifyNumber.stringifyNumber(node);
-      let sign2 = "";
+      let sign3 = "";
       if (value < 0) {
-        sign2 = "-";
+        sign3 = "-";
         value *= num(-1);
       }
       const _60 = num(60);
@@ -25007,7 +25011,7 @@ var require_timestamp = __commonJS({
           parts.unshift(value);
         }
       }
-      return sign2 + parts.map((n) => String(n).padStart(2, "0")).join(":").replace(/000000\d*$/, "");
+      return sign3 + parts.map((n) => String(n).padStart(2, "0")).join(":").replace(/000000\d*$/, "");
     }
     var intTime = {
       identify: (value) => typeof value === "bigint" || Number.isInteger(value),
@@ -28833,14 +28837,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs3 = this.flowScalar(this.type);
+              const fs4 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs3, sep: [] });
+                map.items.push({ start, key: fs4, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs3);
+                this.stack.push(fs4);
               } else {
-                Object.assign(it, { key: fs3, sep: [] });
+                Object.assign(it, { key: fs4, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -28968,13 +28972,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs3 = this.flowScalar(this.type);
+              const fs4 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs3, sep: [] });
+                fc.items.push({ start: [], key: fs4, sep: [] });
               else if (it.sep)
-                this.stack.push(fs3);
+                this.stack.push(fs4);
               else
-                Object.assign(it, { key: fs3, sep: [] });
+                Object.assign(it, { key: fs4, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -30962,6 +30966,2357 @@ var require_picomatch2 = __commonJS({
   }
 });
 
+// ../../node_modules/.pnpm/@1password+sdk-core@0.4.0/node_modules/@1password/sdk-core/nodejs/core.js
+var require_core2 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk-core@0.4.0/node_modules/@1password/sdk-core/nodejs/core.js"(exports, module) {
+    "use strict";
+    init_esm_shims();
+    var imports = {};
+    imports["__wbindgen_placeholder__"] = module.exports;
+    var wasm;
+    var { TextDecoder: TextDecoder2, TextEncoder: TextEncoder2 } = __require("util");
+    var cachedTextDecoder = new TextDecoder2("utf-8", { ignoreBOM: true, fatal: true });
+    cachedTextDecoder.decode();
+    var cachedUint8ArrayMemory0 = null;
+    function getUint8ArrayMemory0() {
+      if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+      }
+      return cachedUint8ArrayMemory0;
+    }
+    function getStringFromWasm0(ptr, len) {
+      ptr = ptr >>> 0;
+      return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+    }
+    function addToExternrefTable0(obj) {
+      const idx = wasm.__externref_table_alloc();
+      wasm.__wbindgen_export_2.set(idx, obj);
+      return idx;
+    }
+    function handleError(f, args) {
+      try {
+        return f.apply(this, args);
+      } catch (e) {
+        const idx = addToExternrefTable0(e);
+        wasm.__wbindgen_exn_store(idx);
+      }
+    }
+    function isLikeNone(x) {
+      return x === void 0 || x === null;
+    }
+    var WASM_VECTOR_LEN = 0;
+    var cachedTextEncoder = new TextEncoder2("utf-8");
+    var encodeString = typeof cachedTextEncoder.encodeInto === "function" ? function(arg, view) {
+      return cachedTextEncoder.encodeInto(arg, view);
+    } : function(arg, view) {
+      const buf = cachedTextEncoder.encode(arg);
+      view.set(buf);
+      return {
+        read: arg.length,
+        written: buf.length
+      };
+    };
+    function passStringToWasm0(arg, malloc, realloc) {
+      if (realloc === void 0) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr2 = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr2, ptr2 + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr2;
+      }
+      let len = arg.length;
+      let ptr = malloc(len, 1) >>> 0;
+      const mem = getUint8ArrayMemory0();
+      let offset = 0;
+      for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 127) break;
+        mem[ptr + offset] = code;
+      }
+      if (offset !== len) {
+        if (offset !== 0) {
+          arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = encodeString(arg, view);
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+      }
+      WASM_VECTOR_LEN = offset;
+      return ptr;
+    }
+    var cachedDataViewMemory0 = null;
+    function getDataViewMemory0() {
+      if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || cachedDataViewMemory0.buffer.detached === void 0 && cachedDataViewMemory0.buffer !== wasm.memory.buffer) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+      }
+      return cachedDataViewMemory0;
+    }
+    var CLOSURE_DTORS = typeof FinalizationRegistry === "undefined" ? { register: () => {
+    }, unregister: () => {
+    } } : new FinalizationRegistry((state) => {
+      wasm.__wbindgen_export_5.get(state.dtor)(state.a, state.b);
+    });
+    function makeMutClosure(arg0, arg1, dtor, f) {
+      const state = { a: arg0, b: arg1, cnt: 1, dtor };
+      const real = (...args) => {
+        state.cnt++;
+        const a = state.a;
+        state.a = 0;
+        try {
+          return f(a, state.b, ...args);
+        } finally {
+          if (--state.cnt === 0) {
+            wasm.__wbindgen_export_5.get(state.dtor)(a, state.b);
+            CLOSURE_DTORS.unregister(state);
+          } else {
+            state.a = a;
+          }
+        }
+      };
+      real.original = state;
+      CLOSURE_DTORS.register(real, state, state);
+      return real;
+    }
+    function debugString(val) {
+      const type = typeof val;
+      if (type == "number" || type == "boolean" || val == null) {
+        return `${val}`;
+      }
+      if (type == "string") {
+        return `"${val}"`;
+      }
+      if (type == "symbol") {
+        const description = val.description;
+        if (description == null) {
+          return "Symbol";
+        } else {
+          return `Symbol(${description})`;
+        }
+      }
+      if (type == "function") {
+        const name = val.name;
+        if (typeof name == "string" && name.length > 0) {
+          return `Function(${name})`;
+        } else {
+          return "Function";
+        }
+      }
+      if (Array.isArray(val)) {
+        const length = val.length;
+        let debug = "[";
+        if (length > 0) {
+          debug += debugString(val[0]);
+        }
+        for (let i = 1; i < length; i++) {
+          debug += ", " + debugString(val[i]);
+        }
+        debug += "]";
+        return debug;
+      }
+      const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+      let className;
+      if (builtInMatches && builtInMatches.length > 1) {
+        className = builtInMatches[1];
+      } else {
+        return toString.call(val);
+      }
+      if (className == "Object") {
+        try {
+          return "Object(" + JSON.stringify(val) + ")";
+        } catch (_) {
+          return "Object";
+        }
+      }
+      if (val instanceof Error) {
+        return `${val.name}: ${val.message}
+${val.stack}`;
+      }
+      return className;
+    }
+    module.exports.init_client = function(config) {
+      const ptr0 = passStringToWasm0(config, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len0 = WASM_VECTOR_LEN;
+      const ret = wasm.init_client(ptr0, len0);
+      return ret;
+    };
+    module.exports.invoke = function(parameters) {
+      const ptr0 = passStringToWasm0(parameters, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len0 = WASM_VECTOR_LEN;
+      const ret = wasm.invoke(ptr0, len0);
+      return ret;
+    };
+    function takeFromExternrefTable0(idx) {
+      const value = wasm.__wbindgen_export_2.get(idx);
+      wasm.__externref_table_dealloc(idx);
+      return value;
+    }
+    module.exports.invoke_sync = function(parameters) {
+      let deferred3_0;
+      let deferred3_1;
+      try {
+        const ptr0 = passStringToWasm0(parameters, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.invoke_sync(ptr0, len0);
+        var ptr2 = ret[0];
+        var len2 = ret[1];
+        if (ret[3]) {
+          ptr2 = 0;
+          len2 = 0;
+          throw takeFromExternrefTable0(ret[2]);
+        }
+        deferred3_0 = ptr2;
+        deferred3_1 = len2;
+        return getStringFromWasm0(ptr2, len2);
+      } finally {
+        wasm.__wbindgen_free(deferred3_0, deferred3_1, 1);
+      }
+    };
+    module.exports.release_client = function(client_id) {
+      const ptr0 = passStringToWasm0(client_id, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len0 = WASM_VECTOR_LEN;
+      const ret = wasm.release_client(ptr0, len0);
+      if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+      }
+    };
+    function __wbg_adapter_30(arg0, arg1) {
+      wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h4fa304e9a7297dba(arg0, arg1);
+    }
+    function __wbg_adapter_33(arg0, arg1, arg2) {
+      wasm.closure2484_externref_shim(arg0, arg1, arg2);
+    }
+    function __wbg_adapter_156(arg0, arg1, arg2, arg3) {
+      wasm.closure2632_externref_shim(arg0, arg1, arg2, arg3);
+    }
+    var __wbindgen_enum_RequestCache = ["default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached"];
+    var __wbindgen_enum_RequestCredentials = ["omit", "same-origin", "include"];
+    var __wbindgen_enum_RequestMode = ["same-origin", "no-cors", "cors", "navigate"];
+    module.exports.__wbg_abort_410ec47a64ac6117 = function(arg0, arg1) {
+      arg0.abort(arg1);
+    };
+    module.exports.__wbg_abort_775ef1d17fc65868 = function(arg0) {
+      arg0.abort();
+    };
+    module.exports.__wbg_append_8c7dd8d641a5f01b = function() {
+      return handleError(function(arg0, arg1, arg2, arg3, arg4) {
+        arg0.append(getStringFromWasm0(arg1, arg2), getStringFromWasm0(arg3, arg4));
+      }, arguments);
+    };
+    module.exports.__wbg_arrayBuffer_d1b44c4390db422f = function() {
+      return handleError(function(arg0) {
+        const ret = arg0.arrayBuffer();
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_buffer_609cc3eee51ed158 = function(arg0) {
+      const ret = arg0.buffer;
+      return ret;
+    };
+    module.exports.__wbg_call_672a4d21634d4a24 = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = arg0.call(arg1);
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_call_7cccdd69e0791ae2 = function() {
+      return handleError(function(arg0, arg1, arg2) {
+        const ret = arg0.call(arg1, arg2);
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_clearTimeout_42d9ccd50822fd3a = function(arg0) {
+      const ret = clearTimeout(arg0);
+      return ret;
+    };
+    module.exports.__wbg_crypto_86f2631e91b51511 = function(arg0) {
+      const ret = arg0.crypto;
+      return ret;
+    };
+    module.exports.__wbg_done_769e5ede4b31c67b = function(arg0) {
+      const ret = arg0.done;
+      return ret;
+    };
+    module.exports.__wbg_fetch_509096533071c657 = function(arg0, arg1) {
+      const ret = arg0.fetch(arg1);
+      return ret;
+    };
+    module.exports.__wbg_fetch_6bbc32f991730587 = function(arg0) {
+      const ret = fetch(arg0);
+      return ret;
+    };
+    module.exports.__wbg_getFullYear_17d3c9e4db748eb7 = function(arg0) {
+      const ret = arg0.getFullYear();
+      return ret;
+    };
+    module.exports.__wbg_getRandomValues_b3f15fcbfabb0f8b = function() {
+      return handleError(function(arg0, arg1) {
+        arg0.getRandomValues(arg1);
+      }, arguments);
+    };
+    module.exports.__wbg_getTimezoneOffset_6b5752021c499c47 = function(arg0) {
+      const ret = arg0.getTimezoneOffset();
+      return ret;
+    };
+    module.exports.__wbg_get_67b2ba62fc30de12 = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = Reflect.get(arg0, arg1);
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_has_a5ea9117f258a0ec = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = Reflect.has(arg0, arg1);
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_headers_9cb51cfd2ac780a4 = function(arg0) {
+      const ret = arg0.headers;
+      return ret;
+    };
+    module.exports.__wbg_instanceof_Response_f2cc20d9f7dfd644 = function(arg0) {
+      let result;
+      try {
+        result = arg0 instanceof Response;
+      } catch (_) {
+        result = false;
+      }
+      const ret = result;
+      return ret;
+    };
+    module.exports.__wbg_instanceof_Window_def73ea0955fc569 = function(arg0) {
+      let result;
+      try {
+        result = arg0 instanceof Window;
+      } catch (_) {
+        result = false;
+      }
+      const ret = result;
+      return ret;
+    };
+    module.exports.__wbg_instanceof_WorkerGlobalScope_dbdbdea7e3b56493 = function(arg0) {
+      let result;
+      try {
+        result = arg0 instanceof WorkerGlobalScope;
+      } catch (_) {
+        result = false;
+      }
+      const ret = result;
+      return ret;
+    };
+    module.exports.__wbg_iterator_9a24c88df860dc65 = function() {
+      const ret = Symbol.iterator;
+      return ret;
+    };
+    module.exports.__wbg_languages_2420955220685766 = function(arg0) {
+      const ret = arg0.languages;
+      return ret;
+    };
+    module.exports.__wbg_languages_d8dad509faf757df = function(arg0) {
+      const ret = arg0.languages;
+      return ret;
+    };
+    module.exports.__wbg_length_a446193dc22c12f8 = function(arg0) {
+      const ret = arg0.length;
+      return ret;
+    };
+    module.exports.__wbg_msCrypto_d562bbe83e0d4b91 = function(arg0) {
+      const ret = arg0.msCrypto;
+      return ret;
+    };
+    module.exports.__wbg_navigator_0a9bf1120e24fec2 = function(arg0) {
+      const ret = arg0.navigator;
+      return ret;
+    };
+    module.exports.__wbg_navigator_1577371c070c8947 = function(arg0) {
+      const ret = arg0.navigator;
+      return ret;
+    };
+    module.exports.__wbg_new0_f788a2397c7ca929 = function() {
+      const ret = /* @__PURE__ */ new Date();
+      return ret;
+    };
+    module.exports.__wbg_new_018dcc2d6c8c2f6a = function() {
+      return handleError(function() {
+        const ret = new Headers();
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_new_23a2665fac83c611 = function(arg0, arg1) {
+      try {
+        var state0 = { a: arg0, b: arg1 };
+        var cb0 = (arg02, arg12) => {
+          const a = state0.a;
+          state0.a = 0;
+          try {
+            return __wbg_adapter_156(a, state0.b, arg02, arg12);
+          } finally {
+            state0.a = a;
+          }
+        };
+        const ret = new Promise(cb0);
+        return ret;
+      } finally {
+        state0.a = state0.b = 0;
+      }
+    };
+    module.exports.__wbg_new_31a97dac4f10fab7 = function(arg0) {
+      const ret = new Date(arg0);
+      return ret;
+    };
+    module.exports.__wbg_new_405e22f390576ce2 = function() {
+      const ret = new Object();
+      return ret;
+    };
+    module.exports.__wbg_new_a12002a7f91c75be = function(arg0) {
+      const ret = new Uint8Array(arg0);
+      return ret;
+    };
+    module.exports.__wbg_new_e25e5aab09ff45db = function() {
+      return handleError(function() {
+        const ret = new AbortController();
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_newnoargs_105ed471475aaf50 = function(arg0, arg1) {
+      const ret = new Function(getStringFromWasm0(arg0, arg1));
+      return ret;
+    };
+    module.exports.__wbg_newwithbyteoffsetandlength_d97e637ebe145a9a = function(arg0, arg1, arg2) {
+      const ret = new Uint8Array(arg0, arg1 >>> 0, arg2 >>> 0);
+      return ret;
+    };
+    module.exports.__wbg_newwithlength_a381634e90c276d4 = function(arg0) {
+      const ret = new Uint8Array(arg0 >>> 0);
+      return ret;
+    };
+    module.exports.__wbg_newwithstrandinit_06c535e0a867c635 = function() {
+      return handleError(function(arg0, arg1, arg2) {
+        const ret = new Request(getStringFromWasm0(arg0, arg1), arg2);
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_next_25feadfc0913fea9 = function(arg0) {
+      const ret = arg0.next;
+      return ret;
+    };
+    module.exports.__wbg_next_6574e1a8a62d1055 = function() {
+      return handleError(function(arg0) {
+        const ret = arg0.next();
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_node_e1f24f89a7336c2e = function(arg0) {
+      const ret = arg0.node;
+      return ret;
+    };
+    module.exports.__wbg_now_807e54c39636c349 = function() {
+      const ret = Date.now();
+      return ret;
+    };
+    module.exports.__wbg_now_d18023d54d4e5500 = function(arg0) {
+      const ret = arg0.now();
+      return ret;
+    };
+    module.exports.__wbg_parse_def2e24ef1252aff = function() {
+      return handleError(function(arg0, arg1) {
+        const ret = JSON.parse(getStringFromWasm0(arg0, arg1));
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_process_3975fd6c72f520aa = function(arg0) {
+      const ret = arg0.process;
+      return ret;
+    };
+    module.exports.__wbg_queueMicrotask_97d92b4fcc8a61c5 = function(arg0) {
+      queueMicrotask(arg0);
+    };
+    module.exports.__wbg_queueMicrotask_d3219def82552485 = function(arg0) {
+      const ret = arg0.queueMicrotask;
+      return ret;
+    };
+    module.exports.__wbg_randomFillSync_f8c153b79f285817 = function() {
+      return handleError(function(arg0, arg1) {
+        arg0.randomFillSync(arg1);
+      }, arguments);
+    };
+    module.exports.__wbg_require_b74f47fc2d022fd6 = function() {
+      return handleError(function() {
+        const ret = module.require;
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_resolve_4851785c9c5f573d = function(arg0) {
+      const ret = Promise.resolve(arg0);
+      return ret;
+    };
+    module.exports.__wbg_self_b29ea9f89ecb0567 = function() {
+      return handleError(function() {
+        const ret = self.self;
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_setTimeout_4ec014681668a581 = function(arg0, arg1) {
+      const ret = setTimeout(arg0, arg1);
+      return ret;
+    };
+    module.exports.__wbg_set_65595bdd868b3009 = function(arg0, arg1, arg2) {
+      arg0.set(arg1, arg2 >>> 0);
+    };
+    module.exports.__wbg_setbody_5923b78a95eedf29 = function(arg0, arg1) {
+      arg0.body = arg1;
+    };
+    module.exports.__wbg_setcache_12f17c3a980650e4 = function(arg0, arg1) {
+      arg0.cache = __wbindgen_enum_RequestCache[arg1];
+    };
+    module.exports.__wbg_setcredentials_c3a22f1cd105a2c6 = function(arg0, arg1) {
+      arg0.credentials = __wbindgen_enum_RequestCredentials[arg1];
+    };
+    module.exports.__wbg_setheaders_834c0bdb6a8949ad = function(arg0, arg1) {
+      arg0.headers = arg1;
+    };
+    module.exports.__wbg_setmethod_3c5280fe5d890842 = function(arg0, arg1, arg2) {
+      arg0.method = getStringFromWasm0(arg1, arg2);
+    };
+    module.exports.__wbg_setmode_5dc300b865044b65 = function(arg0, arg1) {
+      arg0.mode = __wbindgen_enum_RequestMode[arg1];
+    };
+    module.exports.__wbg_setsignal_75b21ef3a81de905 = function(arg0, arg1) {
+      arg0.signal = arg1;
+    };
+    module.exports.__wbg_signal_aaf9ad74119f20a4 = function(arg0) {
+      const ret = arg0.signal;
+      return ret;
+    };
+    module.exports.__wbg_static_accessor_GLOBAL_88a902d13a557d07 = function() {
+      const ret = typeof global === "undefined" ? null : global;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module.exports.__wbg_static_accessor_GLOBAL_THIS_56578be7e9f832b0 = function() {
+      const ret = typeof globalThis === "undefined" ? null : globalThis;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module.exports.__wbg_static_accessor_SELF_37c5d418e4bf5819 = function() {
+      const ret = typeof self === "undefined" ? null : self;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module.exports.__wbg_static_accessor_WINDOW_5de37043a91a9c40 = function() {
+      const ret = typeof window === "undefined" ? null : window;
+      return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+    };
+    module.exports.__wbg_static_accessor_performance_da77b3a901a72934 = function() {
+      const ret = performance;
+      return ret;
+    };
+    module.exports.__wbg_status_f6360336ca686bf0 = function(arg0) {
+      const ret = arg0.status;
+      return ret;
+    };
+    module.exports.__wbg_stringify_f7ed6987935b4a24 = function() {
+      return handleError(function(arg0) {
+        const ret = JSON.stringify(arg0);
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbg_subarray_aa9065fa9dc5df96 = function(arg0, arg1, arg2) {
+      const ret = arg0.subarray(arg1 >>> 0, arg2 >>> 0);
+      return ret;
+    };
+    module.exports.__wbg_then_44b73946d2fb3e7d = function(arg0, arg1) {
+      const ret = arg0.then(arg1);
+      return ret;
+    };
+    module.exports.__wbg_then_48b406749878a531 = function(arg0, arg1, arg2) {
+      const ret = arg0.then(arg1, arg2);
+      return ret;
+    };
+    module.exports.__wbg_toLocaleDateString_e5424994746e8415 = function(arg0, arg1, arg2, arg3) {
+      const ret = arg0.toLocaleDateString(getStringFromWasm0(arg1, arg2), arg3);
+      return ret;
+    };
+    module.exports.__wbg_url_ae10c34ca209681d = function(arg0, arg1) {
+      const ret = arg1.url;
+      const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len1 = WASM_VECTOR_LEN;
+      getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+      getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    module.exports.__wbg_value_cd1ffa7b1ab794f1 = function(arg0) {
+      const ret = arg0.value;
+      return ret;
+    };
+    module.exports.__wbg_values_99f7a68c7f313d66 = function(arg0) {
+      const ret = arg0.values();
+      return ret;
+    };
+    module.exports.__wbg_versions_4e31226f5e8dc909 = function(arg0) {
+      const ret = arg0.versions;
+      return ret;
+    };
+    module.exports.__wbg_window_aa5515e600e96252 = function() {
+      return handleError(function() {
+        const ret = window.window;
+        return ret;
+      }, arguments);
+    };
+    module.exports.__wbindgen_cb_drop = function(arg0) {
+      const obj = arg0.original;
+      if (obj.cnt-- == 1) {
+        obj.a = 0;
+        return true;
+      }
+      const ret = false;
+      return ret;
+    };
+    module.exports.__wbindgen_closure_wrapper9169 = function(arg0, arg1, arg2) {
+      const ret = makeMutClosure(arg0, arg1, 2463, __wbg_adapter_30);
+      return ret;
+    };
+    module.exports.__wbindgen_closure_wrapper9209 = function(arg0, arg1, arg2) {
+      const ret = makeMutClosure(arg0, arg1, 2485, __wbg_adapter_33);
+      return ret;
+    };
+    module.exports.__wbindgen_debug_string = function(arg0, arg1) {
+      const ret = debugString(arg1);
+      const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      const len1 = WASM_VECTOR_LEN;
+      getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+      getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    module.exports.__wbindgen_init_externref_table = function() {
+      const table = wasm.__wbindgen_export_2;
+      const offset = table.grow(4);
+      table.set(0, void 0);
+      table.set(offset + 0, void 0);
+      table.set(offset + 1, null);
+      table.set(offset + 2, true);
+      table.set(offset + 3, false);
+      ;
+    };
+    module.exports.__wbindgen_is_function = function(arg0) {
+      const ret = typeof arg0 === "function";
+      return ret;
+    };
+    module.exports.__wbindgen_is_object = function(arg0) {
+      const val = arg0;
+      const ret = typeof val === "object" && val !== null;
+      return ret;
+    };
+    module.exports.__wbindgen_is_string = function(arg0) {
+      const ret = typeof arg0 === "string";
+      return ret;
+    };
+    module.exports.__wbindgen_is_undefined = function(arg0) {
+      const ret = arg0 === void 0;
+      return ret;
+    };
+    module.exports.__wbindgen_memory = function() {
+      const ret = wasm.memory;
+      return ret;
+    };
+    module.exports.__wbindgen_number_new = function(arg0) {
+      const ret = arg0;
+      return ret;
+    };
+    module.exports.__wbindgen_string_get = function(arg0, arg1) {
+      const obj = arg1;
+      const ret = typeof obj === "string" ? obj : void 0;
+      var ptr1 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+      var len1 = WASM_VECTOR_LEN;
+      getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+      getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+    };
+    module.exports.__wbindgen_string_new = function(arg0, arg1) {
+      const ret = getStringFromWasm0(arg0, arg1);
+      return ret;
+    };
+    module.exports.__wbindgen_throw = function(arg0, arg1) {
+      throw new Error(getStringFromWasm0(arg0, arg1));
+    };
+    var path4 = __require("path").join(__dirname, "core_bg.wasm");
+    var bytes = __require("fs").readFileSync(path4);
+    var wasmModule = new WebAssembly.Module(bytes);
+    var wasmInstance = new WebAssembly.Instance(wasmModule, imports);
+    wasm = wasmInstance.exports;
+    module.exports.__wasm = wasm;
+    wasm.__wbindgen_start();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/types.js
+var require_types = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/types.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ReplacerFunc = exports.ReviverFunc = exports.UPDATE_ITEM_HISTORY = exports.UPDATE_ITEMS = exports.SEND_ITEMS = exports.REVEAL_ITEM_PASSWORD = exports.RECOVER_VAULT = exports.READ_ITEMS = exports.PRINT_ITEMS = exports.NO_ACCESS = exports.MANAGE_VAULT = exports.IMPORT_ITEMS = exports.EXPORT_ITEMS = exports.DELETE_ITEMS = exports.CREATE_ITEMS = exports.ARCHIVE_ITEMS = exports.WordListType = exports.SeparatorType = exports.VaultType = exports.AllowedRecipientType = exports.AllowedType = exports.ItemShareDuration = exports.ItemState = exports.AutofillBehavior = exports.ItemFieldType = exports.ItemCategory = exports.VaultAccessorType = exports.GroupState = exports.GroupType = void 0;
+    var GroupType;
+    (function(GroupType2) {
+      GroupType2["Owners"] = "owners";
+      GroupType2["Administrators"] = "administrators";
+      GroupType2["Recovery"] = "recovery";
+      GroupType2["ExternalAccountManagers"] = "externalAccountManagers";
+      GroupType2["TeamMembers"] = "teamMembers";
+      GroupType2["UserDefined"] = "userDefined";
+      GroupType2["Unsupported"] = "unsupported";
+    })(GroupType || (exports.GroupType = GroupType = {}));
+    var GroupState;
+    (function(GroupState2) {
+      GroupState2["Active"] = "active";
+      GroupState2["Deleted"] = "deleted";
+      GroupState2["Unsupported"] = "unsupported";
+    })(GroupState || (exports.GroupState = GroupState = {}));
+    var VaultAccessorType;
+    (function(VaultAccessorType2) {
+      VaultAccessorType2["User"] = "user";
+      VaultAccessorType2["Group"] = "group";
+    })(VaultAccessorType || (exports.VaultAccessorType = VaultAccessorType = {}));
+    var ItemCategory;
+    (function(ItemCategory2) {
+      ItemCategory2["Login"] = "Login";
+      ItemCategory2["SecureNote"] = "SecureNote";
+      ItemCategory2["CreditCard"] = "CreditCard";
+      ItemCategory2["CryptoWallet"] = "CryptoWallet";
+      ItemCategory2["Identity"] = "Identity";
+      ItemCategory2["Password"] = "Password";
+      ItemCategory2["Document"] = "Document";
+      ItemCategory2["ApiCredentials"] = "ApiCredentials";
+      ItemCategory2["BankAccount"] = "BankAccount";
+      ItemCategory2["Database"] = "Database";
+      ItemCategory2["DriverLicense"] = "DriverLicense";
+      ItemCategory2["Email"] = "Email";
+      ItemCategory2["MedicalRecord"] = "MedicalRecord";
+      ItemCategory2["Membership"] = "Membership";
+      ItemCategory2["OutdoorLicense"] = "OutdoorLicense";
+      ItemCategory2["Passport"] = "Passport";
+      ItemCategory2["Rewards"] = "Rewards";
+      ItemCategory2["Router"] = "Router";
+      ItemCategory2["Server"] = "Server";
+      ItemCategory2["SshKey"] = "SshKey";
+      ItemCategory2["SocialSecurityNumber"] = "SocialSecurityNumber";
+      ItemCategory2["SoftwareLicense"] = "SoftwareLicense";
+      ItemCategory2["Person"] = "Person";
+      ItemCategory2["Unsupported"] = "Unsupported";
+    })(ItemCategory || (exports.ItemCategory = ItemCategory = {}));
+    var ItemFieldType;
+    (function(ItemFieldType2) {
+      ItemFieldType2["Text"] = "Text";
+      ItemFieldType2["Concealed"] = "Concealed";
+      ItemFieldType2["CreditCardType"] = "CreditCardType";
+      ItemFieldType2["CreditCardNumber"] = "CreditCardNumber";
+      ItemFieldType2["Phone"] = "Phone";
+      ItemFieldType2["Url"] = "Url";
+      ItemFieldType2["Totp"] = "Totp";
+      ItemFieldType2["Email"] = "Email";
+      ItemFieldType2["Reference"] = "Reference";
+      ItemFieldType2["SshKey"] = "SshKey";
+      ItemFieldType2["Menu"] = "Menu";
+      ItemFieldType2["MonthYear"] = "MonthYear";
+      ItemFieldType2["Address"] = "Address";
+      ItemFieldType2["Date"] = "Date";
+      ItemFieldType2["Unsupported"] = "Unsupported";
+    })(ItemFieldType || (exports.ItemFieldType = ItemFieldType = {}));
+    var AutofillBehavior;
+    (function(AutofillBehavior2) {
+      AutofillBehavior2["AnywhereOnWebsite"] = "AnywhereOnWebsite";
+      AutofillBehavior2["ExactDomain"] = "ExactDomain";
+      AutofillBehavior2["Never"] = "Never";
+    })(AutofillBehavior || (exports.AutofillBehavior = AutofillBehavior = {}));
+    var ItemState;
+    (function(ItemState2) {
+      ItemState2["Active"] = "active";
+      ItemState2["Archived"] = "archived";
+    })(ItemState || (exports.ItemState = ItemState = {}));
+    var ItemShareDuration;
+    (function(ItemShareDuration2) {
+      ItemShareDuration2["OneHour"] = "OneHour";
+      ItemShareDuration2["OneDay"] = "OneDay";
+      ItemShareDuration2["SevenDays"] = "SevenDays";
+      ItemShareDuration2["FourteenDays"] = "FourteenDays";
+      ItemShareDuration2["ThirtyDays"] = "ThirtyDays";
+    })(ItemShareDuration || (exports.ItemShareDuration = ItemShareDuration = {}));
+    var AllowedType;
+    (function(AllowedType2) {
+      AllowedType2["Authenticated"] = "Authenticated";
+      AllowedType2["Public"] = "Public";
+    })(AllowedType || (exports.AllowedType = AllowedType = {}));
+    var AllowedRecipientType;
+    (function(AllowedRecipientType2) {
+      AllowedRecipientType2["Email"] = "Email";
+      AllowedRecipientType2["Domain"] = "Domain";
+    })(AllowedRecipientType || (exports.AllowedRecipientType = AllowedRecipientType = {}));
+    var VaultType;
+    (function(VaultType2) {
+      VaultType2["Personal"] = "personal";
+      VaultType2["Everyone"] = "everyone";
+      VaultType2["Transfer"] = "transfer";
+      VaultType2["UserCreated"] = "userCreated";
+      VaultType2["Unsupported"] = "unsupported";
+    })(VaultType || (exports.VaultType = VaultType = {}));
+    var SeparatorType;
+    (function(SeparatorType2) {
+      SeparatorType2["Digits"] = "digits";
+      SeparatorType2["DigitsAndSymbols"] = "digitsAndSymbols";
+      SeparatorType2["Spaces"] = "spaces";
+      SeparatorType2["Hyphens"] = "hyphens";
+      SeparatorType2["Underscores"] = "underscores";
+      SeparatorType2["Periods"] = "periods";
+      SeparatorType2["Commas"] = "commas";
+    })(SeparatorType || (exports.SeparatorType = SeparatorType = {}));
+    var WordListType;
+    (function(WordListType2) {
+      WordListType2["FullWords"] = "fullWords";
+      WordListType2["Syllables"] = "syllables";
+      WordListType2["ThreeLetters"] = "threeLetters";
+    })(WordListType || (exports.WordListType = WordListType = {}));
+    exports.ARCHIVE_ITEMS = 256;
+    exports.CREATE_ITEMS = 128;
+    exports.DELETE_ITEMS = 512;
+    exports.EXPORT_ITEMS = 4194304;
+    exports.IMPORT_ITEMS = 2097152;
+    exports.MANAGE_VAULT = 2;
+    exports.NO_ACCESS = 0;
+    exports.PRINT_ITEMS = 8388608;
+    exports.READ_ITEMS = 32;
+    exports.RECOVER_VAULT = 1;
+    exports.REVEAL_ITEM_PASSWORD = 16;
+    exports.SEND_ITEMS = 1048576;
+    exports.UPDATE_ITEMS = 64;
+    exports.UPDATE_ITEM_HISTORY = 1024;
+    var ReviverFunc = (key, value) => {
+      if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value) && (key === "createdAt" || key === "updatedAt")) {
+        return new Date(value);
+      }
+      if (Array.isArray(value) && value.every((v) => Number.isInteger(v) && v >= 0 && v <= 255) && value.length > 0) {
+        return new Uint8Array(value);
+      }
+      return value;
+    };
+    exports.ReviverFunc = ReviverFunc;
+    var ReplacerFunc = (key, value) => {
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+      if (value instanceof Uint8Array) {
+        return Array.from(value);
+      }
+      return value;
+    };
+    exports.ReplacerFunc = ReplacerFunc;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/errors.js
+var require_errors3 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/errors.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.throwError = exports.RateLimitExceededError = exports.DesktopSessionExpiredError = void 0;
+    var DesktopSessionExpiredError = class extends Error {
+      constructor(message) {
+        super();
+        this.message = message;
+      }
+    };
+    exports.DesktopSessionExpiredError = DesktopSessionExpiredError;
+    var RateLimitExceededError = class extends Error {
+      constructor(message) {
+        super();
+        this.message = message;
+      }
+    };
+    exports.RateLimitExceededError = RateLimitExceededError;
+    var throwError = (errString) => {
+      let err;
+      try {
+        err = JSON.parse(errString);
+      } catch (e) {
+        throw new Error(errString);
+      }
+      switch (err.name) {
+        case "DesktopSessionExpired":
+          throw new DesktopSessionExpiredError(err.message);
+        case "RateLimitExceeded":
+          throw new RateLimitExceededError(err.message);
+        default:
+          throw new Error(err.message);
+      }
+    };
+    exports.throwError = throwError;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/core.js
+var require_core3 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/core.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.InnerClient = exports.SharedCore = exports.WasmCore = void 0;
+    var sdk_core_1 = require_core2();
+    var types_1 = require_types();
+    var errors_1 = require_errors3();
+    var messageLimit = 50 * 1024 * 1024;
+    var WasmCore = class {
+      initClient(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          try {
+            return yield (0, sdk_core_1.init_client)(config);
+          } catch (e) {
+            (0, errors_1.throwError)(e);
+          }
+        });
+      }
+      invoke(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          try {
+            return yield (0, sdk_core_1.invoke)(config);
+          } catch (e) {
+            (0, errors_1.throwError)(e);
+          }
+        });
+      }
+      releaseClient(clientId) {
+        try {
+          (0, sdk_core_1.release_client)(clientId);
+        } catch (e) {
+          console.warn("failed to release client:", e);
+        }
+      }
+    };
+    exports.WasmCore = WasmCore;
+    var SharedCore = class {
+      constructor() {
+        this.inner = new WasmCore();
+      }
+      setInner(core2) {
+        this.inner = core2;
+      }
+      initClient(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const serializedConfig = JSON.stringify(config);
+          return this.inner.initClient(serializedConfig);
+        });
+      }
+      invoke(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const serializedConfig = JSON.stringify(config, types_1.ReplacerFunc);
+          if (new TextEncoder().encode(serializedConfig).length > messageLimit) {
+            (0, errors_1.throwError)(`message size exceeds the limit of ${messageLimit} bytes, please contact 1Password at support@1password.com or https://developer.1password.com/joinslack if you need help."`);
+          }
+          return this.inner.invoke(serializedConfig);
+        });
+      }
+      invoke_sync(config) {
+        const serializedConfig = JSON.stringify(config, types_1.ReplacerFunc);
+        if (new TextEncoder().encode(serializedConfig).length > messageLimit) {
+          (0, errors_1.throwError)(`message size exceeds the limit of ${messageLimit} bytes, please contact 1Password at support@1password.com or https://developer.1password.com/joinslack if you need help.`);
+        }
+        return (0, sdk_core_1.invoke_sync)(serializedConfig);
+      }
+      releaseClient(clientId) {
+        const serializedId = JSON.stringify(clientId);
+        this.inner.releaseClient(serializedId);
+      }
+    };
+    exports.SharedCore = SharedCore;
+    var InnerClient = class {
+      constructor(id, core2, config) {
+        this.id = id;
+        this.core = core2;
+        this.config = config;
+      }
+      invoke(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          try {
+            return yield this.core.invoke(config);
+          } catch (err) {
+            if (err instanceof errors_1.DesktopSessionExpiredError) {
+              const newId = yield this.core.initClient(this.config);
+              this.id = parseInt(newId, 10);
+              config.invocation.clientId = this.id;
+              return yield this.core.invoke(config);
+            }
+            throw err;
+          }
+        });
+      }
+    };
+    exports.InnerClient = InnerClient;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/version.js
+var require_version = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/version.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.SDK_BUILD_NUMBER = exports.SDK_VERSION = void 0;
+    exports.SDK_VERSION = "0.4.0";
+    exports.SDK_BUILD_NUMBER = "0040003";
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/configuration.js
+var require_configuration = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/configuration.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __importDefault = exports && exports.__importDefault || function(mod) {
+      return mod && mod.__esModule ? mod : { "default": mod };
+    };
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.getOsName = exports.clientAuthConfig = exports.DesktopAuth = exports.VERSION = exports.LANGUAGE = void 0;
+    var os_1 = __importDefault(__require("os"));
+    var version_js_1 = require_version();
+    exports.LANGUAGE = "JS";
+    exports.VERSION = version_js_1.SDK_BUILD_NUMBER;
+    var DesktopAuth = class {
+      constructor(accountName) {
+        this.accountName = accountName;
+      }
+    };
+    exports.DesktopAuth = DesktopAuth;
+    var clientAuthConfig = (userConfig) => {
+      const defaultOsVersion = "0.0.0";
+      let serviceAccountToken;
+      let accountName;
+      if (typeof userConfig.auth === "string") {
+        serviceAccountToken = userConfig.auth;
+      } else if (userConfig.auth instanceof DesktopAuth) {
+        accountName = userConfig.auth.accountName;
+      }
+      return {
+        serviceAccountToken: serviceAccountToken !== null && serviceAccountToken !== void 0 ? serviceAccountToken : "",
+        accountName,
+        programmingLanguage: exports.LANGUAGE,
+        sdkVersion: exports.VERSION,
+        integrationName: userConfig.integrationName,
+        integrationVersion: userConfig.integrationVersion,
+        requestLibraryName: "Fetch API",
+        requestLibraryVersion: "Fetch API",
+        os: (0, exports.getOsName)(),
+        osVersion: defaultOsVersion,
+        architecture: os_1.default.arch()
+      };
+    };
+    exports.clientAuthConfig = clientAuthConfig;
+    var getOsName = () => {
+      const os_name = os_1.default.type().toLowerCase();
+      if (os_name === "windows_nt") {
+        return "windows";
+      }
+      return os_name;
+    };
+    exports.getOsName = getOsName;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/secrets.js
+var require_secrets = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/secrets.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports && exports.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports && exports.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Secrets_inner;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Secrets = void 0;
+    var core_js_1 = require_core3();
+    var types_js_1 = require_types();
+    var Secrets = class {
+      constructor(inner) {
+        _Secrets_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Secrets_inner, inner, "f");
+      }
+      /**
+       * Resolve returns the secret the provided secret reference points to.
+       */
+      resolve(secretReference) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Secrets_inner, "f").id,
+              parameters: {
+                name: "SecretsResolve",
+                parameters: {
+                  secret_reference: secretReference
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Secrets_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Resolve takes in a list of secret references and returns the secrets they point to or errors if any.
+       */
+      resolveAll(secretReferences) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Secrets_inner, "f").id,
+              parameters: {
+                name: "SecretsResolveAll",
+                parameters: {
+                  secret_references: secretReferences
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Secrets_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Validate the secret reference to ensure there are no syntax errors.
+       */
+      static validateSecretReference(secretReference) {
+        const sharedCore = new core_js_1.SharedCore();
+        const invocationConfig = {
+          invocation: {
+            parameters: {
+              name: "ValidateSecretReference",
+              parameters: {
+                secret_reference: secretReference
+              }
+            }
+          }
+        };
+        sharedCore.invoke_sync(invocationConfig);
+      }
+      /**
+       * Generate a password using the provided recipe.
+       */
+      static generatePassword(recipe) {
+        const sharedCore = new core_js_1.SharedCore();
+        const invocationConfig = {
+          invocation: {
+            parameters: {
+              name: "GeneratePassword",
+              parameters: {
+                recipe
+              }
+            }
+          }
+        };
+        return JSON.parse(sharedCore.invoke_sync(invocationConfig), types_js_1.ReviverFunc);
+      }
+    };
+    exports.Secrets = Secrets;
+    _Secrets_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_shares.js
+var require_items_shares = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_shares.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports && exports.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports && exports.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _ItemsShares_inner;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ItemsShares = void 0;
+    var types_js_1 = require_types();
+    var ItemsShares = class {
+      constructor(inner) {
+        _ItemsShares_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _ItemsShares_inner, inner, "f");
+      }
+      /**
+       * Get the item sharing policy of your account.
+       */
+      getAccountPolicy(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsShares_inner, "f").id,
+              parameters: {
+                name: "ItemsSharesGetAccountPolicy",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsShares_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Validate the recipients of an item sharing link.
+       */
+      validateRecipients(policy, recipients) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsShares_inner, "f").id,
+              parameters: {
+                name: "ItemsSharesValidateRecipients",
+                parameters: {
+                  policy,
+                  recipients
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsShares_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Create a new item sharing link.
+       */
+      create(item, policy, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsShares_inner, "f").id,
+              parameters: {
+                name: "ItemsSharesCreate",
+                parameters: {
+                  item,
+                  policy,
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsShares_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports.ItemsShares = ItemsShares;
+    _ItemsShares_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_files.js
+var require_items_files = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items_files.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports && exports.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports && exports.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _ItemsFiles_inner;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.ItemsFiles = void 0;
+    var types_js_1 = require_types();
+    var ItemsFiles = class {
+      constructor(inner) {
+        _ItemsFiles_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _ItemsFiles_inner, inner, "f");
+      }
+      /**
+       * Attach files to Items.
+       */
+      attach(item, fileParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesAttach",
+                parameters: {
+                  item,
+                  file_params: fileParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Read file content from the Item.
+       */
+      read(vaultId, itemId, attr) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesRead",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId,
+                  attr
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Delete a field file from Item using the section and field IDs.
+       */
+      delete(item, sectionId, fieldId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesDelete",
+                parameters: {
+                  item,
+                  section_id: sectionId,
+                  field_id: fieldId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Replace the document file within a document item.
+       */
+      replaceDocument(item, docParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _ItemsFiles_inner, "f").id,
+              parameters: {
+                name: "ItemsFilesReplaceDocument",
+                parameters: {
+                  item,
+                  doc_params: docParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _ItemsFiles_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports.ItemsFiles = ItemsFiles;
+    _ItemsFiles_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items.js
+var require_items = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/items.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports && exports.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports && exports.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Items_inner;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Items = void 0;
+    var types_js_1 = require_types();
+    var items_shares_js_1 = require_items_shares();
+    var items_files_js_1 = require_items_files();
+    var Items = class {
+      constructor(inner) {
+        _Items_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Items_inner, inner, "f");
+        this.shares = new items_shares_js_1.ItemsShares(inner);
+        this.files = new items_files_js_1.ItemsFiles(inner);
+      }
+      /**
+       * Create a new item.
+       */
+      create(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsCreate",
+                parameters: {
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Create items in batch, within a single vault.
+       */
+      createAll(vaultId, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsCreateAll",
+                parameters: {
+                  vault_id: vaultId,
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get an item by vault and item ID.
+       */
+      get(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsGet",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get items by vault and their item IDs.
+       */
+      getAll(vaultId, itemIds) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsGetAll",
+                parameters: {
+                  vault_id: vaultId,
+                  item_ids: itemIds
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Update an existing item.
+       */
+      put(item) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsPut",
+                parameters: {
+                  item
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Delete an item.
+       */
+      delete(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsDelete",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Delete items in batch, within a single vault.
+       */
+      deleteAll(vaultId, itemIds) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsDeleteAll",
+                parameters: {
+                  vault_id: vaultId,
+                  item_ids: itemIds
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Archive an item.
+       */
+      archive(vaultId, itemId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsArchive",
+                parameters: {
+                  vault_id: vaultId,
+                  item_id: itemId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * List items based on filters.
+       */
+      list(vaultId, ...filters) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Items_inner, "f").id,
+              parameters: {
+                name: "ItemsList",
+                parameters: {
+                  vault_id: vaultId,
+                  filters
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Items_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports.Items = Items;
+    _Items_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/vaults.js
+var require_vaults = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/vaults.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports && exports.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports && exports.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Vaults_inner;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Vaults = void 0;
+    var types_js_1 = require_types();
+    var Vaults = class {
+      constructor(inner) {
+        _Vaults_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Vaults_inner, inner, "f");
+      }
+      /**
+       * Create a new user vault.
+       */
+      create(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsCreate",
+                parameters: {
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * List information about vaults that's configurable based on some input parameters.
+       */
+      list(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsList",
+                parameters: {
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get an overview of a vault by its ID.
+       */
+      getOverview(vaultId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsGetOverview",
+                parameters: {
+                  vault_id: vaultId
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Get detailed vault information by vault ID and parameters.
+       */
+      get(vaultId, vaultParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsGet",
+                parameters: {
+                  vault_id: vaultId,
+                  vault_params: vaultParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Update a vault
+       */
+      update(vaultId, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsUpdate",
+                parameters: {
+                  vault_id: vaultId,
+                  params
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+      /**
+       * Delete a vault by its ID.
+       */
+      delete(vaultId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsDelete",
+                parameters: {
+                  vault_id: vaultId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Grant group permissions to a vault.
+       */
+      grantGroupPermissions(vaultId, groupPermissionsList) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsGrantGroupPermissions",
+                parameters: {
+                  vault_id: vaultId,
+                  group_permissions_list: groupPermissionsList
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Update group permissions for vaults.
+       */
+      updateGroupPermissions(groupPermissionsList) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsUpdateGroupPermissions",
+                parameters: {
+                  group_permissions_list: groupPermissionsList
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+      /**
+       * Revoke group permissions from a vault.
+       */
+      revokeGroupPermissions(vaultId, groupId) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Vaults_inner, "f").id,
+              parameters: {
+                name: "VaultsRevokeGroupPermissions",
+                parameters: {
+                  vault_id: vaultId,
+                  group_id: groupId
+                }
+              }
+            }
+          };
+          yield __classPrivateFieldGet(this, _Vaults_inner, "f").invoke(invocationConfig);
+        });
+      }
+    };
+    exports.Vaults = Vaults;
+    _Vaults_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/groups.js
+var require_groups = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/groups.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    var __classPrivateFieldSet = exports && exports.__classPrivateFieldSet || function(receiver, state, value, kind, f) {
+      if (kind === "m") throw new TypeError("Private method is not writable");
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+      return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
+    };
+    var __classPrivateFieldGet = exports && exports.__classPrivateFieldGet || function(receiver, state, kind, f) {
+      if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+      if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+      return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+    var _Groups_inner;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Groups = void 0;
+    var types_js_1 = require_types();
+    var Groups = class {
+      constructor(inner) {
+        _Groups_inner.set(this, void 0);
+        __classPrivateFieldSet(this, _Groups_inner, inner, "f");
+      }
+      /**
+       * Get a group by its ID and parameters.
+       */
+      get(groupId, groupParams) {
+        return __awaiter(this, void 0, void 0, function* () {
+          const invocationConfig = {
+            invocation: {
+              clientId: __classPrivateFieldGet(this, _Groups_inner, "f").id,
+              parameters: {
+                name: "GroupsGet",
+                parameters: {
+                  group_id: groupId,
+                  group_params: groupParams
+                }
+              }
+            }
+          };
+          return JSON.parse(yield __classPrivateFieldGet(this, _Groups_inner, "f").invoke(invocationConfig), types_js_1.ReviverFunc);
+        });
+      }
+    };
+    exports.Groups = Groups;
+    _Groups_inner = /* @__PURE__ */ new WeakMap();
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client.js
+var require_client2 = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.Client = void 0;
+    var secrets_js_1 = require_secrets();
+    var items_js_1 = require_items();
+    var vaults_js_1 = require_vaults();
+    var groups_js_1 = require_groups();
+    var Client = class {
+      constructor(innerClient) {
+        this.secrets = new secrets_js_1.Secrets(innerClient);
+        this.items = new items_js_1.Items(innerClient);
+        this.vaults = new vaults_js_1.Vaults(innerClient);
+        this.groups = new groups_js_1.Groups(innerClient);
+      }
+    };
+    exports.Client = Client;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/shared_lib_core.js
+var require_shared_lib_core = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/shared_lib_core.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __createBinding = exports && exports.__createBinding || (Object.create ? (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      var desc = Object.getOwnPropertyDescriptor(m, k);
+      if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+        desc = { enumerable: true, get: function() {
+          return m[k];
+        } };
+      }
+      Object.defineProperty(o, k2, desc);
+    }) : (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      o[k2] = m[k];
+    }));
+    var __setModuleDefault = exports && exports.__setModuleDefault || (Object.create ? (function(o, v) {
+      Object.defineProperty(o, "default", { enumerable: true, value: v });
+    }) : function(o, v) {
+      o["default"] = v;
+    });
+    var __importStar = exports && exports.__importStar || /* @__PURE__ */ (function() {
+      var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function(o2) {
+          var ar = [];
+          for (var k in o2) if (Object.prototype.hasOwnProperty.call(o2, k)) ar[ar.length] = k;
+          return ar;
+        };
+        return ownKeys(o);
+      };
+      return function(mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) {
+          for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        }
+        __setModuleDefault(result, mod);
+        return result;
+      };
+    })();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.SharedLibCore = void 0;
+    var fs4 = __importStar(__require("fs"));
+    var os3 = __importStar(__require("os"));
+    var path4 = __importStar(__require("path"));
+    var errors_1 = require_errors3();
+    var find1PasswordLibPath = () => {
+      const platform = os3.platform();
+      const appRoot = path4.dirname(process.execPath);
+      let searchPaths = [];
+      switch (platform) {
+        case "darwin":
+          searchPaths = [
+            "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib",
+            path4.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
+          ];
+          break;
+        case "linux":
+          searchPaths = [
+            "/usr/bin/1password/libop_sdk_ipc_client.so",
+            "/opt/1Password/libop_sdk_ipc_client.so",
+            "/snap/bin/1password/libop_sdk_ipc_client.so"
+          ];
+          break;
+        case "win32":
+          searchPaths = [
+            path4.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
+            "C:/Program Files/1Password/app/8/op_sdk_ipc_client.dll",
+            "C:/Program Files (x86)/1Password/app/8/op_sdk_ipc_client.dll",
+            path4.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
+          ];
+          break;
+        default:
+          throw new Error(`Unsupported platform: ${platform}`);
+      }
+      for (const addonPath of searchPaths) {
+        if (fs4.existsSync(addonPath)) {
+          return addonPath;
+        }
+      }
+      throw new Error("1Password desktop application not found");
+    };
+    var SharedLibCore = class {
+      constructor(accountName) {
+        this.lib = null;
+        try {
+          const libPath = find1PasswordLibPath();
+          const moduleStub = { exports: {} };
+          process.dlopen(moduleStub, libPath);
+          if (typeof moduleStub === "object" && moduleStub !== null && typeof moduleStub.exports === "object" && moduleStub.exports !== null && "sendMessage" in moduleStub.exports && typeof moduleStub.exports.sendMessage === "function") {
+            this.lib = moduleStub.exports;
+          } else {
+            throw new Error("Failed to initialize native library: sendMessage function not found on module.");
+          }
+        } catch (e) {
+          console.error("A critical error occurred while loading the native addon:", e);
+          this.lib = null;
+        }
+        this.acccountName = accountName;
+      }
+      /**
+       * callSharedLibrary - send string to native function, receive string back.
+       */
+      callSharedLibrary(input, operation_type) {
+        return __awaiter(this, void 0, void 0, function* () {
+          if (!this.lib) {
+            throw new Error("Native library is not available.");
+          }
+          if (!input || input.length === 0) {
+            throw new Error("internal: empty input");
+          }
+          const inputEncoded = Buffer.from(input, "utf8").toString("base64");
+          const req = {
+            account_name: this.acccountName,
+            kind: operation_type,
+            payload: inputEncoded
+          };
+          const inputBuf = Buffer.from(JSON.stringify(req), "utf8");
+          const nativeResponse = yield this.lib.sendMessage(inputBuf);
+          if (!(nativeResponse instanceof Uint8Array)) {
+            throw new Error(`Native function returned an unexpected type. Expected Uint8Array, got ${typeof nativeResponse}`);
+          }
+          const respString = new TextDecoder().decode(nativeResponse);
+          const response = JSON.parse(respString);
+          if (response.success) {
+            const decodedPayload = Buffer.from(response.payload).toString("utf8");
+            return decodedPayload;
+          } else {
+            const errorMessage = Array.isArray(response.payload) ? String.fromCharCode(...response.payload) : JSON.stringify(response.payload);
+            (0, errors_1.throwError)(errorMessage);
+          }
+        });
+      }
+      // Core interface implementation
+      initClient(config) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.callSharedLibrary(config, "init_client");
+        });
+      }
+      invoke(invokeConfigBytes) {
+        return __awaiter(this, void 0, void 0, function* () {
+          return this.callSharedLibrary(invokeConfigBytes, "invoke");
+        });
+      }
+      releaseClient(clientId) {
+        this.callSharedLibrary(clientId, "release_client").catch((err) => {
+          console.warn("failed to release client:", err);
+        });
+      }
+    };
+    exports.SharedLibCore = SharedLibCore;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client_builder.js
+var require_client_builder = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/client_builder.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.createClientWithCore = void 0;
+    var core_js_1 = require_core3();
+    var configuration_js_1 = require_configuration();
+    var client_js_1 = require_client2();
+    var shared_lib_core_js_1 = require_shared_lib_core();
+    var finalizationRegistry = new FinalizationRegistry((heldClient) => {
+      heldClient.core.releaseClient(heldClient.id);
+    });
+    var createClientWithCore = (config, core2) => __awaiter(void 0, void 0, void 0, function* () {
+      const authConfig = (0, configuration_js_1.clientAuthConfig)(config);
+      if (authConfig.accountName) {
+        core2.setInner(new shared_lib_core_js_1.SharedLibCore(authConfig.accountName));
+      }
+      const clientId = yield core2.initClient(authConfig);
+      const inner = new core_js_1.InnerClient(parseInt(clientId, 10), core2, authConfig);
+      const client = new client_js_1.Client(inner);
+      finalizationRegistry.register(client, inner);
+      return client;
+    });
+    exports.createClientWithCore = createClientWithCore;
+  }
+});
+
+// ../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/sdk.js
+var require_sdk = __commonJS({
+  "../../node_modules/.pnpm/@1password+sdk@0.4.0/node_modules/@1password/sdk/dist/sdk.js"(exports) {
+    "use strict";
+    init_esm_shims();
+    var __createBinding = exports && exports.__createBinding || (Object.create ? (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      var desc = Object.getOwnPropertyDescriptor(m, k);
+      if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+        desc = { enumerable: true, get: function() {
+          return m[k];
+        } };
+      }
+      Object.defineProperty(o, k2, desc);
+    }) : (function(o, m, k, k2) {
+      if (k2 === void 0) k2 = k;
+      o[k2] = m[k];
+    }));
+    var __exportStar = exports && exports.__exportStar || function(m, exports2) {
+      for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports2, p)) __createBinding(exports2, m, p);
+    };
+    var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
+      function adopt(value) {
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
+        });
+      }
+      return new (P || (P = Promise))(function(resolve6, reject) {
+        function fulfilled(value) {
+          try {
+            step(generator.next(value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function rejected(value) {
+          try {
+            step(generator["throw"](value));
+          } catch (e) {
+            reject(e);
+          }
+        }
+        function step(result) {
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+        }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+      });
+    };
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.createClient = exports.DesktopAuth = exports.Secrets = exports.DEFAULT_INTEGRATION_VERSION = exports.DEFAULT_INTEGRATION_NAME = void 0;
+    var core_js_1 = require_core3();
+    var client_builder_js_1 = require_client_builder();
+    exports.DEFAULT_INTEGRATION_NAME = "Unknown";
+    exports.DEFAULT_INTEGRATION_VERSION = "Unknown";
+    var secrets_js_1 = require_secrets();
+    Object.defineProperty(exports, "Secrets", { enumerable: true, get: function() {
+      return secrets_js_1.Secrets;
+    } });
+    var configuration_js_1 = require_configuration();
+    Object.defineProperty(exports, "DesktopAuth", { enumerable: true, get: function() {
+      return configuration_js_1.DesktopAuth;
+    } });
+    __exportStar(require_client2(), exports);
+    __exportStar(require_errors3(), exports);
+    __exportStar(require_types(), exports);
+    var createClient = (config) => __awaiter(void 0, void 0, void 0, function* () {
+      return (0, client_builder_js_1.createClientWithCore)(config, new core_js_1.SharedCore());
+    });
+    exports.createClient = createClient;
+  }
+});
+
 // ../../node_modules/.pnpm/@actions+github@7.0.0/node_modules/@actions/github/lib/context.js
 var require_context = __commonJS({
   "../../node_modules/.pnpm/@actions+github@7.0.0/node_modules/@actions/github/lib/context.js"(exports) {
@@ -31148,11 +33503,11 @@ var require_lib2 = __commonJS({
     })();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -31168,7 +33523,7 @@ var require_lib2 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -31212,11 +33567,11 @@ var require_lib2 = __commonJS({
       HttpCodes2[HttpCodes2["ServiceUnavailable"] = 503] = "ServiceUnavailable";
       HttpCodes2[HttpCodes2["GatewayTimeout"] = 504] = "GatewayTimeout";
     })(HttpCodes || (exports.HttpCodes = HttpCodes = {}));
-    var Headers;
-    (function(Headers2) {
-      Headers2["Accept"] = "accept";
-      Headers2["ContentType"] = "content-type";
-    })(Headers || (exports.Headers = Headers = {}));
+    var Headers2;
+    (function(Headers3) {
+      Headers3["Accept"] = "accept";
+      Headers3["ContentType"] = "content-type";
+    })(Headers2 || (exports.Headers = Headers2 = {}));
     var MediaTypes;
     (function(MediaTypes2) {
       MediaTypes2["ApplicationJson"] = "application/json";
@@ -31255,26 +33610,26 @@ var require_lib2 = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve4(output.toString());
+              resolve6(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve4(Buffer.concat(chunks));
+              resolve6(Buffer.concat(chunks));
             });
           }));
         });
@@ -31369,7 +33724,7 @@ var require_lib2 = __commonJS({
        */
       getJson(requestUrl_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, additionalHeaders = {}) {
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
           const res = yield this.get(requestUrl, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31377,8 +33732,8 @@ var require_lib2 = __commonJS({
       postJson(requestUrl_1, obj_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, obj, additionalHeaders = {}) {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
           const res = yield this.post(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31386,8 +33741,8 @@ var require_lib2 = __commonJS({
       putJson(requestUrl_1, obj_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, obj, additionalHeaders = {}) {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
           const res = yield this.put(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31395,8 +33750,8 @@ var require_lib2 = __commonJS({
       patchJson(requestUrl_1, obj_1) {
         return __awaiter(this, arguments, void 0, function* (requestUrl, obj, additionalHeaders = {}) {
           const data = JSON.stringify(obj, null, 2);
-          additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers.Accept, MediaTypes.ApplicationJson);
-          additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.Accept] = this._getExistingOrDefaultHeader(additionalHeaders, Headers2.Accept, MediaTypes.ApplicationJson);
+          additionalHeaders[Headers2.ContentType] = this._getExistingOrDefaultContentTypeHeader(additionalHeaders, MediaTypes.ApplicationJson);
           const res = yield this.patch(requestUrl, data, additionalHeaders);
           return this._processResponse(res, this.requestOptions);
         });
@@ -31482,14 +33837,14 @@ var require_lib2 = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => {
+          return new Promise((resolve6, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve4(res);
+                resolve6(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -31626,7 +33981,7 @@ var require_lib2 = __commonJS({
       _getExistingOrDefaultContentTypeHeader(additionalHeaders, _default) {
         let clientHeader;
         if (this.requestOptions && this.requestOptions.headers) {
-          const headerValue = lowercaseKeys2(this.requestOptions.headers)[Headers.ContentType];
+          const headerValue = lowercaseKeys2(this.requestOptions.headers)[Headers2.ContentType];
           if (headerValue) {
             if (typeof headerValue === "number") {
               clientHeader = String(headerValue);
@@ -31637,7 +33992,7 @@ var require_lib2 = __commonJS({
             }
           }
         }
-        const additionalValue = additionalHeaders[Headers.ContentType];
+        const additionalValue = additionalHeaders[Headers2.ContentType];
         if (additionalValue !== void 0) {
           if (typeof additionalValue === "number") {
             return String(additionalValue);
@@ -31733,12 +34088,12 @@ var require_lib2 = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve4) => setTimeout(() => resolve4(), ms2));
+          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve4, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -31746,7 +34101,7 @@ var require_lib2 = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve4(response);
+              resolve6(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -31785,7 +34140,7 @@ var require_lib2 = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve4(response);
+              resolve6(response);
             }
           }));
         });
@@ -31840,11 +34195,11 @@ var require_utils4 = __commonJS({
     })();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve4) {
-          resolve4(value);
+        return value instanceof P ? value : new P(function(resolve6) {
+          resolve6(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve4, reject) {
+      return new (P || (P = Promise))(function(resolve6, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -31860,7 +34215,7 @@ var require_utils4 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve4(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32735,16 +35090,16 @@ function fetchWrapper(requestOptions) {
   let headers = {};
   let status;
   let url;
-  let { fetch } = globalThis;
+  let { fetch: fetch2 } = globalThis;
   if (requestOptions.request?.fetch) {
-    fetch = requestOptions.request.fetch;
+    fetch2 = requestOptions.request.fetch;
   }
-  if (!fetch) {
+  if (!fetch2) {
     throw new Error(
       "fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}). Learn more at https://github.com/octokit/octokit.js/#fetch-missing"
     );
   }
-  return fetch(requestOptions.url, {
+  return fetch2(requestOptions.url, {
     method: requestOptions.method,
     body: requestOptions.body,
     redirect: requestOptions.request?.redirect,
@@ -35923,16 +38278,16 @@ var require_github = __commonJS({
 // src/index.ts
 init_esm_shims();
 var core = __toESM(require_core(), 1);
-import { resolve as resolve3 } from "path";
+import { resolve as resolve5 } from "path";
 
 // ../core/dist/index.js
 init_esm_shims();
 import * as fs from "fs";
-import { readFileSync as readFileSync2, mkdirSync as mkdirSync2, writeFileSync as writeFileSync2 } from "fs";
+import { readFileSync as readFileSync3, mkdirSync as mkdirSync2, writeFileSync as writeFileSync2 } from "fs";
 var import_semver = __toESM(require_semver2(), 1);
 var import_yaml = __toESM(require_dist(), 1);
 import * as path3 from "path";
-import { join as join2, dirname as dirname3 } from "path";
+import { join as join4, dirname as dirname4 } from "path";
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/index.js
 init_esm_shims();
@@ -41009,8 +43364,8 @@ function fromZod(version2, zodSchema, options) {
 
 // ../core/dist/index.js
 import * as fs2 from "fs/promises";
-import { readFile as readFile2, mkdir as mkdir2, writeFile as writeFile2, stat as stat2 } from "fs/promises";
-import * as crypto3 from "crypto";
+import { readFile as readFile3, mkdir as mkdir3, writeFile as writeFile3, stat as stat2 } from "fs/promises";
+import * as crypto22 from "crypto";
 
 // ../../node_modules/.pnpm/tinyglobby@0.2.15/node_modules/tinyglobby/dist/index.mjs
 init_esm_shims();
@@ -41135,11 +43490,11 @@ function build$3(options) {
   return options.group ? groupFiles : empty;
 }
 var resolveSymlinksAsync = function(path4, state, callback$1) {
-  const { queue, fs: fs3, options: { suppressErrors } } = state;
+  const { queue, fs: fs4, options: { suppressErrors } } = state;
   queue.enqueue();
-  fs3.realpath(path4, (error2, resolvedPath) => {
+  fs4.realpath(path4, (error2, resolvedPath) => {
     if (error2) return queue.dequeue(suppressErrors ? null : error2, state);
-    fs3.stat(resolvedPath, (error$1, stat3) => {
+    fs4.stat(resolvedPath, (error$1, stat3) => {
       if (error$1) return queue.dequeue(suppressErrors ? null : error$1, state);
       if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return queue.dequeue(null, state);
       callback$1(stat3, resolvedPath);
@@ -41148,11 +43503,11 @@ var resolveSymlinksAsync = function(path4, state, callback$1) {
   });
 };
 var resolveSymlinks = function(path4, state, callback$1) {
-  const { queue, fs: fs3, options: { suppressErrors } } = state;
+  const { queue, fs: fs4, options: { suppressErrors } } = state;
   queue.enqueue();
   try {
-    const resolvedPath = fs3.realpathSync(path4);
-    const stat3 = fs3.statSync(resolvedPath);
+    const resolvedPath = fs4.realpathSync(path4);
+    const stat3 = fs4.statSync(resolvedPath);
     if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return;
     callback$1(stat3, resolvedPath);
   } catch (e) {
@@ -41222,22 +43577,22 @@ var readdirOpts = { withFileTypes: true };
 var walkAsync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
   state.queue.enqueue();
   if (currentDepth < 0) return state.queue.dequeue(null, state);
-  const { fs: fs3 } = state;
+  const { fs: fs4 } = state;
   state.visited.push(crawlPath);
   state.counts.directories++;
-  fs3.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
+  fs4.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
     callback$1(entries, directoryPath, currentDepth);
     state.queue.dequeue(state.options.suppressErrors ? null : error2, state);
   });
 };
 var walkSync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
-  const { fs: fs3 } = state;
+  const { fs: fs4 } = state;
   if (currentDepth < 0) return;
   state.visited.push(crawlPath);
   state.counts.directories++;
   let entries = [];
   try {
-    entries = fs3.readdirSync(crawlPath || ".", readdirOpts);
+    entries = fs4.readdirSync(crawlPath || ".", readdirOpts);
   } catch (e) {
     if (!state.options.suppressErrors) throw e;
   }
@@ -41796,18 +44151,1967 @@ async function glob(patternsOrOptions, options) {
 }
 
 // ../core/dist/index.js
-import { spawn } from "child_process";
-import { Writable } from "stream";
+import * as os2 from "os";
+
+// ../../node_modules/.pnpm/vaultkeeper@0.7.0_@1password+sdk@0.4.0_@types+node@22.19.3/node_modules/vaultkeeper/dist/index.js
+init_esm_shims();
+import * as fs3 from "fs/promises";
+import * as path22 from "path";
+import { join as join2, dirname as dirname2, resolve as resolve3 } from "path";
 import * as os from "os";
-import { homedir as homedir2 } from "os";
+import * as crypto2 from "crypto";
+import { spawn } from "child_process";
+import { fileURLToPath as fileURLToPath3 } from "url";
+import { existsSync, readFileSync } from "fs";
+var VaultError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "VaultError";
+  }
+};
+var BackendLockedError = class extends VaultError {
+  /**
+   * Whether the lock can be resolved through an interactive user prompt.
+   * When `true`, callers may retry after prompting the user.
+   */
+  interactive;
+  constructor(message, interactive) {
+    super(message);
+    this.name = "BackendLockedError";
+    this.interactive = interactive;
+  }
+};
+var DeviceNotPresentError = class extends VaultError {
+  /**
+   * How long (in milliseconds) the operation waited for the device before
+   * giving up.
+   */
+  timeoutMs;
+  constructor(message, timeoutMs) {
+    super(message);
+    this.name = "DeviceNotPresentError";
+    this.timeoutMs = timeoutMs;
+  }
+};
+var AuthorizationDeniedError = class extends VaultError {
+  constructor(message) {
+    super(message);
+    this.name = "AuthorizationDeniedError";
+  }
+};
+var PresenceDeclinedError = class extends VaultError {
+  /** The `type` identifier of the backend that requested the presence action. */
+  backendType;
+  constructor(message, backendType) {
+    super(message);
+    this.name = "PresenceDeclinedError";
+    this.backendType = backendType;
+  }
+};
+var PresenceTimeoutError = class extends VaultError {
+  /** The `type` identifier of the backend that requested the presence action. */
+  backendType;
+  /** How long (in milliseconds) the operation waited for the presence action. */
+  timeoutMs;
+  constructor(message, backendType, timeoutMs) {
+    super(message);
+    this.name = "PresenceTimeoutError";
+    this.backendType = backendType;
+    this.timeoutMs = timeoutMs;
+  }
+};
+var BackendUnavailableError = class extends VaultError {
+  /**
+   * Machine-readable reason code describing why the backend is unavailable
+   * (e.g. `'none-enabled'`, `'all-failed'`).
+   */
+  reason;
+  /**
+   * The backend type identifiers that were attempted before this error was
+   * thrown.
+   */
+  attempted;
+  constructor(message, reason, attempted) {
+    super(message);
+    this.name = "BackendUnavailableError";
+    this.reason = reason;
+    this.attempted = attempted;
+  }
+};
+var PluginNotFoundError = class extends VaultError {
+  /**
+   * The plugin package or binary name that was not found.
+   */
+  plugin;
+  /**
+   * A URL pointing to installation instructions for the missing plugin.
+   */
+  installUrl;
+  constructor(message, plugin, installUrl) {
+    super(message);
+    this.name = "PluginNotFoundError";
+    this.plugin = plugin;
+    this.installUrl = installUrl;
+  }
+};
+var SecretNotFoundError = class extends VaultError {
+  constructor(message) {
+    super(message);
+    this.name = "SecretNotFoundError";
+  }
+};
+var ExecError = class extends VaultError {
+  /**
+   * The command that failed to execute.
+   */
+  command;
+  constructor(message, command) {
+    super(message);
+    this.name = "ExecError";
+    this.command = command;
+  }
+};
+var InvalidAlgorithmError = class extends VaultError {
+  /**
+   * The algorithm that was requested.
+   */
+  algorithm;
+  /**
+   * The set of algorithms that are allowed.
+   */
+  allowed;
+  constructor(message, algorithm, allowed) {
+    super(message);
+    this.name = "InvalidAlgorithmError";
+    this.algorithm = algorithm;
+    this.allowed = allowed;
+  }
+};
+var InvalidKeyMaterialError = class extends VaultError {
+  constructor(message) {
+    super(message);
+    this.name = "InvalidKeyMaterialError";
+  }
+};
+var SigningKeyNotFoundError = class extends VaultError {
+  /**
+   * The signing-key name that was requested (the caller-facing `--name`, not
+   * the internal namespaced identifier).
+   */
+  keyName;
+  constructor(message, keyName) {
+    super(message);
+    this.name = "SigningKeyNotFoundError";
+    this.keyName = keyName;
+  }
+};
+var SigningKeyAlreadyExistsError = class extends VaultError {
+  /**
+   * The signing-key name that already exists (the caller-facing `--name`, not
+   * the internal namespaced identifier).
+   */
+  keyName;
+  constructor(message, keyName) {
+    super(message);
+    this.name = "SigningKeyAlreadyExistsError";
+    this.keyName = keyName;
+  }
+};
+var DecryptionError = class extends VaultError {
+  /**
+   * The path of the encrypted entry that failed to decrypt.
+   */
+  path;
+  constructor(message, path9) {
+    super(message);
+    this.name = "DecryptionError";
+    this.path = path9;
+  }
+};
+var ConfigValidationError = class extends VaultError {
+  /**
+   * The dotted/bracketed path to the offending config field (e.g.
+   * `'backends[0].path'`).
+   */
+  field;
+  /**
+   * The path of the config file that failed validation, when the error
+   * originated from loading a file on disk (via `loadConfig`) rather than
+   * from validating an in-memory value directly. This is `configDir` joined
+   * with `config.json` exactly as provided to `loadConfig` — it is not
+   * guaranteed to be absolute (`loadConfig` does not resolve a relative
+   * `configDir`).
+   */
+  configFilePath;
+  constructor(message, field, configFilePath) {
+    super(message);
+    this.name = "ConfigValidationError";
+    this.field = field;
+    this.configFilePath = configFilePath;
+  }
+};
+var SetupError = class extends VaultError {
+  /**
+   * The name of the dependency that caused the setup failure.
+   */
+  dependency;
+  constructor(message, dependency) {
+    super(message);
+    this.name = "SetupError";
+    this.dependency = dependency;
+  }
+};
+var FilesystemError = class extends VaultError {
+  /**
+   * The path of the file or directory that caused the error, as provided by
+   * the caller. Not guaranteed to be absolute — e.g. `loadConfig` throws this
+   * with `configDir` joined with `config.json` exactly as given, without
+   * resolving a relative `configDir`.
+   */
+  path;
+  /**
+   * The file operation or access mode that was being attempted when the
+   * failure occurred, for example 'read', 'write', 'delete', or 'rwx' for a
+   * directory create/access check. Despite the field name, this does not
+   * imply the failure was itself a permission problem — it names the
+   * attempted operation regardless of the underlying errno, which may be a
+   * non-permission code such as ENOSPC or EISDIR.
+   */
+  permission;
+  /**
+   * The Node.js errno code from the underlying filesystem failure, for
+   * example EACCES, EPERM, ENOSPC, or EISDIR. Undefined when the error was
+   * constructed without an underlying cause, or when that cause did not
+   * expose a string errno code. Prefer this over parsing the message text,
+   * which is not a contractual format.
+   */
+  code;
+  /**
+   * @param message - Human-readable description of the failure.
+   * @param filePath - The path of the file or directory that caused the error.
+   * @param permission - The file operation or access mode being attempted,
+   * for example 'read', 'write', 'delete', or 'rwx'. See the `permission`
+   * property for why this need not indicate an actual permission problem.
+   * @param cause - The underlying error that was caught, if any. Recorded as
+   * the standard `Error.cause` and used to populate `code` when it exposes a
+   * string errno code.
+   */
+  constructor(message, filePath, permission, cause) {
+    super(message);
+    this.name = "FilesystemError";
+    this.path = filePath;
+    this.permission = permission;
+    this.code = hasErrnoCode(cause) ? cause.code : void 0;
+    if (cause !== void 0) {
+      Object.defineProperty(this, "cause", {
+        value: cause,
+        writable: true,
+        enumerable: false,
+        configurable: true
+      });
+    }
+  }
+};
+function hasErrnoCode(err) {
+  return err instanceof Error && "code" in err && typeof err.code === "string";
+}
+function toFilesystemError(err, resourceLabel, filePath, permission) {
+  const detail = err instanceof Error ? err.message : String(err);
+  return new FilesystemError(
+    `Failed to ${permission} ${resourceLabel} at ${filePath}: ${detail}`,
+    filePath,
+    permission,
+    err
+  );
+}
+var BackendRegistry = class {
+  static backends = /* @__PURE__ */ new Map();
+  static setups = /* @__PURE__ */ new Map();
+  /**
+   * Register a backend factory.
+   * @param type - Backend type identifier
+   * @param factory - Factory function to create backend instances
+   */
+  static register(type, factory) {
+    this.backends.set(type, factory);
+  }
+  /**
+   * Create a backend instance by type.
+   * @param type - Backend type identifier
+   * @param config - Optional backend configuration forwarded to the factory
+   * @param configDir - Optional resolved config directory forwarded to the
+   *   factory, so file-based backends can default their storage under it
+   * @returns A SecretBackend instance
+   * @throws {@link BackendUnavailableError} if the backend type is not registered
+   */
+  static create(type, config, configDir) {
+    const factory = this.backends.get(type);
+    if (factory === void 0) {
+      throw new BackendUnavailableError(
+        `Unknown backend type: ${type}. Available types: ${Array.from(this.backends.keys()).join(", ")}`,
+        "unknown-type",
+        Array.from(this.backends.keys())
+      );
+    }
+    return factory(config, configDir);
+  }
+  /**
+   * Get all registered backend type identifiers.
+   * @returns Array of backend type identifiers
+   */
+  static getTypes() {
+    return Array.from(this.backends.keys());
+  }
+  /**
+   * Returns backend types that are available on the current system.
+   *
+   * @remarks
+   * Creates each registered backend via its factory, calls `isAvailable()`,
+   * and returns only the type identifiers whose backend reports availability.
+   * If a backend's `isAvailable()` call throws, that backend is excluded from
+   * the result rather than propagating the error.
+   *
+   * @returns Promise resolving to an array of available backend type identifiers
+   * @public
+   */
+  static async getAvailableTypes() {
+    const entries = Array.from(this.backends.entries());
+    const results = await Promise.all(
+      entries.map(async ([type, factory]) => {
+        try {
+          const backend = factory();
+          const available = await backend.isAvailable();
+          return available ? type : null;
+        } catch {
+          return null;
+        }
+      })
+    );
+    return results.filter((type) => type !== null);
+  }
+  /**
+   * Register a setup factory for a backend type.
+   * @param type - Backend type identifier
+   * @param factory - Factory function that creates a setup generator
+   */
+  static registerSetup(type, factory) {
+    this.setups.set(type, factory);
+  }
+  /**
+   * Get the setup factory for a backend type, if one is registered.
+   * @param type - Backend type identifier
+   * @returns The setup factory, or `undefined` if none is registered
+   */
+  static getSetup(type) {
+    return this.setups.get(type);
+  }
+  /**
+   * Check whether a setup factory is registered for the given backend type.
+   * @param type - Backend type identifier
+   * @returns `true` if a setup factory is registered
+   */
+  static hasSetup(type) {
+    return this.setups.has(type);
+  }
+  /**
+   * Clear all registered backend factories.
+   * Intended for use in tests only.
+   * @internal
+   */
+  static clearBackends() {
+    this.backends.clear();
+  }
+  /**
+   * Clear all registered setup factories.
+   * Intended for use in tests only.
+   * @internal
+   */
+  static clearSetups() {
+    this.setups.clear();
+  }
+};
+var GCM_IV_BYTES = 12;
+var GCM_KEY_BYTES = 32;
+var GCM_TAG_LENGTH_BITS = 128;
+function encryptGcm(key, plaintext) {
+  const iv = crypto2.randomBytes(GCM_IV_BYTES);
+  const cipher = crypto2.createCipheriv("aes-256-gcm", key, iv, {
+    authTagLength: GCM_TAG_LENGTH_BITS / 8
+  });
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [iv.toString("base64"), authTag.toString("base64"), encrypted.toString("base64")].join(":");
+}
+function decryptGcm(key, encoded, path9 = "") {
+  const parts = encoded.split(":");
+  if (parts.length !== 3) {
+    throw new DecryptionError("Invalid encrypted envelope: expected iv:authTag:ciphertext", path9);
+  }
+  const [ivB64, authTagB64, ciphertextB64] = parts;
+  if (ivB64 === void 0 || authTagB64 === void 0 || ciphertextB64 === void 0) {
+    throw new DecryptionError("Invalid encrypted envelope: missing part", path9);
+  }
+  const iv = Buffer.from(ivB64, "base64");
+  const authTag = Buffer.from(authTagB64, "base64");
+  const ciphertext = Buffer.from(ciphertextB64, "base64");
+  try {
+    const decipher = crypto2.createDecipheriv("aes-256-gcm", key, iv, {
+      authTagLength: GCM_TAG_LENGTH_BITS / 8
+    });
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return decrypted.toString("utf8");
+  } catch (err) {
+    throw new DecryptionError(
+      `Failed to decrypt envelope: ${err instanceof Error ? err.message : String(err)}`,
+      path9
+    );
+  }
+}
+async function getOrCreateWrapKey(keyPath) {
+  let existing;
+  try {
+    existing = await fs3.readFile(keyPath);
+  } catch (err) {
+    if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+      throw toFilesystemError(err, "wrapping key file", keyPath, "read");
+    }
+  }
+  if (existing?.byteLength === GCM_KEY_BYTES) {
+    return existing;
+  }
+  const key = crypto2.randomBytes(GCM_KEY_BYTES);
+  try {
+    await fs3.writeFile(keyPath, key, { mode: 384 });
+  } catch (err) {
+    throw toFilesystemError(err, "wrapping key file", keyPath, "write");
+  }
+  return key;
+}
+function getPlatformDefaultConfigDir() {
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA;
+    if (appData !== void 0) {
+      return path22.join(appData, "vaultkeeper");
+    }
+    return path22.join(os.homedir(), "AppData", "Roaming", "vaultkeeper");
+  }
+  return path22.join(os.homedir(), ".config", "vaultkeeper");
+}
+function getDefaultConfigDir() {
+  const envOverride = process.env.VAULTKEEPER_CONFIG_DIR;
+  if (envOverride !== void 0 && envOverride !== "") {
+    return envOverride;
+  }
+  return getPlatformDefaultConfigDir();
+}
+var STORAGE_DIR_NAME = "file";
+var KEY_FILE = ".key";
+var SIGNING_DIR_NAME = "signing-keys";
+var SIGNING_KEY_PREFIX = "signing-key:";
+var SUPPORTED_SIGNING_ALGORITHMS = ["EdDSA"];
+function computeKid(spkiDer) {
+  return crypto2.createHash("sha256").update(spkiDer).digest("base64url");
+}
+function displayKeyName(id) {
+  return id.startsWith(SIGNING_KEY_PREFIX) ? id.slice(SIGNING_KEY_PREFIX.length) : id;
+}
+function legacyStorageDir() {
+  return path22.join(os.homedir(), ".vaultkeeper", "file");
+}
+function resolveStorageDir(configuredPath, configDir) {
+  if (configuredPath !== void 0) {
+    return configuredPath;
+  }
+  return path22.join(configDir ?? getDefaultConfigDir(), STORAGE_DIR_NAME);
+}
+function getEntryPath(storageDir, id) {
+  const safeId = Buffer.from(id, "utf8").toString("hex");
+  return path22.join(storageDir, `${safeId}.enc`);
+}
+async function ensureStorageDir(storageDir) {
+  try {
+    await fs3.mkdir(storageDir, { recursive: true, mode: 448 });
+  } catch (err) {
+    throw new FilesystemError(
+      `Failed to create storage directory: ${storageDir}`,
+      storageDir,
+      "rwx",
+      err
+    );
+  }
+}
+async function getOrCreateKey(storageDir) {
+  return getOrCreateWrapKey(path22.join(storageDir, KEY_FILE));
+}
+var FileBackend = class _FileBackend {
+  type = "file";
+  displayName = "Encrypted File Store";
+  #storageDir;
+  /** Directory holding encrypted signing-key private material. */
+  #signingDir;
+  /**
+   * Pre-#99 default storage directory, consulted as a read-only fallback
+   * when `storageDir` was not explicitly configured. `undefined` when an
+   * explicit `storageDir` was given — an explicit path never falls back.
+   */
+  #legacyStorageDir;
+  /**
+   * @param storageDir - Directory in which encrypted secrets are stored.
+   *   Sourced from `BackendConfig.path`. Defaults to `<configDir>/file`.
+   * @param configDir - Resolved config directory, used to compute the
+   *   default `storageDir` when one is not explicitly provided. Ignored when
+   *   `storageDir` is given. Defaults to `getDefaultConfigDir()`.
+   */
+  constructor(storageDir, configDir) {
+    this.#storageDir = resolveStorageDir(storageDir, configDir);
+    this.#legacyStorageDir = storageDir === void 0 ? legacyStorageDir() : void 0;
+    this.#signingDir = path22.join(this.#storageDir, SIGNING_DIR_NAME);
+  }
+  async isAvailable() {
+    try {
+      await ensureStorageDir(this.#storageDir);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const storageDir = this.#storageDir;
+    await ensureStorageDir(storageDir);
+    const key = await getOrCreateKey(storageDir);
+    const entryPath = getEntryPath(storageDir, id);
+    const encrypted = encryptGcm(key, secret);
+    try {
+      await fs3.writeFile(entryPath, encrypted, { mode: 384 });
+    } catch (err) {
+      throw toFilesystemError(err, "secret file", entryPath, "write");
+    }
+  }
+  /**
+   * Attempt to read and decrypt the entry for `id` from `storageDir`.
+   * Returns `undefined` (rather than throwing) when the entry does not
+   * exist in `storageDir`, so callers can probe a fallback location.
+   */
+  async #tryRetrieveFrom(storageDir, id) {
+    const entryPath = getEntryPath(storageDir, id);
+    let encoded;
+    try {
+      encoded = await fs3.readFile(entryPath, "utf8");
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        return void 0;
+      }
+      throw toFilesystemError(err, "secret file", entryPath, "read");
+    }
+    const key = await getOrCreateKey(storageDir);
+    try {
+      return decryptGcm(key, encoded, entryPath);
+    } catch (err) {
+      throw new DecryptionError(
+        `Failed to decrypt secret: ${err instanceof Error ? err.message : String(err)}`,
+        entryPath
+      );
+    }
+  }
+  async retrieve(id) {
+    const fromPrimary = await this.#tryRetrieveFrom(this.#storageDir, id);
+    if (fromPrimary !== void 0) {
+      return fromPrimary;
+    }
+    if (this.#legacyStorageDir !== void 0) {
+      const fromLegacy = await this.#tryRetrieveFrom(this.#legacyStorageDir, id);
+      if (fromLegacy !== void 0) {
+        return fromLegacy;
+      }
+    }
+    throw new SecretNotFoundError(`Secret not found in file store: ${id}`);
+  }
+  async delete(id) {
+    const entryPath = getEntryPath(this.#storageDir, id);
+    try {
+      await fs3.unlink(entryPath);
+      return;
+    } catch (err) {
+      if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+        throw toFilesystemError(err, "secret file", entryPath, "delete");
+      }
+    }
+    if (this.#legacyStorageDir !== void 0) {
+      const legacyEntryPath = getEntryPath(this.#legacyStorageDir, id);
+      try {
+        await fs3.unlink(legacyEntryPath);
+        return;
+      } catch (err) {
+        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+          throw toFilesystemError(err, "secret file", legacyEntryPath, "delete");
+        }
+      }
+    }
+    throw new SecretNotFoundError(`Secret not found in file store: ${id}`);
+  }
+  async exists(id) {
+    if (await _FileBackend.#entryExists(this.#storageDir, id)) {
+      return true;
+    }
+    if (this.#legacyStorageDir !== void 0) {
+      return _FileBackend.#entryExists(this.#legacyStorageDir, id);
+    }
+    return false;
+  }
+  static async #entryExists(storageDir, id) {
+    try {
+      await fs3.access(getEntryPath(storageDir, id));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async list() {
+    const ids = /* @__PURE__ */ new Set();
+    for (const storageDir of [this.#storageDir, this.#legacyStorageDir].filter(
+      (dir) => dir !== void 0
+    )) {
+      for (const id of await _FileBackend.#listEntries(storageDir)) {
+        ids.add(id);
+      }
+    }
+    return Array.from(ids);
+  }
+  static async #listEntries(storageDir) {
+    let entries;
+    try {
+      entries = await fs3.readdir(storageDir);
+    } catch {
+      return [];
+    }
+    return entries.filter((f) => f.endsWith(".enc")).map((f) => Buffer.from(f.slice(0, -4), "hex").toString("utf8"));
+  }
+  // --- Signing contract (SigningBackend) ---
+  /** On-disk path of the encrypted private key for a signing-key id. */
+  #signingKeyPath(id) {
+    const safeId = Buffer.from(id, "utf8").toString("hex");
+    return path22.join(this.#signingDir, `${safeId}.pem.enc`);
+  }
+  /**
+   * Load and decrypt the PKCS#8 private key PEM for `id`, or throw
+   * {@link SigningKeyNotFoundError} when no signing key exists under `id`.
+   */
+  async #loadSigningKeyPem(id) {
+    const keyPath = this.#signingKeyPath(id);
+    let encoded;
+    try {
+      encoded = await fs3.readFile(keyPath, "utf8");
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        throw new SigningKeyNotFoundError(
+          `Signing key not found: ${displayKeyName(id)}`,
+          displayKeyName(id)
+        );
+      }
+      throw toFilesystemError(err, "signing key", keyPath, "read");
+    }
+    const wrapKey = await getOrCreateKey(this.#storageDir);
+    try {
+      return decryptGcm(wrapKey, encoded);
+    } catch (err) {
+      throw new DecryptionError(
+        `Failed to decrypt signing key: ${err instanceof Error ? err.message : String(err)}`,
+        keyPath
+      );
+    }
+  }
+  async generateSigningKey(id, algorithm) {
+    if (!SUPPORTED_SIGNING_ALGORITHMS.includes(algorithm)) {
+      throw new InvalidAlgorithmError(
+        `Unsupported signing algorithm '${algorithm}'. Supported: ${SUPPORTED_SIGNING_ALGORITHMS.join(", ")}.`,
+        algorithm,
+        [...SUPPORTED_SIGNING_ALGORITHMS]
+      );
+    }
+    await ensureStorageDir(this.#storageDir);
+    try {
+      await fs3.mkdir(this.#signingDir, { recursive: true, mode: 448 });
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code !== "EEXIST") {
+        throw toFilesystemError(err, "signing-key directory", this.#signingDir, "create");
+      }
+    }
+    const keyPath = this.#signingKeyPath(id);
+    let keyExists = false;
+    try {
+      await fs3.access(keyPath);
+      keyExists = true;
+    } catch (err) {
+      if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+        throw toFilesystemError(err, "signing key", keyPath, "read");
+      }
+    }
+    if (keyExists) {
+      throw new SigningKeyAlreadyExistsError(
+        `Signing key already exists: ${displayKeyName(id)}`,
+        displayKeyName(id)
+      );
+    }
+    const { privateKey } = crypto2.generateKeyPairSync("ed25519");
+    const pkcs8Pem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    const wrapKey = await getOrCreateKey(this.#storageDir);
+    const encrypted = encryptGcm(wrapKey, pkcs8Pem);
+    try {
+      await fs3.writeFile(keyPath, encrypted, { mode: 384, flag: "wx" });
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "EEXIST") {
+        throw new SigningKeyAlreadyExistsError(
+          `Signing key already exists: ${displayKeyName(id)}`,
+          displayKeyName(id)
+        );
+      }
+      throw toFilesystemError(err, "signing key", keyPath, "write");
+    }
+  }
+  /**
+   * Load, decrypt, and parse the private key for `id` into a `KeyObject`.
+   *
+   * A parse failure means the decrypted-at-rest material is corrupt or tampered
+   * (it decrypted cleanly but is not a valid PKCS#8 private key). It is
+   * translated into a typed {@link InvalidKeyMaterialError} — never allowed to
+   * surface as a raw Node crypto exception — and the message never echoes any
+   * part of the key material.
+   */
+  async #loadSigningKeyObject(id) {
+    const pkcs8Pem = await this.#loadSigningKeyPem(id);
+    try {
+      return crypto2.createPrivateKey(pkcs8Pem);
+    } catch {
+      throw new InvalidKeyMaterialError(
+        `The stored signing key for "${displayKeyName(id)}" is not valid private key material (it may be corrupt or tampered).`
+      );
+    }
+  }
+  async getPublicKey(id) {
+    const privateKey = await this.#loadSigningKeyObject(id);
+    const publicKey = crypto2.createPublicKey(privateKey);
+    const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    const spkiDer = publicKey.export({ type: "spki", format: "der" });
+    return {
+      publicKeyPem,
+      algorithm: "EdDSA",
+      kid: computeKid(spkiDer)
+    };
+  }
+  async signWithKey(id, data) {
+    const privateKey = await this.#loadSigningKeyObject(id);
+    return crypto2.sign(null, data, privateKey);
+  }
+};
+async function execCommand(command, args, options) {
+  const result = await execCommandFull(command, args, options);
+  if (result.exitCode !== 0) {
+    throw new ExecError(
+      `Command failed with exit code ${String(result.exitCode)}: ${result.stderr}`,
+      command
+    );
+  }
+  return result.stdout.trim();
+}
+function execCommandFull(command, args, options) {
+  return new Promise((resolve32, reject) => {
+    const proc = spawn(command, args, {
+      stdio: [options?.stdin !== void 0 ? "pipe" : "ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    let timeoutHandle;
+    proc.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+    proc.stderr?.on("data", (data) => {
+      stderr += data.toString();
+    });
+    if (options?.stdin !== void 0 && proc.stdin) {
+      proc.stdin.write(options.stdin);
+      proc.stdin.end();
+    }
+    if (options?.timeoutMs !== void 0) {
+      timeoutHandle = setTimeout(() => {
+        timeoutHandle = void 0;
+        proc.kill("SIGTERM");
+        reject(new ExecError(`Command timed out after ${String(options.timeoutMs)}ms`, command));
+      }, options.timeoutMs);
+    }
+    proc.on("close", (code) => {
+      if (timeoutHandle !== void 0) {
+        clearTimeout(timeoutHandle);
+      }
+      resolve32({ stdout, stderr, exitCode: code ?? 1 });
+    });
+    proc.on("error", (error2) => {
+      if (timeoutHandle !== void 0) {
+        clearTimeout(timeoutHandle);
+      }
+      if ("code" in error2 && error2.code === "ENOENT") {
+        reject(
+          new PluginNotFoundError(
+            `'${command}' is not installed or not found in PATH`,
+            command,
+            ""
+          )
+        );
+      } else {
+        reject(new ExecError(`Failed to spawn '${command}': ${error2.message}`, command));
+      }
+    });
+  });
+}
+var ACCOUNT = "vaultkeeper";
+var SERVICE_PREFIX = "vaultkeeper:";
+var KeychainBackend = class {
+  type = "keychain";
+  displayName = "macOS Keychain";
+  async isAvailable() {
+    if (process.platform !== "darwin") {
+      return false;
+    }
+    try {
+      const result = await execCommandFull("security", ["version"]);
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const encoded = Buffer.from(secret, "utf8").toString("base64");
+    await execCommandFull("security", ["delete-generic-password", "-a", ACCOUNT, "-s", service]);
+    await execCommand("security", [
+      "add-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service,
+      "-w",
+      encoded
+    ]);
+  }
+  async retrieve(id) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const result = await execCommandFull("security", [
+      "find-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service,
+      "-w"
+    ]);
+    if (result.exitCode !== 0) {
+      throw new SecretNotFoundError(`Secret not found in macOS Keychain: ${id}`);
+    }
+    const encoded = result.stdout.trim();
+    return Buffer.from(encoded, "base64").toString("utf8");
+  }
+  async delete(id) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const result = await execCommandFull("security", [
+      "delete-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service
+    ]);
+    if (result.exitCode !== 0) {
+      throw new SecretNotFoundError(`Secret not found in macOS Keychain: ${id}`);
+    }
+  }
+  async exists(id) {
+    const service = `${SERVICE_PREFIX}${id}`;
+    const result = await execCommandFull("security", [
+      "find-generic-password",
+      "-a",
+      ACCOUNT,
+      "-s",
+      service
+    ]);
+    return result.exitCode === 0;
+  }
+  async list() {
+    const result = await execCommandFull("security", ["dump-keychain"]);
+    if (result.exitCode !== 0) {
+      return [];
+    }
+    const ids = [];
+    const servicePattern = /0x00000007 <blob>="vaultkeeper:([^"]+)"/g;
+    let match = servicePattern.exec(result.stdout);
+    while (match !== null) {
+      const id = match[1];
+      if (id !== void 0) {
+        ids.push(id);
+      }
+      match = servicePattern.exec(result.stdout);
+    }
+    return ids;
+  }
+};
+function resolveStorageDir2(configuredPath) {
+  if (configuredPath !== void 0) {
+    return configuredPath;
+  }
+  return path22.join(os.homedir(), ".vaultkeeper", "dpapi");
+}
+function getEntryPath2(storageDir, id) {
+  const safeId = Buffer.from(id, "utf8").toString("hex");
+  return path22.join(storageDir, `${safeId}.enc`);
+}
+var DpapiBackend = class {
+  type = "dpapi";
+  displayName = "Windows DPAPI";
+  #storageDir;
+  /**
+   * @param storageDir - Directory in which encrypted blobs are stored.
+   *   Sourced from `BackendConfig.path`. Defaults to `$HOME/.vaultkeeper/dpapi`.
+   */
+  constructor(storageDir) {
+    this.#storageDir = resolveStorageDir2(storageDir);
+  }
+  async isAvailable() {
+    if (process.platform !== "win32") {
+      return false;
+    }
+    try {
+      const result = await execCommandFull("powershell", [
+        "-NoProfile",
+        "-Command",
+        "[System.Security.Cryptography.ProtectedData] | Out-Null; exit 0"
+      ]);
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const storageDir = this.#storageDir;
+    await fs3.mkdir(storageDir, { recursive: true });
+    const entryPath = getEntryPath2(storageDir, id);
+    const script = [
+      "Add-Type -AssemblyName System.Security",
+      `$bytes = [System.Text.Encoding]::UTF8.GetBytes(${JSON.stringify(secret)})`,
+      "$entropy = $null",
+      "$scope = [System.Security.Cryptography.DataProtectionScope]::CurrentUser",
+      "$encrypted = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $entropy, $scope)",
+      `[System.IO.File]::WriteAllBytes(${JSON.stringify(entryPath)}, $encrypted)`
+    ].join("; ");
+    await execCommand("powershell", ["-NoProfile", "-Command", script]);
+  }
+  async retrieve(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath2(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+    } catch {
+      throw new SecretNotFoundError(`Secret not found in Windows DPAPI store: ${id}`);
+    }
+    const script = [
+      "Add-Type -AssemblyName System.Security",
+      `$encrypted = [System.IO.File]::ReadAllBytes(${JSON.stringify(entryPath)})`,
+      "$entropy = $null",
+      "$scope = [System.Security.Cryptography.DataProtectionScope]::CurrentUser",
+      "$bytes = [System.Security.Cryptography.ProtectedData]::Unprotect($encrypted, $entropy, $scope)",
+      "Write-Output ([System.Text.Encoding]::UTF8.GetString($bytes))"
+    ].join("; ");
+    return execCommand("powershell", ["-NoProfile", "-Command", script]);
+  }
+  async delete(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath2(storageDir, id);
+    try {
+      await fs3.unlink(entryPath);
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        throw new SecretNotFoundError(`Secret not found in Windows DPAPI store: ${id}`);
+      }
+      throw toFilesystemError(err, "secret file", entryPath, "delete");
+    }
+  }
+  async exists(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath2(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async list() {
+    const storageDir = this.#storageDir;
+    let entries;
+    try {
+      entries = await fs3.readdir(storageDir);
+    } catch {
+      return [];
+    }
+    return entries.filter((f) => f.endsWith(".enc")).map((f) => Buffer.from(f.slice(0, -4), "hex").toString("utf8"));
+  }
+};
+var ATTRIBUTE_KEY = "vaultkeeper-id";
+var LABEL_PREFIX = "vaultkeeper: ";
+var SecretToolBackend = class {
+  type = "secret-tool";
+  displayName = "Linux Secret Service (secret-tool)";
+  async isAvailable() {
+    if (process.platform !== "linux") {
+      return false;
+    }
+    try {
+      const result = await execCommandFull("secret-tool", ["--version"]);
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+  async store(id, secret) {
+    const label = `${LABEL_PREFIX}${id}`;
+    await execCommand("secret-tool", ["store", "--label", label, ATTRIBUTE_KEY, id], {
+      stdin: secret
+    });
+  }
+  async retrieve(id) {
+    const result = await execCommandFull("secret-tool", ["lookup", ATTRIBUTE_KEY, id]);
+    if (result.exitCode !== 0 || result.stdout.trim() === "") {
+      throw new SecretNotFoundError(`Secret not found in Secret Service: ${id}`);
+    }
+    return result.stdout.trim();
+  }
+  async delete(id) {
+    const result = await execCommandFull("secret-tool", ["clear", ATTRIBUTE_KEY, id]);
+    if (result.exitCode !== 0) {
+      throw new SecretNotFoundError(`Secret not found in Secret Service: ${id}`);
+    }
+  }
+  async exists(id) {
+    const result = await execCommandFull("secret-tool", ["lookup", ATTRIBUTE_KEY, id]);
+    return result.exitCode === 0 && result.stdout.trim() !== "";
+  }
+  async list() {
+    const result = await execCommandFull("secret-tool", ["search", ATTRIBUTE_KEY, ""]);
+    if (result.exitCode !== 0) {
+      return [];
+    }
+    const ids = [];
+    const attrPattern = new RegExp(`attribute\\.${ATTRIBUTE_KEY} = (.+)`, "g");
+    let match = attrPattern.exec(result.stdout);
+    while (match !== null) {
+      const id = match[1];
+      if (id !== void 0) {
+        ids.push(id);
+      }
+      match = attrPattern.exec(result.stdout);
+    }
+    return ids;
+  }
+};
+var TAG = "vaultkeeper";
+var PASSWORD_FIELD_TITLE = "password";
+async function findItemOverviewByTitle(client, vaultId, title) {
+  const overviews = await client.items.list(vaultId);
+  for (const overview of overviews) {
+    if (overview.title === title && overview.tags.includes(TAG)) {
+      return overview;
+    }
+  }
+  return void 0;
+}
+async function findItemByTitle(client, vaultId, title) {
+  const overview = await findItemOverviewByTitle(client, vaultId, title);
+  if (overview === void 0) return void 0;
+  return client.items.get(vaultId, overview.id);
+}
+function extractPasswordField(item) {
+  for (const field of item.fields) {
+    if (field.title === PASSWORD_FIELD_TITLE) {
+      return field.value;
+    }
+  }
+  return void 0;
+}
+async function storeSecretItem(client, vaultId, title, secret, passwordCategory, concealedFieldType) {
+  const existing = await findItemByTitle(client, vaultId, title);
+  if (existing !== void 0) {
+    const hasPasswordField = existing.fields.some((f) => f.title === PASSWORD_FIELD_TITLE);
+    const updatedFields = hasPasswordField ? existing.fields.map((f) => f.title === PASSWORD_FIELD_TITLE ? { ...f, value: secret } : f) : [
+      ...existing.fields,
+      {
+        id: "password",
+        title: PASSWORD_FIELD_TITLE,
+        fieldType: concealedFieldType,
+        value: secret
+      }
+    ];
+    await client.items.put({ ...existing, fields: updatedFields });
+  } else {
+    await client.items.create({
+      category: passwordCategory,
+      vaultId,
+      title,
+      tags: [TAG],
+      fields: [
+        {
+          id: "password",
+          title: PASSWORD_FIELD_TITLE,
+          fieldType: concealedFieldType,
+          value: secret
+        }
+      ]
+    });
+  }
+}
+async function deleteSecretItem(client, vaultId, title) {
+  const overview = await findItemOverviewByTitle(client, vaultId, title);
+  if (overview === void 0) return false;
+  await client.items.delete(vaultId, overview.id);
+  return true;
+}
+var INTEGRATION_NAME = "vaultkeeper";
+var SDK_PACKAGE = "@1password/sdk";
+var SDK_INSTALL_URL = "https://developer.1password.com/docs/sdks/";
+var SDK_NOT_INSTALLED_MESSAGE = `1Password SDK (${SDK_PACKAGE}) is not installed. Install it to use the 1Password backend.`;
+var PRESENCE_WRITE_TIMEOUT_MS = 3e4;
+function isModuleNotFoundError(error2) {
+  const hasNotFoundCode = (value) => {
+    if (value === null || typeof value !== "object" || !("code" in value)) {
+      return false;
+    }
+    const { code } = value;
+    return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+  };
+  if (hasNotFoundCode(error2)) {
+    return true;
+  }
+  if (error2 !== null && typeof error2 === "object" && "cause" in error2) {
+    return hasNotFoundCode(error2.cause);
+  }
+  return false;
+}
 var cachedVersion;
+function getIntegrationVersion() {
+  if (cachedVersion !== void 0) return cachedVersion;
+  const dir = dirname2(fileURLToPath3(import.meta.url));
+  const candidates = [resolve3(dir, "..", "..", "package.json"), resolve3(dir, "..", "package.json")];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const raw = JSON.parse(readFileSync(candidate, "utf8"));
+    if (raw !== null && typeof raw === "object" && "version" in raw && typeof raw.version === "string") {
+      cachedVersion = raw.version;
+      return cachedVersion;
+    }
+  }
+  throw new SetupError(
+    `Could not read version from vaultkeeper package.json. Tried paths: ${candidates.join(", ")}`,
+    "vaultkeeper package.json"
+  );
+}
+var SESSION_TIMEOUT_MS = 3e4;
+function isWorkerSuccess(res) {
+  return "value" in res;
+}
+function isWorkerResponse(value) {
+  if (value === null || typeof value !== "object") return false;
+  if ("value" in value && typeof value.value === "string") return true;
+  if ("error" in value && typeof value.error === "string" && "code" in value && typeof value.code === "string")
+    return true;
+  return false;
+}
+function isWorkerWriteSuccess(res) {
+  const record = { ...res };
+  return record.ok === true;
+}
+function isWorkerWriteResponse(value) {
+  if (value === null || typeof value !== "object") return false;
+  if ("ok" in value && value.ok === true) return true;
+  if ("error" in value && typeof value.error === "string" && "code" in value && typeof value.code === "string")
+    return true;
+  return false;
+}
+var OnePasswordBackend = class {
+  type = "1password";
+  displayName = "1Password";
+  vaultId;
+  account;
+  serviceAccountToken;
+  accessMode;
+  sessionTimeoutMs;
+  /** In-flight or resolved client promise — prevents duplicate createClient calls. */
+  clientPromise;
+  constructor(options) {
+    if (options.accessMode === "per-access" && options.serviceAccountToken !== void 0) {
+      throw new ConfigValidationError(
+        "per-access mode requires desktop biometric authentication and cannot be used with a service account token",
+        "options.accessMode"
+      );
+    }
+    if (options.account !== void 0 && options.serviceAccountToken !== void 0) {
+      throw new ConfigValidationError(
+        "account and serviceAccountToken are mutually exclusive \u2014 provide one or the other, not both",
+        "options.serviceAccountToken"
+      );
+    }
+    this.vaultId = options.vault;
+    this.sessionTimeoutMs = options.sessionTimeoutMs ?? SESSION_TIMEOUT_MS;
+    if (options.account !== void 0) {
+      this.account = options.account;
+    }
+    if (options.serviceAccountToken !== void 0) {
+      this.serviceAccountToken = options.serviceAccountToken;
+    }
+    this.accessMode = options.accessMode ?? "session";
+  }
+  async isAvailable() {
+    const sdk = await this.tryLoadSdk();
+    return sdk !== null;
+  }
+  /**
+   * Report this instance's capabilities.
+   *
+   * @remarks
+   * `presencePerUse` is `true` only in `per-access` mode, where every keyed
+   * operation (`retrieve()`, `store()`, `delete()`) spawns a fresh worker
+   * process that creates a new SDK client and triggers a per-operation
+   * biometric approval that cannot be satisfied from the cached session
+   * client. In the default `session` mode a single client is cached for all
+   * operations, so operations ride one earlier unlock — that mode reports
+   * `false`.
+   *
+   * **Operation coverage:** the per-access biometric path gates `retrieve()`,
+   * `store()`, and `delete()` — every keyed operation reachable from
+   * `presenceEnforcedOperations`. `exists()`/`list()` are read-only probes,
+   * not keyed operations the presence contract covers, so they continue to
+   * use the cached session client. This reports
+   * `presenceEnforcedOperations: ['read', 'store', 'delete']` (issue #211
+   * closed the earlier `store`/`delete` gap — see
+   * {@link https://github.com/mike-north/vaultkeeper/issues/211}).
+   *
+   * **Truth-basis / cached-OS-unlock caveat:** even for a covered operation
+   * the fresh action is "a fresh SDK client plus whatever the OS enforces at
+   * that moment" — a "fresh process/SDK client" is **not** the same as a
+   * guaranteed fresh hardware action. A per-access call can still ride a
+   * cached OS-level Touch ID / Windows Hello unlock if the OS does not
+   * re-prompt. The strongest per-use hardware guarantee comes from a touch
+   * device (YubiKey / gpg smartcard).
+   */
+  getCapabilities() {
+    if (this.accessMode === "per-access") {
+      return Promise.resolve({
+        presencePerUse: true,
+        presenceEnforcedOperations: ["read", "store", "delete"]
+      });
+    }
+    return Promise.resolve({ presencePerUse: false });
+  }
+  // ---- Session client management ----
+  /**
+   * Dynamically import the SDK. Returns `null` if the SDK is not installed or
+   * the native library cannot be loaded. Used by {@link isAvailable}, which
+   * only needs a yes/no answer; call {@link loadSdkOrThrow} on paths that must
+   * report *why* the SDK could not be loaded.
+   */
+  async tryLoadSdk() {
+    try {
+      const sdk = await Promise.resolve().then(() => __toESM(require_sdk(), 1));
+      return sdk;
+    } catch {
+      return null;
+    }
+  }
+  /**
+   * Dynamically import the SDK, throwing a typed {@link PluginNotFoundError}
+   * only when the module cannot be resolved (the optional peer is not
+   * installed). A present-but-broken SDK (native binding failure, init throw,
+   * incompatible Node) surfaces its real error instead of a misleading
+   * "not installed" message.
+   */
+  async loadSdkOrThrow() {
+    try {
+      return await Promise.resolve().then(() => __toESM(require_sdk(), 1));
+    } catch (error2) {
+      if (isModuleNotFoundError(error2)) {
+        throw new PluginNotFoundError(SDK_NOT_INSTALLED_MESSAGE, SDK_PACKAGE, SDK_INSTALL_URL);
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Acquire (or create) a cached SDK client.
+   * Wraps `createClient` with a configurable timeout (default 30 s) to handle
+   * the known beta SDK hang after session expiry.
+   */
+  acquireClient() {
+    this.clientPromise ??= this.createClientInternal().catch((err) => {
+      this.clientPromise = void 0;
+      throw err;
+    });
+    return this.clientPromise;
+  }
+  async createClientInternal() {
+    const sdk = await this.loadSdkOrThrow();
+    const auth2 = this.buildAuth(sdk);
+    let timerId;
+    const timeoutPromise = new Promise((_resolve, reject) => {
+      timerId = setTimeout(() => {
+        reject(
+          new BackendLockedError("1Password session timed out waiting for authentication", true)
+        );
+      }, this.sessionTimeoutMs);
+    });
+    try {
+      const client = await Promise.race([
+        sdk.createClient({
+          auth: auth2,
+          integrationName: INTEGRATION_NAME,
+          integrationVersion: getIntegrationVersion()
+        }),
+        timeoutPromise
+      ]);
+      return client;
+    } catch (err) {
+      if (err instanceof BackendLockedError) {
+        throw err;
+      }
+      if (err instanceof sdk.DesktopSessionExpiredError) {
+        throw new BackendLockedError("1Password session has expired. Please unlock the app.", true);
+      }
+      throw new AuthorizationDeniedError(`1Password authentication failed: ${String(err)}`);
+    } finally {
+      if (timerId !== void 0) {
+        clearTimeout(timerId);
+      }
+    }
+  }
+  buildAuth(sdk) {
+    if (this.serviceAccountToken !== void 0) {
+      return this.serviceAccountToken;
+    }
+    const accountName = this.account ?? "";
+    return new sdk.DesktopAuth(accountName);
+  }
+  // ---- SecretBackend / ListableBackend implementation ----
+  async store(id, secret) {
+    if (this.accessMode === "per-access") {
+      return this.writeViaWorker("store", id, secret);
+    }
+    const { ItemCategory, ItemFieldType } = await this.requireSdk();
+    const client = await this.acquireClient();
+    await storeSecretItem(
+      client,
+      this.vaultId,
+      id,
+      secret,
+      ItemCategory.Password,
+      ItemFieldType.Concealed
+    );
+  }
+  async retrieve(id) {
+    if (this.accessMode === "per-access") {
+      return this.retrieveViaWorker(id);
+    }
+    return this.retrieveViaSession(id);
+  }
+  async retrieveViaSession(id) {
+    const client = await this.acquireClient();
+    const item = await findItemByTitle(client, this.vaultId, id);
+    if (item === void 0) {
+      throw new SecretNotFoundError(`Secret not found in 1Password: ${id}`);
+    }
+    const value = extractPasswordField(item);
+    if (value === void 0) {
+      throw new SecretNotFoundError(`Secret found in 1Password but missing password field: ${id}`);
+    }
+    return value;
+  }
+  /**
+   * Spawn the per-access worker script that triggers a fresh biometric prompt
+   * for each retrieval, then returns the secret from its stdout.
+   */
+  retrieveViaWorker(id) {
+    return new Promise((resolve32, reject) => {
+      const workerPath = join2(dirname2(fileURLToPath3(import.meta.url)), "one-password-worker.js");
+      const accountArg = this.account ?? "";
+      const child = spawn(process.execPath, [workerPath, accountArg, this.vaultId, id], {
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+      const stdoutChunks = [];
+      const stderrChunks = [];
+      child.stdout.on("data", (chunk) => {
+        stdoutChunks.push(chunk);
+      });
+      child.stderr.on("data", (chunk) => {
+        stderrChunks.push(chunk);
+      });
+      child.on("close", (code, signal) => {
+        const raw = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        if (raw === "") {
+          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+          const exitDescription = typeof signal === "string" ? `terminated by signal ${signal}` : `exit code ${String(code)}`;
+          const detail = stderr !== "" ? stderr : exitDescription;
+          reject(
+            new BackendUnavailableError(
+              `1Password per-access worker crashed for secret ${id}: ${detail}`,
+              "worker-crashed",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        let parsed;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          reject(new SecretNotFoundError(`Worker returned unparseable output for secret: ${id}`));
+          return;
+        }
+        if (!isWorkerResponse(parsed)) {
+          reject(
+            new SecretNotFoundError(`Worker returned unexpected response shape for secret: ${id}`)
+          );
+          return;
+        }
+        if (isWorkerSuccess(parsed)) {
+          resolve32(parsed.value);
+        } else {
+          switch (parsed.code) {
+            case "PLUGIN_NOT_FOUND":
+              reject(
+                new PluginNotFoundError(SDK_NOT_INSTALLED_MESSAGE, SDK_PACKAGE, SDK_INSTALL_URL)
+              );
+              break;
+            case "NOT_FOUND":
+              reject(new SecretNotFoundError(`Secret not found in 1Password: ${id}`));
+              break;
+            case "AUTH_DENIED":
+              reject(new AuthorizationDeniedError("1Password authentication was denied"));
+              break;
+            case "LOCKED":
+              reject(new BackendLockedError("1Password is locked. Please unlock and retry.", true));
+              break;
+            case "INTERNAL":
+              reject(
+                new BackendUnavailableError(
+                  `1Password per-access worker failed for secret ${id}: ${parsed.error}`,
+                  "worker-internal-error",
+                  ["1password"]
+                )
+              );
+              break;
+            default:
+              reject(new SecretNotFoundError(`Worker failed for secret ${id}: ${parsed.error}`));
+          }
+        }
+      });
+      child.on("error", (err) => {
+        reject(
+          new BackendUnavailableError(
+            `Failed to spawn 1Password per-access worker at ${workerPath}: ${String(err)}`,
+            "worker-spawn-failed",
+            ["1password"]
+          )
+        );
+      });
+    });
+  }
+  /**
+   * Spawn the per-access worker script to perform a `store` or `delete`,
+   * triggering a fresh biometric prompt for this single write (issue #211).
+   *
+   * @remarks
+   * For `store`, `secret` is delivered to the worker over **stdin**, never
+   * argv — it must never appear in a process listing, shell history, or log.
+   * `delete` needs no payload, so no stdin is written and the worker's stdin
+   * is left `'ignore'`d, mirroring the retrieve path's spawn options.
+   */
+  writeViaWorker(op, id, secret) {
+    return new Promise((resolve32, reject) => {
+      const workerPath = join2(dirname2(fileURLToPath3(import.meta.url)), "one-password-worker.js");
+      const accountArg = this.account ?? "";
+      const needsStdin = secret !== void 0;
+      const child = spawn(process.execPath, [workerPath, accountArg, this.vaultId, id, op], {
+        stdio: [needsStdin ? "pipe" : "ignore", "pipe", "pipe"]
+      });
+      if (needsStdin && child.stdin !== null) {
+        child.stdin.on("error", () => {
+        });
+        child.stdin.write(secret, "utf8");
+        child.stdin.end();
+      }
+      const stdoutChunks = [];
+      const stderrChunks = [];
+      child.stdout?.on("data", (chunk) => {
+        stdoutChunks.push(chunk);
+      });
+      child.stderr?.on("data", (chunk) => {
+        stderrChunks.push(chunk);
+      });
+      child.on("close", (code, signal) => {
+        const raw = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        if (raw === "") {
+          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+          const exitDescription = typeof signal === "string" ? `terminated by signal ${signal}` : `exit code ${String(code)}`;
+          const detail = stderr !== "" ? stderr : exitDescription;
+          reject(
+            new BackendUnavailableError(
+              `1Password per-access worker crashed during ${op} of secret ${id}: ${detail}`,
+              "worker-crashed",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        let parsed;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          reject(
+            new BackendUnavailableError(
+              `Worker returned unparseable output during ${op} of secret ${id}`,
+              "worker-internal-error",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        if (!isWorkerWriteResponse(parsed)) {
+          reject(
+            new BackendUnavailableError(
+              `Worker returned unexpected response shape during ${op} of secret ${id}`,
+              "worker-internal-error",
+              ["1password"]
+            )
+          );
+          return;
+        }
+        if (isWorkerWriteSuccess(parsed)) {
+          resolve32();
+          return;
+        }
+        switch (parsed.code) {
+          case "PLUGIN_NOT_FOUND":
+            reject(new PluginNotFoundError(SDK_NOT_INSTALLED_MESSAGE, SDK_PACKAGE, SDK_INSTALL_URL));
+            break;
+          case "NOT_FOUND":
+            reject(new SecretNotFoundError(`Secret not found in 1Password: ${id}`));
+            break;
+          case "LOCKED":
+            reject(new BackendLockedError("1Password is locked. Please unlock and retry.", true));
+            break;
+          case "PRESENCE_DECLINED":
+            reject(
+              new PresenceDeclinedError(
+                `1Password ${op} presence action was declined for secret ${id}`,
+                "1password"
+              )
+            );
+            break;
+          case "PRESENCE_TIMEOUT":
+            reject(
+              new PresenceTimeoutError(
+                `1Password ${op} presence action timed out for secret ${id}`,
+                "1password",
+                PRESENCE_WRITE_TIMEOUT_MS
+              )
+            );
+            break;
+          case "INTERNAL":
+            reject(
+              new BackendUnavailableError(
+                `1Password per-access worker failed during ${op} of secret ${id}: ${parsed.error}`,
+                "worker-internal-error",
+                ["1password"]
+              )
+            );
+            break;
+          default:
+            reject(
+              new BackendUnavailableError(
+                `Worker failed during ${op} of secret ${id}: ${parsed.error}`,
+                "worker-internal-error",
+                ["1password"]
+              )
+            );
+        }
+      });
+      child.on("error", (err) => {
+        reject(
+          new BackendUnavailableError(
+            `Failed to spawn 1Password per-access worker at ${workerPath}: ${String(err)}`,
+            "worker-spawn-failed",
+            ["1password"]
+          )
+        );
+      });
+    });
+  }
+  async delete(id) {
+    if (this.accessMode === "per-access") {
+      return this.writeViaWorker("delete", id);
+    }
+    const client = await this.acquireClient();
+    const deleted = await deleteSecretItem(client, this.vaultId, id);
+    if (!deleted) {
+      throw new SecretNotFoundError(`Secret not found in 1Password: ${id}`);
+    }
+  }
+  async exists(id) {
+    const client = await this.acquireClient();
+    const overview = await findItemOverviewByTitle(client, this.vaultId, id);
+    return overview !== void 0;
+  }
+  async list() {
+    const client = await this.acquireClient();
+    const overviews = await client.items.list(this.vaultId);
+    const ids = [];
+    for (const overview of overviews) {
+      if (overview.tags.includes(TAG)) {
+        ids.push(overview.title);
+      }
+    }
+    return ids;
+  }
+  // ---- Private helpers ----
+  /**
+   * Load SDK, throwing a typed {@link PluginNotFoundError} when it is not
+   * installed and surfacing the real error when it is present but broken.
+   */
+  requireSdk() {
+    return this.loadSdkOrThrow();
+  }
+};
+var YKMAN_INSTALL_URL = "https://developers.yubico.com/yubikey-manager/";
+var STORAGE_DIR_NAME2 = path22.join(".vaultkeeper", "yubikey");
+var METADATA_FILE = "metadata.json";
+var DEVICE_TIMEOUT_MS = 5e3;
+var GCM_IV_BYTES2 = 12;
+var GCM_KEY_BYTES2 = 32;
+var GCM_TAG_LENGTH_BITS2 = 128;
+var FORMAT_VERSION = "1";
+function resolveStorageDir3(configuredPath) {
+  if (configuredPath !== void 0) {
+    return configuredPath;
+  }
+  return path22.join(os.homedir(), STORAGE_DIR_NAME2);
+}
+function getEntryPath3(storageDir, id) {
+  const safeId = Buffer.from(id, "utf8").toString("hex");
+  return path22.join(storageDir, `${safeId}.enc`);
+}
+function isStringRecord(value) {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  return Object.values(value).every((v) => typeof v === "string");
+}
+async function loadMetadata(storageDir) {
+  const metaPath = path22.join(storageDir, METADATA_FILE);
+  try {
+    const raw = await fs3.readFile(metaPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed !== null && typeof parsed === "object" && "entries" in parsed && isStringRecord(parsed.entries)) {
+      return { entries: parsed.entries };
+    }
+    return { entries: {} };
+  } catch {
+    return { entries: {} };
+  }
+}
+async function saveMetadata(storageDir, metadata) {
+  const metaPath = path22.join(storageDir, METADATA_FILE);
+  await fs3.writeFile(metaPath, JSON.stringify(metadata, null, 2), { mode: 384 });
+}
+var HMAC_RESPONSE_HEX_LENGTH = 40;
+var HMAC_RESPONSE_RE = /^[0-9a-fA-F]{40}$/;
+function deriveKey(hmacResponse, id) {
+  const trimmed = hmacResponse.trim();
+  if (!HMAC_RESPONSE_RE.test(trimmed)) {
+    throw new SetupError(
+      `Invalid YubiKey HMAC response: expected exactly ${String(HMAC_RESPONSE_HEX_LENGTH)} hex characters (20 bytes), got ${String(trimmed.length)} characters`,
+      "ykman"
+    );
+  }
+  const ikm = Buffer.from(trimmed, "hex");
+  const info2 = Buffer.from(`vaultkeeper-yubikey:${id}`, "utf8");
+  const keyMaterial = crypto2.hkdfSync("sha256", ikm, Buffer.alloc(0), info2, GCM_KEY_BYTES2);
+  return Buffer.from(keyMaterial);
+}
+function encryptGcm2(key, plaintext) {
+  const iv = crypto2.randomBytes(GCM_IV_BYTES2);
+  let encrypted;
+  let authTag;
+  try {
+    const cipher = crypto2.createCipheriv("aes-256-gcm", key, iv, {
+      authTagLength: GCM_TAG_LENGTH_BITS2 / 8
+    });
+    encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    authTag = cipher.getAuthTag();
+    return [
+      FORMAT_VERSION,
+      iv.toString("base64"),
+      authTag.toString("base64"),
+      encrypted.toString("base64")
+    ].join(":");
+  } finally {
+    key.fill(0);
+    iv.fill(0);
+    encrypted?.fill(0);
+    authTag?.fill(0);
+  }
+}
+function decryptGcm2(key, encoded, path9) {
+  const parts = encoded.split(":");
+  const versionSegment = parts[0] ?? "";
+  const parsedVersion = parseInt(versionSegment, 10);
+  const isNumericVersion = String(parsedVersion) === versionSegment && !Number.isNaN(parsedVersion);
+  if (!isNumericVersion) {
+    key.fill(0);
+    throw new DecryptionError(
+      "Encrypted file uses a legacy format (AES-256-CBC). Delete the secret and re-store it to migrate to AES-256-GCM.",
+      path9
+    );
+  }
+  if (versionSegment !== FORMAT_VERSION) {
+    key.fill(0);
+    throw new DecryptionError(
+      `Unsupported encrypted file version: ${versionSegment}. This vaultkeeper build only supports version ${FORMAT_VERSION}. Upgrade vaultkeeper to read this secret.`,
+      path9
+    );
+  }
+  if (parts.length !== 4) {
+    key.fill(0);
+    throw new DecryptionError(
+      `Invalid encrypted file format: expected ${FORMAT_VERSION}:iv:authTag:ciphertext`,
+      path9
+    );
+  }
+  const [_version, ivB64, authTagB64, ciphertextB64] = parts;
+  if (ivB64 === void 0 || authTagB64 === void 0 || ciphertextB64 === void 0) {
+    key.fill(0);
+    throw new DecryptionError("Invalid encrypted file format: missing part", path9);
+  }
+  let decrypted;
+  try {
+    const iv = Buffer.from(ivB64, "base64");
+    const authTag = Buffer.from(authTagB64, "base64");
+    const ciphertext = Buffer.from(ciphertextB64, "base64");
+    try {
+      const decipher = crypto2.createDecipheriv("aes-256-gcm", key, iv, {
+        authTagLength: GCM_TAG_LENGTH_BITS2 / 8
+      });
+      decipher.setAuthTag(authTag);
+      decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    } catch (err) {
+      throw new DecryptionError(
+        `GCM authentication failed \u2014 ciphertext may be tampered or corrupt: ${err instanceof Error ? err.message : String(err)}`,
+        path9
+      );
+    }
+    const plaintext = decrypted.toString("utf8");
+    return plaintext;
+  } finally {
+    key.fill(0);
+    decrypted?.fill(0);
+  }
+}
+var YubikeyBackend = class {
+  type = "yubikey";
+  displayName = "YubiKey";
+  #storageDir;
+  /**
+   * Whether the configured challenge-response slot enforces a touch for every
+   * operation. When `true`, each `store`/`retrieve`/`delete` requires a fresh
+   * physical tap (see {@link YubikeyBackend.getCapabilities}). Sourced from
+   * configuration, not hardcoded by type — a slot without a touch policy
+   * reports `false`.
+   */
+  #requireTouch;
+  /**
+   * @param storageDir - Directory in which encrypted secrets and metadata are
+   *   stored. Sourced from `BackendConfig.path`. Defaults to
+   *   `$HOME/.vaultkeeper/yubikey`.
+   * @param requireTouch - Whether the configured challenge-response slot
+   *   enforces a touch-per-operation policy. Defaults to `false`. Sourced from
+   *   the operator's configuration and must match the physical slot's policy
+   *   (verify with `ykman otp info`); it governs the value reported by
+   *   {@link YubikeyBackend.getCapabilities}.
+   */
+  constructor(storageDir, requireTouch = false) {
+    this.#storageDir = resolveStorageDir3(storageDir);
+    this.#requireTouch = requireTouch;
+  }
+  /**
+   * Report this instance's capabilities.
+   *
+   * @remarks
+   * `presencePerUse` is `true` only when the configured slot enforces a
+   * touch-per-operation policy (`requireTouch`), in which case every
+   * challenge-response — and therefore every `store`/`retrieve`/`delete` — forces
+   * a fresh physical tap that cannot be satisfied from any cached state. A slot
+   * without a touch policy reports `false`; the answer is never derived from the
+   * backend `type` alone. Truth-basis: the reported value comes from the
+   * operator-declared `touchPolicy` configuration; confirm it matches the
+   * physical slot with `ykman otp info` (a manual verification).
+   */
+  getCapabilities() {
+    return Promise.resolve({ presencePerUse: this.#requireTouch });
+  }
+  async isAvailable() {
+    try {
+      const result = await execCommandFull("ykman", ["--version"]);
+      if (result.exitCode !== 0) {
+        return false;
+      }
+      const listResult = await execCommandFull("ykman", ["list"]);
+      return listResult.exitCode === 0 && listResult.stdout.trim() !== "";
+    } catch {
+      return false;
+    }
+  }
+  async requireDevice() {
+    const available = await this.isAvailable();
+    if (!available) {
+      const hasYkman = await execCommandFull("ykman", ["--version"]).then(
+        (r) => r.exitCode === 0,
+        () => false
+      );
+      if (!hasYkman) {
+        throw new PluginNotFoundError("ykman is not installed", "ykman", YKMAN_INSTALL_URL);
+      }
+      throw new DeviceNotPresentError("No YubiKey device detected", DEVICE_TIMEOUT_MS);
+    }
+  }
+  /**
+   * Perform the YubiKey HMAC-SHA1 challenge-response for `id` and return the
+   * raw hex response string. Throws on device failure.
+   */
+  async challengeResponse(id) {
+    const challenge = Buffer.from(`vaultkeeper:${id}`, "utf8").toString("hex");
+    const responseResult = await execCommandFull("ykman", ["otp", "calculate", "2", challenge]);
+    if (responseResult.exitCode !== 0) {
+      throw new ExecError(`YubiKey challenge-response failed: ${responseResult.stderr}`, "ykman");
+    }
+    return responseResult.stdout.trim();
+  }
+  async store(id, secret) {
+    await this.requireDevice();
+    const storageDir = this.#storageDir;
+    await fs3.mkdir(storageDir, { recursive: true, mode: 448 });
+    const hmacResponse = await this.challengeResponse(id);
+    const key = deriveKey(hmacResponse, id);
+    const encrypted = encryptGcm2(key, secret);
+    const entryPath = getEntryPath3(storageDir, id);
+    await fs3.writeFile(entryPath, encrypted, { mode: 384 });
+    const metadata = await loadMetadata(storageDir);
+    metadata.entries[id] = entryPath;
+    await saveMetadata(storageDir, metadata);
+  }
+  async retrieve(id) {
+    await this.requireDevice();
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath3(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+    } catch {
+      throw new SecretNotFoundError(`Secret not found in YubiKey store: ${id}`);
+    }
+    const encoded = await fs3.readFile(entryPath, "utf8");
+    const hmacResponse = await this.challengeResponse(id);
+    const key = deriveKey(hmacResponse, id);
+    return decryptGcm2(key, encoded, entryPath);
+  }
+  async delete(id) {
+    await this.requireDevice();
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath3(storageDir, id);
+    try {
+      await fs3.unlink(entryPath);
+    } catch (err) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        throw new SecretNotFoundError(`Secret not found in YubiKey store: ${id}`);
+      }
+      throw err;
+    }
+    const metadata = await loadMetadata(storageDir);
+    delete metadata.entries[id];
+    await saveMetadata(storageDir, metadata);
+  }
+  async exists(id) {
+    const storageDir = this.#storageDir;
+    const entryPath = getEntryPath3(storageDir, id);
+    try {
+      await fs3.access(entryPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async list() {
+    const storageDir = this.#storageDir;
+    const metadata = await loadMetadata(storageDir);
+    return Object.keys(metadata.entries);
+  }
+};
+function registerBuiltinBackends() {
+  BackendRegistry.register(
+    "file",
+    (config, configDir) => new FileBackend(config?.path, configDir)
+  );
+  BackendRegistry.register("keychain", () => new KeychainBackend());
+  BackendRegistry.register("dpapi", (config) => new DpapiBackend(config?.path));
+  BackendRegistry.register("secret-tool", () => new SecretToolBackend());
+  BackendRegistry.register("1password", (config) => {
+    const opts = config?.options;
+    const vaultId = opts?.vault ?? "";
+    const opOptions = {
+      vault: vaultId,
+      // 'session' is the safer default — 'per-access' re-prompts on every read.
+      accessMode: opts?.accessMode === "per-access" ? "per-access" : "session"
+    };
+    const account = opts?.account;
+    if (account !== void 0) {
+      opOptions.account = account;
+    }
+    const serviceAccountToken = opts?.serviceAccountToken;
+    if (serviceAccountToken !== void 0) {
+      opOptions.serviceAccountToken = serviceAccountToken;
+    }
+    return new OnePasswordBackend(opOptions);
+  });
+  BackendRegistry.register(
+    "yubikey",
+    (config) => (
+      // `touchPolicy: 'required'` in the backend options declares that the
+      // configured challenge-response slot enforces a touch per operation, which
+      // is what makes the instance presence-per-use capable (see
+      // YubikeyBackend.getCapabilities). Any other value (or absent) reports
+      // false — presence is never assumed from the backend type alone.
+      new YubikeyBackend(config?.path, config?.options?.touchPolicy === "required")
+    )
+  );
+}
+registerBuiltinBackends();
+var INSPECT_CUSTOM = /* @__PURE__ */ Symbol.for("nodejs.util.inspect.custom");
+var SecretAccessorTarget = class {
+  read;
+  [INSPECT_CUSTOM];
+  constructor(readImpl, inspectImpl) {
+    this.read = readImpl;
+    this[INSPECT_CUSTOM] = inspectImpl;
+  }
+};
+
+// ../core/dist/index.js
+var cachedVersion2;
 function getPackageVersion() {
-  if (cachedVersion !== void 0) {
-    return cachedVersion;
+  if (cachedVersion2 !== void 0) {
+    return cachedVersion2;
   }
   {
-    cachedVersion = "0.10.1";
-    return cachedVersion;
+    cachedVersion2 = "0.10.1";
+    return cachedVersion2;
   }
 }
 var VersionIncompatibleError = class _VersionIncompatibleError extends Error {
@@ -41937,12 +46241,88 @@ var localConfigSchemaV1 = external_exports.object({
     message: "At least one identity must be defined"
   })
 }).strict();
+var privateKeyRefSchemaV2 = external_exports.discriminatedUnion("type", [
+  external_exports.object({
+    type: external_exports.literal("file"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty")
+  }),
+  external_exports.object({
+    type: external_exports.literal("keychain"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty")
+  }),
+  external_exports.object({
+    type: external_exports.literal("1password"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty"),
+    vault: external_exports.string().optional()
+  }),
+  external_exports.object({
+    type: external_exports.literal("yubikey"),
+    id: external_exports.string().min(1, "Secret ID cannot be empty")
+  }),
+  external_exports.object({
+    type: external_exports.literal("filesystem"),
+    path: external_exports.string().min(1, "Filesystem path cannot be empty")
+  })
+]);
+var identitySchemaV2 = external_exports.object({
+  name: external_exports.string().min(1, "Identity name cannot be empty"),
+  email: external_exports.string().optional(),
+  github: external_exports.string().optional(),
+  publicKey: external_exports.string().min(1, "Public key cannot be empty"),
+  privateKey: privateKeyRefSchemaV2
+}).strict();
+var localConfigSchemaV2 = external_exports.object({
+  version: external_exports.literal(2),
+  activeIdentity: external_exports.string().min(1, "Active identity name cannot be empty"),
+  identities: external_exports.record(external_exports.string(), identitySchemaV2).refine((identities) => Object.keys(identities).length >= 1, {
+    message: "At least one identity must be defined"
+  })
+}).strict();
 var schemaV1 = fromZod("1", localConfigSchemaV1);
+var schemaV2 = fromZod("2", localConfigSchemaV2);
+function migratePrivateKeyRefV1ToV2(v1) {
+  switch (v1.type) {
+    case "file":
+      return { type: "filesystem", path: v1.path };
+    case "keychain":
+      return { type: "filesystem", path: `keychain://${v1.service}/${v1.account}` };
+    case "1password":
+      return {
+        type: "filesystem",
+        path: `1password://${v1.vault}/${v1.item}`
+      };
+    case "yubikey":
+      return { type: "filesystem", path: v1.encryptedKeyPath };
+  }
+}
 var identityMigrationGraph = createMigrationGraph({
   id: "attest-it-identity-config",
   versionStrategy: integerStrategy,
-  schemas: [schemaV1],
-  migrations: []
+  schemas: [schemaV1, schemaV2],
+  migrations: [
+    {
+      fromVersion: "1",
+      toVersion: "2",
+      irreversibleReason: "V1 private key refs lose provider-specific details when converted to the legacy filesystem fallback format. The original provider-specific fields (service, vault, item, etc.) cannot be fully recovered from the filesystem pseudo-URI paths.",
+      up: (v1Data) => {
+        const identities = {};
+        for (const [key, identity] of Object.entries(v1Data.identities)) {
+          identities[key] = {
+            name: identity.name,
+            publicKey: identity.publicKey,
+            privateKey: migratePrivateKeyRefV1ToV2(identity.privateKey),
+            ...identity.email !== void 0 && { email: identity.email },
+            ...identity.github !== void 0 && { github: identity.github }
+          };
+        }
+        return {
+          version: 2,
+          activeIdentity: v1Data.activeIdentity,
+          identities
+        };
+      }
+    }
+  ]
 });
 function versionSchema(version2) {
   return external_exports.union([external_exports.literal(version2), external_exports.literal(String(version2))]).transform(() => version2);
@@ -42282,12 +46662,12 @@ function isUnifiedShape(parsed) {
   return typeof parsed === "object" && parsed !== null && ("team" in parsed || "gates" in parsed);
 }
 function findUnifiedConfigPath(baseDir) {
-  const configDir = join2(baseDir, ".attest-it");
+  const configDir = join4(baseDir, ".attest-it");
   const candidates = ["config.yaml", "config.yml", "config.json"];
   for (const candidate of candidates) {
-    const configPath = join2(configDir, candidate);
+    const configPath = join4(configDir, candidate);
     try {
-      const content = readFileSync2(configPath, "utf8");
+      const content = readFileSync3(configPath, "utf8");
       const parsed = candidate.endsWith(".json") ? JSON.parse(content) : (0, import_yaml.parse)(content);
       if (isUnifiedShape(parsed)) {
         return configPath;
@@ -42298,12 +46678,12 @@ function findUnifiedConfigPath(baseDir) {
   return null;
 }
 function findPolicyPath(startDir = process.cwd()) {
-  const configDir = join2(startDir, ".attest-it");
+  const configDir = join4(startDir, ".attest-it");
   const candidates = ["policy.yaml", "policy.yml", "policy.json"];
   for (const candidate of candidates) {
-    const configPath = join2(configDir, candidate);
+    const configPath = join4(configDir, candidate);
     try {
-      readFileSync2(configPath, "utf8");
+      readFileSync3(configPath, "utf8");
       return configPath;
     } catch {
     }
@@ -42311,12 +46691,12 @@ function findPolicyPath(startDir = process.cwd()) {
   return null;
 }
 function findOperationalPath(startDir = process.cwd()) {
-  const configDir = join2(startDir, ".attest-it");
+  const configDir = join4(startDir, ".attest-it");
   const candidates = ["config.yaml", "config.yml", "config.json"];
   for (const candidate of candidates) {
-    const configPath = join2(configDir, candidate);
+    const configPath = join4(configDir, candidate);
     try {
-      readFileSync2(configPath, "utf8");
+      readFileSync3(configPath, "utf8");
       return configPath;
     } catch {
     }
@@ -42350,7 +46730,7 @@ async function loadPolicyAsync(source, baseDir) {
     );
   }
   try {
-    const content = await readFile2(policyPath, "utf8");
+    const content = await readFile3(policyPath, "utf8");
     const format = getConfigFormat(policyPath);
     return parsePolicyContent(content, format);
   } catch (error2) {
@@ -42372,7 +46752,7 @@ async function loadOperationalAsync(operationalPath, baseDir) {
     );
   }
   try {
-    const content = await readFile2(resolvedPath, "utf8");
+    const content = await readFile3(resolvedPath, "utf8");
     const format = getConfigFormat(resolvedPath);
     return parseOperationalContent(content, format);
   } catch (error2) {
@@ -42437,13 +46817,13 @@ function computeFinalFingerprint(fileHashes) {
   });
   const hashes = sorted.map((input) => input.hash);
   const concatenated = Buffer.concat(hashes);
-  const finalHash = crypto3.createHash("sha256").update(concatenated).digest();
+  const finalHash = crypto22.createHash("sha256").update(concatenated).digest();
   return `sha256:${finalHash.toString("hex")}`;
 }
 async function hashFileAsync(realPath, normalizedPath, stats) {
   if (stats.size > LARGE_FILE_THRESHOLD) {
-    return new Promise((resolve6, reject) => {
-      const hash2 = crypto3.createHash("sha256");
+    return new Promise((resolve52, reject) => {
+      const hash2 = crypto22.createHash("sha256");
       hash2.update(normalizedPath);
       hash2.update(":");
       const stream = fs.createReadStream(realPath);
@@ -42451,13 +46831,13 @@ async function hashFileAsync(realPath, normalizedPath, stats) {
         hash2.update(chunk);
       });
       stream.on("end", () => {
-        resolve6(hash2.digest());
+        resolve52(hash2.digest());
       });
       stream.on("error", reject);
     });
   }
   const content = await fs.promises.readFile(realPath);
-  const hash = crypto3.createHash("sha256");
+  const hash = crypto22.createHash("sha256");
   hash.update(normalizedPath);
   hash.update(":");
   hash.update(content);
@@ -42559,153 +46939,6 @@ async function listPackageFiles(packages, ignore = [], baseDir = process.cwd()) 
   }
   return allFiles;
 }
-async function runOpenSSL(args, passphrase) {
-  return new Promise((resolve6, reject) => {
-    const stdio = passphrase ? ["ignore", "pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"];
-    const child = spawn("openssl", args, { stdio });
-    const stdoutChunks = [];
-    let stderr = "";
-    child.stdout?.on("data", (chunk) => {
-      stdoutChunks.push(chunk);
-    });
-    child.stderr?.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
-    child.on("error", (err) => {
-      reject(new Error(`Failed to spawn OpenSSL: ${err.message}`));
-    });
-    child.on("close", (code) => {
-      resolve6({
-        exitCode: code ?? 1,
-        stdout: Buffer.concat(stdoutChunks),
-        stderr
-      });
-    });
-    if (passphrase) {
-      const passphraseStream = child.stdio[3];
-      if (!(passphraseStream instanceof Writable)) {
-        reject(new Error("Expected a writable stream for the passphrase file descriptor"));
-        return;
-      }
-      passphraseStream.on("error", () => {
-      });
-      passphraseStream.write(passphrase + "\n");
-      passphraseStream.end();
-    }
-  });
-}
-async function checkOpenSSL() {
-  const result = await runOpenSSL(["version"]);
-  if (result.exitCode !== 0) {
-    throw new Error(`OpenSSL check failed: ${result.stderr}`);
-  }
-  return result.stdout.toString().trim();
-}
-var openSSLChecked = false;
-async function ensureOpenSSLAvailable() {
-  if (openSSLChecked) {
-    return;
-  }
-  try {
-    await checkOpenSSL();
-    openSSLChecked = true;
-  } catch {
-    throw new Error(
-      "OpenSSL is not installed or not in PATH. Please install OpenSSL to use attest-it. On macOS: brew install openssl. On Ubuntu: apt-get install openssl"
-    );
-  }
-}
-function getDefaultPrivateKeyPath() {
-  const homeDir = os.homedir();
-  if (process.platform === "win32") {
-    const appData = process.env.APPDATA ?? path3.join(homeDir, "AppData", "Roaming");
-    return path3.join(appData, "attest-it", "private.pem");
-  }
-  return path3.join(homeDir, ".config", "attest-it", "private.pem");
-}
-function getDefaultPublicKeyPath() {
-  return path3.join(process.cwd(), "attest-it-public.pem");
-}
-async function ensureDir(dirPath) {
-  try {
-    await fs2.mkdir(dirPath, { recursive: true });
-  } catch (err) {
-    if (err instanceof Error && "code" in err && err.code !== "EEXIST") {
-      throw err;
-    }
-  }
-}
-async function fileExists(filePath) {
-  try {
-    await fs2.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-async function cleanupFiles(...paths) {
-  for (const filePath of paths) {
-    try {
-      await fs2.unlink(filePath);
-    } catch {
-    }
-  }
-}
-async function generateKeyPair(options = {}) {
-  await ensureOpenSSLAvailable();
-  const {
-    privatePath = getDefaultPrivateKeyPath(),
-    publicPath = getDefaultPublicKeyPath(),
-    force = false,
-    passphrase
-  } = options;
-  const privateExists = await fileExists(privatePath);
-  const publicExists = await fileExists(publicPath);
-  if ((privateExists || publicExists) && !force) {
-    const existing = [privateExists ? privatePath : null, publicExists ? publicPath : null].filter(
-      Boolean
-    );
-    throw new Error(
-      `Key files already exist: ${existing.join(", ")}. Use force: true to overwrite.`
-    );
-  }
-  await ensureDir(path3.dirname(privatePath));
-  await ensureDir(path3.dirname(publicPath));
-  try {
-    const genArgs = [
-      "genpkey",
-      "-algorithm",
-      "RSA",
-      "-pkeyopt",
-      "rsa_keygen_bits:2048",
-      "-out",
-      privatePath
-    ];
-    if (passphrase) {
-      genArgs.push("-aes256", "-pass", "fd:3");
-    }
-    const genResult = await runOpenSSL(genArgs, passphrase);
-    if (genResult.exitCode !== 0) {
-      throw new Error(`Failed to generate private key: ${genResult.stderr}`);
-    }
-    await setKeyPermissions(privatePath);
-    const pubArgs = ["pkey", "-in", privatePath, "-pubout", "-out", publicPath];
-    if (passphrase) {
-      pubArgs.push("-passin", "fd:3");
-    }
-    const pubResult = await runOpenSSL(pubArgs, passphrase);
-    if (pubResult.exitCode !== 0) {
-      throw new Error(`Failed to extract public key: ${pubResult.stderr}`);
-    }
-    return {
-      privatePath,
-      publicPath
-    };
-  } catch (err) {
-    await cleanupFiles(privatePath, publicPath);
-    throw err;
-  }
-}
 async function setKeyPermissions(keyPath) {
   if (process.platform === "win32") {
     await fs2.chmod(keyPath, 384);
@@ -42716,9 +46949,21 @@ async function setKeyPermissions(keyPath) {
 function isBuffer(value) {
   return Buffer.isBuffer(value);
 }
-function generateKeyPair2() {
+function generateKeyPair2(options = {}) {
   try {
-    const keyPair = crypto3.generateKeyPairSync("ed25519", {
+    const { passphrase } = options;
+    const keyPair = passphrase !== void 0 && passphrase.length > 0 ? crypto22.generateKeyPairSync("ed25519", {
+      publicKeyEncoding: {
+        type: "spki",
+        format: "pem"
+      },
+      privateKeyEncoding: {
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-256-cbc",
+        passphrase
+      }
+    }) : crypto22.generateKeyPairSync("ed25519", {
       publicKeyEncoding: {
         type: "spki",
         format: "pem"
@@ -42732,7 +46977,7 @@ function generateKeyPair2() {
     if (typeof publicKey !== "string" || typeof privateKey !== "string") {
       throw new Error("Expected keypair to have string keys");
     }
-    const publicKeyObj = crypto3.createPublicKey(publicKey);
+    const publicKeyObj = crypto22.createPublicKey(publicKey);
     const publicKeyExport = publicKeyObj.export({
       type: "spki",
       format: "der"
@@ -42781,12 +47026,12 @@ function verify3(data, signature, publicKeyBase64) {
       // BIT STRING, 33 bytes (32 key + 1 padding)
     ]);
     const spkiBuffer = Buffer.concat([spkiHeader, rawPublicKey]);
-    const publicKeyObj = crypto3.createPublicKey({
+    const publicKeyObj = crypto22.createPublicKey({
       key: spkiBuffer,
       format: "der",
       type: "spki"
     });
-    return crypto3.verify(null, dataBuffer, publicKeyObj, signatureBuffer);
+    return crypto22.verify(null, dataBuffer, publicKeyObj, signatureBuffer);
   } catch (err) {
     if (err instanceof Error && err.message.includes("verification failed")) {
       return false;
@@ -42796,27 +47041,133 @@ function verify3(data, signature, publicKeyBase64) {
     );
   }
 }
-var FilesystemKeyProvider = class {
-  type = "filesystem";
-  displayName = "Filesystem";
-  privateKeyPath;
+var VaultKeyProvider = class {
+  type;
+  displayName;
+  backend;
   /**
-   * Create a new FilesystemKeyProvider.
-   * @param options - Provider options
+   * Create a new VaultKeyProvider.
+   * @param options - Provider options including the VaultKeeper backend
    */
-  constructor(options = {}) {
-    this.privateKeyPath = options.privateKeyPath ?? getDefaultPrivateKeyPath();
+  constructor(options) {
+    this.backend = options.backend;
+    this.type = options.backend.type;
+    this.displayName = options.displayName;
   }
   /**
+   * Check if the underlying VaultKeeper backend is available.
+   */
+  async isAvailable() {
+    return this.backend.isAvailable();
+  }
+  /**
+   * Check if a key exists in the VaultKeeper backend.
+   * @param keyRef - Secret identifier in the backend
+   */
+  async keyExists(keyRef) {
+    return this.backend.exists(keyRef);
+  }
+  /**
+   * Retrieve the private key from VaultKeeper for signing.
+   *
+   * @remarks
+   * Downloads the PEM to a secure temporary file (mode 0o600) and returns
+   * a cleanup function that overwrites the file with random bytes before deletion.
+   *
+   * @param keyRef - Secret identifier in the backend
+   * @throws Error if the key does not exist in the backend
+   */
+  async getPrivateKey(keyRef) {
+    const pemContent = await this.backend.retrieve(keyRef);
+    const tempDir = await fs2.mkdtemp(path3.join(os2.tmpdir(), "attest-it-vk-"));
+    const tempKeyPath = path3.join(tempDir, "private.pem");
+    try {
+      await fs2.writeFile(tempKeyPath, pemContent, "utf-8");
+      await setKeyPermissions(tempKeyPath);
+      return {
+        keyPath: tempKeyPath,
+        cleanup: async () => {
+          try {
+            const stat3 = await fs2.stat(tempKeyPath);
+            await fs2.writeFile(tempKeyPath, crypto22.randomBytes(stat3.size));
+            await fs2.unlink(tempKeyPath);
+            await fs2.rmdir(tempDir);
+          } catch (cleanupError) {
+            console.warn(
+              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+            );
+          }
+        }
+      };
+    } catch (error2) {
+      try {
+        await fs2.rm(tempDir, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.warn(
+          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+        );
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Generate a new Ed25519 keypair and store the private key in VaultKeeper.
+   *
+   * @remarks
+   * The public key is written to the filesystem for repository commit.
+   * The private key is stored in the VaultKeeper backend and the local
+   * copy is securely deleted.
+   *
+   * @param options - Key generation options
+   */
+  async generateKeyPair(options) {
+    const { publicKeyPath, force = false } = options;
+    if (!force) {
+      try {
+        await fs2.access(publicKeyPath);
+        throw new Error(
+          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
+        );
+      } catch (err) {
+        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+          throw err;
+        }
+      }
+    }
+    const keyPair = generateKeyPair2();
+    await fs2.mkdir(path3.dirname(publicKeyPath), { recursive: true });
+    await fs2.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
+    const secretId = `attest-it-${crypto22.randomUUID()}`;
+    await this.backend.store(secretId, keyPair.privateKey);
+    return {
+      privateKeyRef: secretId,
+      publicKeyPath,
+      storageDescription: `VaultKeeper (${this.backend.displayName}): ${secretId}`
+    };
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return {
+      type: this.type,
+      options: { backendType: this.backend.type }
+    };
+  }
+};
+var LegacyFilesystemKeyProvider = class {
+  type = "filesystem-legacy";
+  displayName = "Filesystem (Legacy)";
+  /**
    * Check if this provider is available.
-   * Filesystem provider is always available.
+   * The legacy filesystem provider is always available.
    */
   async isAvailable() {
     return Promise.resolve(true);
   }
   /**
-   * Check if a key exists at the given path.
-   * @param keyRef - Path to the private key file
+   * Check if a key exists at the given filesystem path.
+   * @param keyRef - Filesystem path to the private key file
    */
   async keyExists(keyRef) {
     try {
@@ -42829,7 +47180,7 @@ var FilesystemKeyProvider = class {
   /**
    * Get the private key path for signing.
    * Returns the path directly with a no-op cleanup function.
-   * @param keyRef - Path to the private key file
+   * @param keyRef - Filesystem path to the private key file
    */
   async getPrivateKey(keyRef) {
     if (!await this.keyExists(keyRef)) {
@@ -42837,1121 +47188,30 @@ var FilesystemKeyProvider = class {
     }
     return {
       keyPath: keyRef,
-      // No-op cleanup for filesystem provider
+      // No-op cleanup — key stays on filesystem
       cleanup: async () => {
       }
     };
   }
   /**
-   * Generate a new keypair and store on filesystem.
-   * @param options - Key generation options
+   * Not supported — legacy provider does not create new keys.
+   * @param _options - Unused key generation options
+   * @throws Always throws an informative error directing the user to `identity create`
    */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false, passphrase } = options;
-    const cryptoOptions = {
-      privatePath: this.privateKeyPath,
-      publicPath: publicKeyPath,
-      force
-    };
-    if (passphrase !== void 0) {
-      cryptoOptions.passphrase = passphrase;
-    }
-    const result = await generateKeyPair(cryptoOptions);
-    const encrypted = passphrase !== void 0 && passphrase.length > 0;
-    const encryptionStatus = encrypted ? " (passphrase-encrypted)" : "";
-    return {
-      privateKeyRef: result.privatePath,
-      publicKeyPath: result.publicPath,
-      storageDescription: `Filesystem: ${result.privatePath}${encryptionStatus}`,
-      encrypted
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        privateKeyPath: this.privateKeyPath
-      }
-    };
-  }
-};
-var OnePasswordKeyProvider = class _OnePasswordKeyProvider {
-  type = "1password";
-  displayName = "1Password";
-  accountUuid;
-  vault;
-  itemName;
-  /**
-   * Create a new OnePasswordKeyProvider.
-   * @param options - Provider options
-   */
-  constructor(options) {
-    if (options.accountUuid !== void 0) {
-      this.accountUuid = options.accountUuid;
-    }
-    this.vault = options.vault;
-    this.itemName = options.itemName;
-  }
-  /**
-   * Check if the 1Password CLI is installed.
-   * @returns True if `op` command is available
-   */
-  static async isInstalled() {
-    try {
-      await execCommand("op", ["--version"]);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * List all 1Password accounts.
-   * @returns Object containing accessible accounts and inaccessible accounts with reasons
-   */
-  static async listAccounts() {
-    const output = await execCommand("op", ["account", "list", "--format=json"]);
-    const parsed = JSON.parse(output);
-    if (!Array.isArray(parsed)) {
-      throw new Error("Unexpected response from 1Password: account list is not an array");
-    }
-    const basicAccounts = parsed;
-    const accountResults = [];
-    const RETRY_DELAY_MS = 500;
-    const MAX_RETRIES = 2;
-    for (const account of basicAccounts) {
-      if (!account.account_uuid) {
-        accountResults.push({
-          success: false,
-          email: account.email,
-          url: account.url,
-          reason: "Account missing account_uuid field"
-        });
-        continue;
-      }
-      let lastError;
-      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-        if (attempt > 0 || accountResults.length > 0) {
-          await new Promise((resolve6) => setTimeout(resolve6, RETRY_DELAY_MS));
-        }
-        try {
-          const detailOutput = await execCommand("op", [
-            "account",
-            "get",
-            "--account",
-            account.account_uuid,
-            "--format=json"
-          ]);
-          const details = JSON.parse(detailOutput);
-          if (details !== null && typeof details === "object" && "name" in details && typeof details.name === "string") {
-            accountResults.push({
-              success: true,
-              account: { ...account, name: details.name }
-            });
-            lastError = void 0;
-            break;
-          }
-          lastError = "Account details response missing name field";
-          break;
-        } catch (err) {
-          lastError = err instanceof Error ? err.message : String(err);
-        }
-      }
-      if (lastError !== void 0) {
-        accountResults.push({
-          success: false,
-          email: account.email,
-          url: account.url,
-          reason: lastError
-        });
-      }
-    }
-    const accounts = [];
-    const inaccessible = [];
-    for (const result of accountResults) {
-      if (result.success) {
-        accounts.push(result.account);
-      } else {
-        inaccessible.push({
-          email: result.email,
-          url: result.url,
-          reason: result.reason
-        });
-      }
-    }
-    if (accounts.length === 0 && basicAccounts.length > 0) {
-      const reasons = inaccessible.map((a) => `  - ${a.email}: ${a.reason}`).join("\n");
-      throw new Error(
-        `Could not access any 1Password accounts. All ${String(basicAccounts.length)} account(s) failed:
-${reasons}`
-      );
-    }
-    return { accounts, inaccessible };
-  }
-  /**
-   * List vaults in a specific account.
-   * @param accountUuid - Account UUID from listAccounts() (optional if only one account)
-   * @returns Array of vault information
-   */
-  static async listVaults(accountUuid) {
-    const args = ["vault", "list", "--format=json"];
-    if (accountUuid) {
-      args.push("--account", accountUuid);
-    }
-    let output;
-    try {
-      output = await execCommand("op", args);
-    } catch (error2) {
-      throw new Error(
-        `Failed to list 1Password vaults${accountUuid ? ` for account ${accountUuid}` : ""}: ${error2 instanceof Error ? error2.message : String(error2)}`
-      );
-    }
-    const parsed = JSON.parse(output);
-    if (!Array.isArray(parsed)) {
-      throw new Error("Unexpected response from 1Password: vault list is not an array");
-    }
-    return parsed;
-  }
-  /**
-   * Check if this provider is available.
-   * Requires `op` CLI to be installed and authenticated.
-   */
-  async isAvailable() {
-    return _OnePasswordKeyProvider.isInstalled();
-  }
-  /**
-   * Check if a key exists in 1Password.
-   * @param keyRef - Item name in 1Password
-   */
-  async keyExists(keyRef) {
-    try {
-      const args = ["item", "get", keyRef, "--vault", this.vault, "--format=json"];
-      if (this.accountUuid) {
-        args.push("--account", this.accountUuid);
-      }
-      await execCommand("op", args);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key from 1Password for signing.
-   * Downloads to a temporary file and returns a cleanup function.
-   *
-   * @remarks
-   * For security, this runs in a new PTY which requires the user to authenticate
-   * (via Touch ID, password, etc.) each time. This prevents automated agents
-   * from using cached credentials.
-   *
-   * @param keyRef - Item name in 1Password
-   * @throws Error if the key does not exist in 1Password
-   */
-  async getPrivateKey(keyRef) {
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(
-        `Key not found in 1Password: "${keyRef}" (vault: ${this.vault})` + (this.accountUuid ? ` (accountUuid: ${this.accountUuid})` : "")
-      );
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      const args = ["document", "get", keyRef, "--vault", this.vault, "--out-file", tempKeyPath];
-      if (this.accountUuid) {
-        args.push("--account", this.accountUuid);
-      }
-      await execInteractiveCommand("op", args);
-      await setKeyPermissions(tempKeyPath);
-      return {
-        keyPath: tempKeyPath,
-        cleanup: async () => {
-          try {
-            await fs2.unlink(tempKeyPath);
-            await fs2.rmdir(tempDir);
-          } catch (cleanupError) {
-            console.warn(
-              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-            );
-          }
-        }
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new Ed25519 keypair and store private key in 1Password.
-   * Public key is written to filesystem for repository commit.
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    if (!force) {
-      try {
-        await fs2.access(publicKeyPath);
-        throw new Error(
-          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
-        );
-      } catch (err) {
-        if (err instanceof Error && !err.message.includes("already exists")) ;
-        else {
-          throw err;
-        }
-      }
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-keygen-"));
-    const tempPrivateKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      const keyPair = generateKeyPair2();
-      await fs2.writeFile(tempPrivateKeyPath, keyPair.privateKey, "utf-8");
-      await setKeyPermissions(tempPrivateKeyPath);
-      await fs2.mkdir(path3.dirname(publicKeyPath), { recursive: true });
-      await fs2.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
-      const args = [
-        "document",
-        "create",
-        tempPrivateKeyPath,
-        "--title",
-        this.itemName,
-        "--vault",
-        this.vault
-      ];
-      if (this.accountUuid) {
-        args.push("--account", this.accountUuid);
-      }
-      await execCommand("op", args);
-      await fs2.unlink(tempPrivateKeyPath);
-      await fs2.rmdir(tempDir);
-      return {
-        privateKeyRef: this.itemName,
-        publicKeyPath,
-        storageDescription: `1Password: ${this.vault}/${this.itemName}`
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        ...this.accountUuid && { accountUuid: this.accountUuid },
-        vault: this.vault,
-        itemName: this.itemName
-      }
-    };
-  }
-};
-function getCleanEnvironment() {
-  const env = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (!key.startsWith("OP_SESSION_") && key !== "OP_SERVICE_ACCOUNT_TOKEN") {
-      env[key] = value;
-    }
-  }
-  return env;
-}
-async function execCommand(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = spawn(command, args, {
-      stdio: ["inherit", "pipe", "pipe"],
-      env: getCleanEnvironment()
-    });
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-async function execInteractiveCommand(command, args) {
-  return new Promise((resolve6, reject) => {
-    const platform = process.platform;
-    let proc;
-    if (platform === "win32") {
-      proc = spawn(command, args, {
-        stdio: ["inherit", "pipe", "pipe"],
-        env: getCleanEnvironment()
-      });
-    } else if (platform === "darwin") {
-      proc = spawn("script", ["-q", "/dev/null", command, ...args], {
-        stdio: ["inherit", "pipe", "pipe"],
-        env: getCleanEnvironment()
-      });
-    } else {
-      const quotedArgs = args.map((arg) => `'${arg.replace(/'/g, "'\\''")}'`).join(" ");
-      const fullCommand = `${command} ${quotedArgs}`;
-      proc = spawn("script", ["-q", "/dev/null", "-c", fullCommand], {
-        stdio: ["inherit", "pipe", "pipe"],
-        env: getCleanEnvironment()
-      });
-    }
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-var MacOSKeychainKeyProvider = class _MacOSKeychainKeyProvider {
-  type = "macos-keychain";
-  displayName = "macOS Keychain";
-  itemName;
-  keychain;
-  static ACCOUNT = "attest-it";
-  /**
-   * Create a new MacOSKeychainKeyProvider.
-   * @param options - Provider options
-   */
-  constructor(options) {
-    this.itemName = options.itemName;
-    if (options.keychain !== void 0) {
-      this.keychain = options.keychain;
-    }
-  }
-  /**
-   * Check if this provider is available.
-   * Only available on macOS platforms.
-   */
-  static isAvailable() {
-    return process.platform === "darwin";
-  }
-  /**
-   * List available keychains on the system.
-   * @returns Array of keychain information
-   */
-  static async listKeychains() {
-    if (!_MacOSKeychainKeyProvider.isAvailable()) {
-      return [];
-    }
-    try {
-      const output = await execCommand2("security", ["list-keychains"]);
-      const keychains = [];
-      const lines = output.split("\n");
-      for (const line of lines) {
-        const match = /"(.+)"/.exec(line.trim());
-        if (match?.[1]) {
-          const fullPath = match[1];
-          const filename = fullPath.split("/").pop() ?? fullPath;
-          const name = filename.replace(/\.keychain(-db)?$/, "");
-          keychains.push({ path: fullPath, name });
-        }
-      }
-      return keychains;
-    } catch {
-      return [];
-    }
-  }
-  /**
-   * Check if this provider is available on the current system.
-   */
-  isAvailable() {
-    return Promise.resolve(_MacOSKeychainKeyProvider.isAvailable());
-  }
-  /**
-   * Check if a key exists in the keychain.
-   * @param keyRef - Item name in keychain
-   */
-  async keyExists(keyRef) {
-    try {
-      const args = ["find-generic-password", "-a", _MacOSKeychainKeyProvider.ACCOUNT, "-s", keyRef];
-      if (this.keychain) {
-        args.push(this.keychain);
-      }
-      await execCommand2("security", args);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key from keychain for signing.
-   * Downloads to a temporary file and returns a cleanup function.
-   * @param keyRef - Item name in keychain
-   * @throws Error if the key does not exist in keychain
-   */
-  async getPrivateKey(keyRef) {
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(
-        `Key not found in macOS Keychain: "${keyRef}" (account: ${_MacOSKeychainKeyProvider.ACCOUNT})`
-      );
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      const findArgs = [
-        "find-generic-password",
-        "-a",
-        _MacOSKeychainKeyProvider.ACCOUNT,
-        "-s",
-        keyRef,
-        "-w"
-      ];
-      if (this.keychain) {
-        findArgs.push(this.keychain);
-      }
-      const base64Key = await execCommand2("security", findArgs);
-      const keyContent = Buffer.from(base64Key, "base64").toString("utf8");
-      await fs2.writeFile(tempKeyPath, keyContent, { mode: 384 });
-      await setKeyPermissions(tempKeyPath);
-      return {
-        keyPath: tempKeyPath,
-        cleanup: async () => {
-          try {
-            await fs2.unlink(tempKeyPath);
-            await fs2.rmdir(tempDir);
-          } catch (cleanupError) {
-            console.warn(
-              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-            );
-          }
-        }
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new Ed25519 keypair and store private key in keychain.
-   * Public key is written to filesystem for repository commit.
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    let publicKeyExists = false;
-    try {
-      await fs2.access(publicKeyPath);
-      publicKeyExists = true;
-    } catch (error2) {
-      if (error2 instanceof Error && "code" in error2 && error2.code !== "ENOENT") {
-        throw error2;
-      }
-    }
-    if (publicKeyExists && !force) {
-      throw new Error(
-        `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
-      );
-    }
-    const { publicKey: publicKeyBase64, privateKey: privateKeyPem } = generateKeyPair2();
-    const publicKeyDir = path3.dirname(publicKeyPath);
-    await fs2.mkdir(publicKeyDir, { recursive: true });
-    const publicKeyPem = `-----BEGIN PUBLIC KEY-----
-${publicKeyBase64}
------END PUBLIC KEY-----
-`;
-    await fs2.writeFile(publicKeyPath, publicKeyPem, { mode: 420 });
-    const base64Key = Buffer.from(privateKeyPem, "utf8").toString("base64");
-    const addArgs = [
-      "add-generic-password",
-      "-a",
-      _MacOSKeychainKeyProvider.ACCOUNT,
-      "-s",
-      this.itemName,
-      "-w",
-      base64Key,
-      "-T",
-      "",
-      "-U"
-    ];
-    if (this.keychain) {
-      addArgs.push(this.keychain);
-    }
-    await execCommand2("security", addArgs);
-    return {
-      privateKeyRef: this.itemName,
-      publicKeyPath,
-      storageDescription: `macOS Keychain: ${this.itemName}`
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        itemName: this.itemName
-      }
-    };
-  }
-};
-async function execCommand2(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-var ATTEST_IT_HOME_ENV = "ATTEST_IT_HOME";
-var homeDirOverride = null;
-function getAttestItHomeDir() {
-  const envOverride = process.env[ATTEST_IT_HOME_ENV];
-  if (envOverride) {
-    return envOverride;
-  }
-  return homeDirOverride;
-}
-function getIdentityConfigDir(homeDir) {
-  if (homeDir) {
-    return homeDir;
-  }
-  const override = getAttestItHomeDir();
-  if (override) {
-    return override;
-  }
-  return join2(homedir2(), ".config", "attest-it");
-}
-var EncryptedKeyFileSchema = external_exports.object({
-  version: external_exports.literal(1),
-  iv: external_exports.string().min(1),
-  authTag: external_exports.string().min(1),
-  salt: external_exports.string().min(1),
-  challenge: external_exports.string().min(1),
-  ciphertext: external_exports.string().min(1),
-  slot: external_exports.union([external_exports.literal(1), external_exports.literal(2)]),
-  serial: external_exports.string().optional(),
-  aad: external_exports.string().optional()
-});
-var activeCleanupHandlers = /* @__PURE__ */ new Set();
-var processHandlersInstalled = false;
-function installProcessHandlers() {
-  if (processHandlersInstalled) return;
-  processHandlersInstalled = true;
-  const runCleanup = async () => {
-    const handlers = Array.from(activeCleanupHandlers);
-    await Promise.allSettled(handlers.map((h) => h()));
-  };
-  process.once("beforeExit", () => {
-    void runCleanup();
-  });
-  process.once("SIGINT", () => {
-    void runCleanup().finally(() => process.exit(130));
-  });
-  process.once("SIGTERM", () => {
-    void runCleanup().finally(() => process.exit(143));
-  });
-}
-function validateEncryptedKeyFile(data) {
-  const parsed = EncryptedKeyFileSchema.parse(data);
-  const iv = Buffer.from(parsed.iv, "base64");
-  if (iv.length !== 12) {
-    throw new Error(`Invalid IV size: expected 12 bytes, got ${String(iv.length)}`);
-  }
-  const authTag = Buffer.from(parsed.authTag, "base64");
-  if (authTag.length !== 16) {
-    throw new Error(`Invalid auth tag size: expected 16 bytes, got ${String(authTag.length)}`);
-  }
-  const salt = Buffer.from(parsed.salt, "base64");
-  if (salt.length !== 32) {
-    throw new Error(`Invalid salt size: expected 32 bytes, got ${String(salt.length)}`);
-  }
-  const challenge = Buffer.from(parsed.challenge, "base64");
-  if (challenge.length !== 32) {
-    throw new Error(`Invalid challenge size: expected 32 bytes, got ${String(challenge.length)}`);
-  }
-  return parsed;
-}
-function constructAAD(version2, slot, serial) {
-  const aadObject = {
-    version: version2,
-    slot,
-    serial: serial ?? "unspecified"
-  };
-  return Buffer.from(JSON.stringify(aadObject), "utf8");
-}
-var YubiKeyProvider = class _YubiKeyProvider {
-  type = "yubikey";
-  displayName = "YubiKey";
-  encryptedKeyPath;
-  slot;
-  serial;
-  /**
-   * Create a new YubiKeyProvider.
-   * @param options - Provider options
-   * @throws Error if encryptedKeyPath is outside the attest-it config directory
-   */
-  constructor(options) {
-    const resolvedPath = path3.resolve(options.encryptedKeyPath);
-    const configDir = getIdentityConfigDir();
-    if (!resolvedPath.startsWith(configDir)) {
-      throw new Error(
-        `Encrypted key path must be within attest-it config directory (${configDir}). Got: ${resolvedPath}`
-      );
-    }
-    this.encryptedKeyPath = resolvedPath;
-    this.slot = options.slot ?? 2;
-    if (options.serial !== void 0) {
-      this.serial = options.serial;
-    }
-  }
-  /**
-   * Check if ykman CLI is installed and available.
-   * @returns true if ykman is available
-   */
-  static async isInstalled() {
-    try {
-      await execCommand3("ykman", ["--version"]);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Check if any YubiKey is connected.
-   * @returns true if at least one YubiKey is connected
-   */
-  static async isConnected() {
-    try {
-      const output = await execCommand3("ykman", ["list", "--serials"]);
-      return output.trim().length > 0;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Check if HMAC challenge-response is configured on a slot.
-   * @param slot - Slot number (1 or 2)
-   * @param serial - Optional YubiKey serial number
-   * @returns true if challenge-response is configured
-   */
-  static async isChallengeResponseConfigured(slot = 2, serial) {
-    try {
-      const testChallenge = Buffer.from("attest-it-test-challenge-12345");
-      const args = ["otp", "calculate", String(slot), testChallenge.toString("hex")];
-      if (serial) {
-        args.unshift("--device", serial);
-      }
-      await execInteractiveCommand2("ykman", args);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * List connected YubiKeys.
-   * @returns Array of YubiKey information
-   */
-  static async listDevices() {
-    if (!await _YubiKeyProvider.isInstalled()) {
-      return [];
-    }
-    try {
-      const output = await execCommand3("ykman", ["list", "--serials"]);
-      const serials = output.trim().split("\n").filter((s) => s.length > 0);
-      const devices = [];
-      for (const serial of serials) {
-        try {
-          const infoOutput = await execCommand3("ykman", ["--device", serial, "info"]);
-          const typeMatch = /Device type:\s+(.+)/i.exec(infoOutput);
-          const fwMatch = /Firmware version:\s+(.+)/i.exec(infoOutput);
-          devices.push({
-            serial,
-            type: typeMatch?.[1]?.trim() ?? "YubiKey",
-            firmware: fwMatch?.[1]?.trim() ?? "Unknown"
-          });
-        } catch {
-          devices.push({
-            serial,
-            type: "YubiKey",
-            firmware: "Unknown"
-          });
-        }
-      }
-      return devices;
-    } catch {
-      return [];
-    }
-  }
-  /**
-   * Check if this provider is available on the current system.
-   * Requires ykman to be installed.
-   */
-  async isAvailable() {
-    return _YubiKeyProvider.isInstalled();
-  }
-  /**
-   * Check if an encrypted key file exists.
-   * @param keyRef - Path to encrypted key file
-   */
-  async keyExists(keyRef) {
-    try {
-      await fs2.access(keyRef);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key by decrypting with YubiKey.
-   * Downloads to a temporary file and returns a cleanup function.
-   *
-   * **Important**: Always call the cleanup function when done to securely delete
-   * the temporary key file. The cleanup is also registered for process exit handlers.
-   *
-   * @param keyRef - Path to encrypted key file
-   * @throws Error if the key cannot be decrypted
-   */
-  async getPrivateKey(keyRef) {
-    installProcessHandlers();
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(`Encrypted key file not found: ${keyRef}`);
-    }
-    const encryptedData = await fs2.readFile(keyRef, "utf8");
-    let keyFile;
-    try {
-      const parsed = JSON.parse(encryptedData);
-      keyFile = validateEncryptedKeyFile(parsed);
-    } catch (err) {
-      if (err instanceof external_exports.ZodError) {
-        throw new Error(
-          `Invalid encrypted key file format: ${err.errors.map((e) => e.message).join(", ")}`
-        );
-      }
-      throw new Error(`Invalid encrypted key file: malformed JSON or structure`);
-    }
-    const expectedSerial = this.serial ?? keyFile.serial;
-    if (!expectedSerial) {
-      console.warn(
-        "WARNING: No YubiKey serial number specified for key verification. Any YubiKey with the correct HMAC secret could decrypt this key. For better security, re-encrypt the key with a serial number specified."
-      );
-    }
-    if (expectedSerial) {
-      const devices = await _YubiKeyProvider.listDevices();
-      const matchingDevice = devices.find((d) => d.serial === expectedSerial);
-      if (!matchingDevice) {
-        throw new Error(
-          `Required YubiKey not found. Expected serial: ${expectedSerial}. Connected devices: ${devices.map((d) => d.serial).join(", ") || "none"}`
-        );
-      }
-    }
-    const challenge = Buffer.from(keyFile.challenge, "base64");
-    const response = await performChallengeResponse(challenge, keyFile.slot, expectedSerial);
-    const salt = Buffer.from(keyFile.salt, "base64");
-    const aesKey = deriveKey(response, salt);
-    const iv = Buffer.from(keyFile.iv, "base64");
-    const authTag = Buffer.from(keyFile.authTag, "base64");
-    const ciphertext = Buffer.from(keyFile.ciphertext, "base64");
-    let privateKeyContent;
-    try {
-      const decipher = crypto3.createDecipheriv("aes-256-gcm", aesKey, iv);
-      if (keyFile.aad) {
-        decipher.setAAD(Buffer.from(keyFile.aad, "base64"));
-      }
-      decipher.setAuthTag(authTag);
-      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-      privateKeyContent = decrypted.toString("utf8");
-    } catch {
-      throw new Error(
-        "Failed to decrypt private key. Verify you are using the correct YubiKey and the encrypted key file has not been corrupted or tampered with."
-      );
-    }
-    const tempDir = await fs2.mkdtemp(path3.join(os.tmpdir(), "attest-it-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    const cleanup = async () => {
-      activeCleanupHandlers.delete(cleanup);
-      try {
-        const keySize = Buffer.byteLength(privateKeyContent);
-        await fs2.writeFile(tempKeyPath, crypto3.randomBytes(keySize));
-        await fs2.unlink(tempKeyPath);
-        await fs2.rmdir(tempDir);
-      } catch {
-      }
-    };
-    try {
-      await fs2.writeFile(tempKeyPath, privateKeyContent, { mode: 384 });
-      await setKeyPermissions(tempKeyPath);
-      activeCleanupHandlers.add(cleanup);
-      return {
-        keyPath: tempKeyPath,
-        cleanup
-      };
-    } catch (error2) {
-      await cleanup();
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new keypair and store encrypted with YubiKey.
-   * Public key is written to filesystem for repository commit.
-   *
-   * **Security Note**: Always specify a serial number to bind the key to a specific YubiKey.
-   *
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    if (!await _YubiKeyProvider.isChallengeResponseConfigured(this.slot, this.serial)) {
-      throw new Error(
-        `YubiKey slot ${String(this.slot)} is not configured for HMAC challenge-response. Ensure your YubiKey is connected and use "ykman otp chalresp -t --generate 2" to configure it with touch required.`
-      );
-    }
-    if (!force && await this.keyExists(this.encryptedKeyPath)) {
-      throw new Error(
-        `Encrypted key file already exists: ${this.encryptedKeyPath}. Use force: true to overwrite.`
-      );
-    }
-    let serial;
-    if (this.serial) {
-      serial = this.serial;
-    } else {
-      const devices = await _YubiKeyProvider.listDevices();
-      if (devices.length === 1 && devices[0]) {
-        serial = devices[0].serial;
-      } else if (devices.length > 1) {
-        console.warn(
-          "WARNING: Multiple YubiKeys detected but no serial specified. Key will not be bound to a specific device. For better security, specify a serial number."
-        );
-      }
-    }
-    const { publicKey: publicKeyBase64, privateKey: privateKeyPem } = generateKeyPair2();
-    const publicKeyDir = path3.dirname(publicKeyPath);
-    await fs2.mkdir(publicKeyDir, { recursive: true });
-    const publicKeyPemFile = `-----BEGIN PUBLIC KEY-----
-${publicKeyBase64}
------END PUBLIC KEY-----
-`;
-    await fs2.writeFile(publicKeyPath, publicKeyPemFile, { mode: 420 });
-    const privateKeyContent = privateKeyPem;
-    const challenge = crypto3.randomBytes(32);
-    const salt = crypto3.randomBytes(32);
-    const iv = crypto3.randomBytes(12);
-    const response = await performChallengeResponse(challenge, this.slot, this.serial);
-    const aesKey = deriveKey(response, salt);
-    const aad = constructAAD(1, this.slot, serial);
-    const cipher = crypto3.createCipheriv("aes-256-gcm", aesKey, iv);
-    cipher.setAAD(aad);
-    const ciphertext = Buffer.concat([
-      cipher.update(Buffer.from(privateKeyContent, "utf8")),
-      cipher.final()
-    ]);
-    const authTag = cipher.getAuthTag();
-    const keyFile = {
-      version: 1,
-      iv: iv.toString("base64"),
-      authTag: authTag.toString("base64"),
-      salt: salt.toString("base64"),
-      challenge: challenge.toString("base64"),
-      ciphertext: ciphertext.toString("base64"),
-      slot: this.slot,
-      aad: aad.toString("base64"),
-      ...serial && { serial }
-    };
-    await fs2.mkdir(path3.dirname(this.encryptedKeyPath), { recursive: true });
-    await fs2.writeFile(this.encryptedKeyPath, JSON.stringify(keyFile, null, 2), { mode: 384 });
-    await setKeyPermissions(this.encryptedKeyPath);
-    return {
-      privateKeyRef: this.encryptedKeyPath,
-      publicKeyPath,
-      storageDescription: `YubiKey-encrypted: ${this.encryptedKeyPath}`
-    };
-  }
-  /**
-   * Encrypt an existing private key with YubiKey challenge-response.
-   *
-   * @remarks
-   * This static method allows encrypting a private key that was generated
-   * elsewhere (e.g., by the CLI) without having to create a provider instance first.
-   *
-   * **Security Note**: Always specify a serial number to bind the key to a specific YubiKey.
-   * The serial provides defense-in-depth by ensuring only the intended YubiKey can decrypt.
-   *
-   * @param options - Encryption options
-   * @returns Path to the encrypted key file and storage description
-   * @public
-   */
-  static async encryptPrivateKey(options) {
-    const { privateKey, encryptedKeyPath, slot = 2, serial } = options;
-    const resolvedPath = path3.resolve(encryptedKeyPath);
-    const configDir = getIdentityConfigDir();
-    if (!resolvedPath.startsWith(configDir)) {
-      throw new Error(
-        `Encrypted key path must be within attest-it config directory (${configDir}). Got: ${resolvedPath}`
-      );
-    }
-    if (!serial) {
-      console.warn(
-        "WARNING: No YubiKey serial number specified. Key will not be bound to a specific device. For better security, specify a serial number."
-      );
-    }
-    if (!await _YubiKeyProvider.isChallengeResponseConfigured(slot, serial)) {
-      throw new Error(
-        `YubiKey slot ${String(slot)} is not configured for HMAC challenge-response. Ensure your YubiKey is connected and use "ykman otp chalresp -t --generate 2" to configure it with touch required.`
-      );
-    }
-    const challenge = crypto3.randomBytes(32);
-    const salt = crypto3.randomBytes(32);
-    const iv = crypto3.randomBytes(12);
-    const response = await performChallengeResponse(challenge, slot, serial);
-    const aesKey = deriveKey(response, salt);
-    const aad = constructAAD(1, slot, serial);
-    const cipher = crypto3.createCipheriv("aes-256-gcm", aesKey, iv);
-    cipher.setAAD(aad);
-    const ciphertext = Buffer.concat([
-      cipher.update(Buffer.from(privateKey, "utf8")),
-      cipher.final()
-    ]);
-    const authTag = cipher.getAuthTag();
-    const keyFile = {
-      version: 1,
-      iv: iv.toString("base64"),
-      authTag: authTag.toString("base64"),
-      salt: salt.toString("base64"),
-      challenge: challenge.toString("base64"),
-      ciphertext: ciphertext.toString("base64"),
-      slot,
-      aad: aad.toString("base64"),
-      ...serial && { serial }
-    };
-    await fs2.mkdir(path3.dirname(resolvedPath), { recursive: true });
-    await fs2.writeFile(resolvedPath, JSON.stringify(keyFile, null, 2), { mode: 384 });
-    await setKeyPermissions(resolvedPath);
-    return {
-      encryptedKeyPath: resolvedPath,
-      storageDescription: `YubiKey-encrypted: ${resolvedPath}`
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: {
-        encryptedKeyPath: this.encryptedKeyPath,
-        slot: this.slot,
-        ...this.serial && { serial: this.serial }
-      }
-    };
-  }
-};
-async function execCommand3(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}: ${stderr}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-async function execInteractiveCommand2(command, args) {
-  return new Promise((resolve6, reject) => {
-    const proc = spawn(command, args, { stdio: ["inherit", "pipe", "inherit"] });
-    let stdout = "";
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve6(stdout.trim());
-      } else {
-        reject(new Error(`Command failed with exit code ${String(code)}`));
-      }
-    });
-    proc.on("error", (error2) => {
-      reject(error2);
-    });
-  });
-}
-async function performChallengeResponse(challenge, slot, serial) {
-  const args = ["otp", "calculate", String(slot), challenge.toString("hex")];
-  if (serial) {
-    args.unshift("--device", serial);
-  }
-  try {
-    const output = await execInteractiveCommand2("ykman", args);
-    return Buffer.from(output.trim(), "hex");
-  } catch {
+  // Must stay async so the throw below becomes a rejected Promise, matching the KeyProvider interface contract
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async generateKeyPair(_options) {
     throw new Error(
-      "YubiKey challenge-response failed. Verify your YubiKey is inserted, touch it if prompted, and ensure the slot is configured for challenge-response with touch required (ykman otp chalresp -t --generate <slot>)."
+      'Legacy filesystem provider does not support key generation. Use "attest-it identity create" with a VaultKeeper-backed provider.'
     );
   }
-}
-function deriveKey(response, salt) {
-  const derived = crypto3.hkdfSync("sha256", response, salt, "attest-it-yubikey-v1", 32);
-  return Buffer.from(derived);
-}
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return { type: this.type, options: {} };
+  }
+};
 var KeyProviderRegistry = class {
   static providers = /* @__PURE__ */ new Map();
   /**
@@ -43985,52 +47245,24 @@ var KeyProviderRegistry = class {
     return Array.from(this.providers.keys());
   }
 };
-KeyProviderRegistry.register("filesystem", (config) => {
-  const privateKeyPath = typeof config.options.privateKeyPath === "string" ? config.options.privateKeyPath : void 0;
-  if (privateKeyPath !== void 0) {
-    return new FilesystemKeyProvider({ privateKeyPath });
-  }
-  return new FilesystemKeyProvider();
+KeyProviderRegistry.register("filesystem", (_config) => {
+  const backend = BackendRegistry.create("file");
+  return new VaultKeyProvider({ backend, displayName: "Filesystem" });
 });
-KeyProviderRegistry.register("1password", (config) => {
-  const { options } = config;
-  const accountUuid = typeof options.accountUuid === "string" ? options.accountUuid : void 0;
-  const vault = typeof options.vault === "string" ? options.vault : "";
-  const itemName = typeof options.itemName === "string" ? options.itemName : "";
-  if (!vault || !itemName) {
-    throw new Error("1Password provider requires vault and itemName options");
-  }
-  if (accountUuid !== void 0) {
-    return new OnePasswordKeyProvider({ accountUuid, vault, itemName });
-  }
-  return new OnePasswordKeyProvider({ vault, itemName });
+KeyProviderRegistry.register("1password", (_config) => {
+  const backend = BackendRegistry.create("1password");
+  return new VaultKeyProvider({ backend, displayName: "1Password" });
 });
-KeyProviderRegistry.register("macos-keychain", (config) => {
-  const { options } = config;
-  const itemName = typeof options.itemName === "string" ? options.itemName : "";
-  if (!itemName) {
-    throw new Error("macOS Keychain provider requires itemName option");
-  }
-  return new MacOSKeychainKeyProvider({ itemName });
+KeyProviderRegistry.register("macos-keychain", (_config) => {
+  const backend = BackendRegistry.create("keychain");
+  return new VaultKeyProvider({ backend, displayName: "macOS Keychain" });
 });
-KeyProviderRegistry.register("yubikey", (config) => {
-  const { options } = config;
-  const encryptedKeyPath = typeof options.encryptedKeyPath === "string" ? options.encryptedKeyPath : "";
-  if (!encryptedKeyPath) {
-    throw new Error("YubiKey provider requires encryptedKeyPath option");
-  }
-  const slot = typeof options.slot === "number" && (options.slot === 1 || options.slot === 2) ? options.slot : void 0;
-  const serial = typeof options.serial === "string" ? options.serial : void 0;
-  const providerOptions = {
-    encryptedKeyPath
-  };
-  if (slot !== void 0) {
-    providerOptions.slot = slot;
-  }
-  if (serial !== void 0) {
-    providerOptions.serial = serial;
-  }
-  return new YubiKeyProvider(providerOptions);
+KeyProviderRegistry.register("yubikey", (_config) => {
+  const backend = BackendRegistry.create("yubikey");
+  return new VaultKeyProvider({ backend, displayName: "YubiKey" });
+});
+KeyProviderRegistry.register("filesystem-legacy", (_config) => {
+  return new LegacyFilesystemKeyProvider();
 });
 var cliExperienceSchema = external_exports.object({
   declinedCompletionInstall: external_exports.boolean().optional()
@@ -44413,7 +47645,7 @@ async function run() {
             content: policyResult.content,
             format: policyFormat
           },
-          operationalPath: resolve3(process.cwd(), operationalConfigPath)
+          operationalPath: resolve5(process.cwd(), operationalConfigPath)
         });
       } else {
         core.info("Loading configuration from filesystem");
@@ -44421,9 +47653,9 @@ async function run() {
         config = await loadSplitConfig({
           policySource: {
             type: "filesystem",
-            path: resolve3(process.cwd(), policyPath)
+            path: resolve5(process.cwd(), policyPath)
           },
-          operationalPath: resolve3(process.cwd(), operationalConfigPath)
+          operationalPath: resolve5(process.cwd(), operationalConfigPath)
         });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Refs #80

`identity create` (and other setup commands) were fully interactive with no non-interactive flags, so any scripted, CI, agent-driven, or embedder-driven setup hung at the first prompt. This gives every setup command a flag-driven non-interactive path while leaving interactive mode unchanged for humans:

- **`identity create`**: `--name`, `--slug` (auto-derived from `--name` when omitted), `--email`, `--github`, `--storage <file|keychain|1password|yubikey>`, and backend-specific flags (`--keychain-path`/`--keychain-item`, `--op-account`/`--op-vault`/`--op-item`, `--yubikey-serial`/`--encrypted-key-name`). `--passphrase-stdin` encrypts a file-backed private key using a passphrase piped via stdin (never a prompt).
- **`init`**: fails fast naming `--force` instead of hanging when config already exists and stdin isn't a TTY.
- **`team add` / `team join`**: `--slug`, `--name`, `--email`, `--github`, `--public-key` (add only), `--gates` (comma-separated); gate authorization defaults to none rather than prompting when non-interactive.
- **`run`**: `-y, --yes` auto-confirms seal creation; running with neither `--suite` nor `--all` and no TTY now fails fast instead of launching an interactive UI that can never receive input; signing with a passphrase-encrypted identity key resolves the passphrase from `ATTEST_IT_KEY_PASSPHRASE`, an interactive prompt, or fails fast.
- **Bonus fix**: the shell-completion offer shown after `init`/`identity create` had **no TTY gate at all** — it called `@inquirer/prompts`' `confirm()` unconditionally whenever `SHELL` was set and the user hadn't previously declined. Found this auditing `init`'s full call path; it's now skipped (not prompted) when stdin isn't an interactive TTY.

Every gate follows the same rule: **flag not supplied AND stdin is an interactive TTY → prompt** (unchanged human behavior); **flag not supplied AND no TTY → fail fast naming the missing flag** (never hang). `identity use` was audited and needs no change — it's already argument-based with no prompts.

`@attest-it/core`: `generateEd25519KeyPair`/`signEd25519` gained an optional `passphrase` parameter, `createSeal` gained an optional `passphrase` option, and a new `isEncryptedPrivateKeyPem` helper detects encrypted keys — needed so a `--passphrase-stdin`-encrypted identity can actually sign later. `--storage`'s allowed values are validated against `KeyProviderRegistry.getProviderTypes()` at runtime so they can't silently drift from what's actually registered (`vaultkeeper` is intentionally excluded — the registry doesn't auto-register it without an explicit `SecretBackend`, matching the existing interactive picker).

**Deferred (out of scope for this PR):** the standalone `seal` command reads private keys directly and has the same "no passphrase support" gap as `run` did before this PR — if you create a passphrase-encrypted identity and then run `attest-it seal <gate>` (instead of `attest-it run`), it will fail with an unhelpful low-level signing error rather than the clear `ATTEST_IT_KEY_PASSPHRASE` message `run` now gives. `seal.ts` wasn't in issue #80's audited command list; flagging this as a natural follow-up since `seal.ts` and `run.ts`'s sealing logic are near-duplicates of each other (a separate refactor concern).

## Criteria → test mapping

| Acceptance criterion | Test(s) |
|---|---|
| `identity create` accepts flags for zero-TTY-prompt creation (name/storage/slug/passphrase-stdin) | `packages/cli/test/identity-create.test.ts` (required flags, storage validation, passphrase encryption round-trip) |
| Interactive mode remains default with a TTY and no flags | `packages/cli/test/team-add.test.ts`, `team-join.test.ts` "interactive fallback" blocks; existing `identity create` behavior preserved (no flag == same prompts) |
| Non-TTY + missing required input fails fast naming the flag | `packages/cli/test/prompts.test.ts` (`resolveOrPrompt`), `identity-create.test.ts`, `team-add.test.ts`, `team-join.test.ts`, `init.test.ts`, `run.test.ts` (`resolveKeyPassphrase`), `run-interactive.test.tsx` |
| Audit `init`, `team add`, `team join`, `identity use`, `run` for hang risk | `init.test.ts` "non-interactive guard" block; `team-add.test.ts`/`team-join.test.ts` non-interactive blocks; `identity use` audited, no change needed (already argument-based); `run-interactive.test.tsx` "non-interactive guard" block; `run.test.ts` `resolveKeyPassphrase` |
| Checked-in integration test: identity create → init → seal/verify, stdin from `/dev/null`, no hang | `packages/cli/test/integration/non-interactive-setup.integration.test.ts` — real CLI subprocesses, `stdio: ['ignore', ...]`, hard per-call timeout that fails loudly instead of hanging the suite if a prompt sneaks back in |
| Docs show non-interactive invocation alongside interactive | `README.md` (new "Non-interactive" quick-start block), `docs/getting-started.md` (new subsections under each step) |

## `--help` diffs

### `identity create --help`

```diff
 Usage: attest-it identity create [options]

 Create a new identity with Ed25519 keypair

 Options:
+  --name <name>                Display name for the identity
+  --slug <slug>                Unique identity slug (derived from --name when
+                               omitted)
+  --email <email>              Email address (optional)
+  --github <username>          GitHub username (optional)
+  --storage <backend>          Key storage backend:
+                               file|keychain|1password|yubikey
+  --passphrase-stdin           Read a passphrase from stdin to encrypt a
+                               file-backed private key (only used with --storage
+                               file)
+  --keychain-path <path>       macOS Keychain path (needed only when multiple
+                               keychains exist)
+  --keychain-item <name>       macOS Keychain item name (default:
+                               attest-it-<slug>)
+  --op-account <uuid>          1Password account UUID (needed only when multiple
+                               accounts are signed in)
+  --op-vault <name>            1Password vault name (needed only when multiple
+                               vaults exist)
+  --op-item <name>             1Password item name (default: attest-it-<slug>)
+  --yubikey-serial <serial>    YubiKey serial number (needed only when multiple
+                               devices are connected)
+  --encrypted-key-name <name>  Encrypted key file name for YubiKey storage
+                               (default: <slug>.enc)
   -h, --help                   display help for command
```

### `team add --help`

```diff
 Usage: attest-it team add [options]

 Add a new team member

 Options:
+  --slug <slug>        Unique identifier for the team member
+  --name <name>        Display name
+  --email <email>      Email address (optional)
+  --github <username>  GitHub username (optional)
+  --public-key <key>   Base64-encoded Ed25519 public key (from 'attest-it
+                       identity export')
+  --gates <ids>        Comma-separated gate IDs to authorize (default: none)
   -h, --help           display help for command
```

### `team join --help`

```diff
 Usage: attest-it team join [options]

 Add yourself to the project team using your active identity

 Options:
+  --slug <slug>  Slug to use if your identity slug is already taken by another
+                 member
+  --gates <ids>  Comma-separated gate IDs to authorize (default: none)
   -h, --help     display help for command
```

### `run --help`

```diff
 Usage: attest-it run [options]

 Execute tests and create attestation

 Options:
   -s, --suite <name>  Run specific suite (required unless --all or interactive
                       mode)
   -a, --all           Run all suites needing attestation
   --no-attest         Run tests without creating attestation
   --dry-run           Show what would run without executing
   -c, --continue      Resume interrupted session
   --filter <pattern>  Filter suites by pattern (glob-style)
+  -y, --yes           Automatically confirm seal creation without prompting
   -h, --help          display help for command
```

`init --help` is unchanged (its existing `-d/-f/--migrate` flags already covered non-interactive use; only its internal overwrite-confirmation behavior changed).

## Test plan

- [x] `pnpm build && pnpm check && pnpm test` green at repo root
- [x] Core package: 602 tests passing, `check:api-report`/`check:eslint`/`check:types` clean
- [x] CLI package: 699 tests passing (including 4 new test files + additions to 4 existing ones), `check:eslint`/`check:types` clean
- [x] New end-to-end integration test drives `identity create` → `init` → `run` (seal) → `verify` via the built CLI binary with `stdio: ['ignore', ...]` (stdin closed) throughout, plus dedicated fail-fast tests for each audited command