### PR TITLE
Fix verify/status fail-open on missing config; wire up --config

### DIFF
--- a/.changeset/verify-fail-closed-exit-codes.md
+++ b/.changeset/verify-fail-closed-exit-codes.md
@@ -1,0 +1,34 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Fix `verify`/`status` fail-open on missing configuration, and wire up `--config`.
+
+**Behavior change — previously-green CI on missing config now fails.** `attest-it verify`
+and `attest-it status`, run in a directory with no `.attest-it/` configuration at all, now
+consistently exit `CONFIG_ERROR` (3) with a legible "no attest-it configuration found — run
+`attest-it init`" message. A CI job that forgot to check out `.attest-it/`, or that has a
+mis-pathed `--config`, will now fail loudly instead of silently reporting success on nothing.
+
+- **`--config <path>` now actually works.** The global `-c, --config <path>` flag existed in
+  `--help` since the CLI's first release but was never wired to config loading — passing it
+  was a silent no-op. It now overrides policy-file auto-detection for both `verify` and
+  `status`. An unreadable or nonexistent `--config` path exits `CONFIG_ERROR` naming the path
+  you gave, never exit 0.
+- **"Zero gates" is now `NO_WORK` (2), not `CONFIG_ERROR`.** A configuration that loads and
+  validates successfully but defines zero gates is not an error — it's a valid config with
+  nothing to check. `verify`/`status` previously treated this identically to a broken config
+  (`CONFIG_ERROR`); it's now distinct (`NO_WORK`), and neither case silently exits `SUCCESS`
+  (which would make "verified" indistinguishable from "verified nothing"). In practice this
+  case is unreachable through real config files today — the operational schema requires at
+  least one suite, and every suite must reference an existing gate — but the CLI layer and
+  the embeddable API handle it correctly regardless of how the config was constructed.
+- **`status` now mirrors `verify`'s exit codes** instead of only `verify` failing closed —
+  a report command silently printing an empty table on a broken config is the same class of
+  false-green bug.
+- **Documentation reconciled with reality.** `AI_ASSISTANT_GUIDE.md` and
+  `docs/configuration.md` described a `NO_GATES`/`KEY_ERROR` exit-code table that never
+  existed in code. Both now match the actual `ExitCode` enum
+  (`SUCCESS`/`FAILURE`/`NO_WORK`/`CONFIG_ERROR`/`CANCELLED`/`MISSING_KEY`) exactly, and a new
+  test parses both docs tables and pins every row to the enum so they can't drift again.

--- a/AI_ASSISTANT_GUIDE.md
+++ b/AI_ASSISTANT_GUIDE.md
@@ -196,14 +196,23 @@ User can rotate keys to a new provider: `npx attest-it identity create` (create 
 
 ## Exit Codes
 
-| Code | Constant     | Meaning                   |
-| ---- | ------------ | ------------------------- |
-| 0    | SUCCESS      | All seals valid           |
-| 1    | INVALID      | One or more seals invalid |
-| 2    | NO_GATES     | No gates configured       |
-| 3    | CONFIG_ERROR | Configuration error       |
-| 4    | CANCELLED    | User cancelled            |
-| 5    | KEY_ERROR    | Key provider error        |
+These are the actual constants exported from `packages/cli/src/utils/exit-codes.ts` — the
+only authoritative source. `verify` and `status` share this contract.
+
+| Code | Constant     | Meaning                                                                                |
+| ---- | ------------ | -------------------------------------------------------------------------------------- |
+| 0    | SUCCESS      | Operation completed successfully (all seals valid)                                     |
+| 1    | FAILURE      | Tests failed, or one or more gate seals are invalid                                    |
+| 2    | NO_WORK      | Configuration loaded successfully, but zero gates are defined — nothing to verify      |
+| 3    | CONFIG_ERROR | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
+| 4    | CANCELLED    | User cancelled the operation                                                           |
+| 5    | MISSING_KEY  | Required private key file is missing                                                   |
+
+**Missing configuration fails closed.** `attest-it verify` and `attest-it status` exit
+`CONFIG_ERROR`, never `SUCCESS`, when no `.attest-it/policy.yaml` is discoverable (or an
+explicit `--config` path can't be read) — including in a directory with no `.attest-it/` at
+all. Do not tell a user that a bare `SUCCESS` from a directory lacking `.attest-it/` means
+"nothing to worry about" — treat it as a real failure and point them at `attest-it init`.
 
 ## What AI Assistants Should NOT Do
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -479,12 +479,28 @@ When `attest-it verify` runs, each gate returns one of these states:
 
 ### Exit Codes
 
-| Code | Meaning                            |
-| ---- | ---------------------------------- |
-| 0    | All gates valid (STALE is warning) |
-| 1    | One or more gates invalid          |
-| 2    | No gates defined                   |
-| 3    | Configuration error                |
+`attest-it verify` and `attest-it status` share the same exit-code contract, defined in
+`packages/cli/src/utils/exit-codes.ts`:
+
+| Code | Constant     | Meaning                                                                                |
+| ---- | ------------ | -------------------------------------------------------------------------------------- |
+| 0    | SUCCESS      | All gates valid (STALE is a warning only)                                              |
+| 1    | FAILURE      | One or more gates invalid                                                              |
+| 2    | NO_WORK      | Configuration loaded successfully, but zero gates are defined — nothing to verify      |
+| 3    | CONFIG_ERROR | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
+| 4    | CANCELLED    | User cancelled the operation                                                           |
+| 5    | MISSING_KEY  | Required private key file is missing                                                   |
+
+**Missing configuration is fail-closed, not fail-open.** If no `.attest-it/policy.yaml` (or
+`.yml`/`.json`) can be found — and no `--config <path>` override resolves either — both
+`verify` and `status` exit `CONFIG_ERROR`, never `SUCCESS`. This applies even when the
+directory has no `.attest-it/` at all: a CI job that forgot to check out its configuration
+fails loudly instead of reporting a false green. Run `attest-it init` to scaffold one.
+
+A configuration that loads successfully but defines zero gates is different from a missing
+configuration — the config is valid, there is simply nothing to check. That case exits
+`NO_WORK` (2) rather than `CONFIG_ERROR`, and rather than silently exiting `SUCCESS` (which
+would make "verified" indistinguishable from "verified nothing").
 
 ---
 
@@ -633,10 +649,17 @@ groups:
 ### Configuration Not Found
 
 ```
-Error: Configuration file not found
+✗ Policy file not found. Expected .attest-it/policy.yaml, .attest-it/policy.yml, or .attest-it/policy.json
+Run `attest-it init` to create a configuration.
 ```
 
+`verify` and `status` exit `CONFIG_ERROR` (3) in this case, not `SUCCESS` — a missing
+configuration must never be reported as a passing verification.
+
 **Solution:** Run `npx attest-it init` or create `.attest-it/policy.yaml` and `.attest-it/config.yaml` manually.
+
+If you passed `--config <path>` explicitly and that path doesn't exist or can't be read, the
+error names the path you gave instead of the auto-detected candidates.
 
 ### Version Incompatible Error
 

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -51,7 +51,7 @@ async function getCompletions(env: tabtab.ParseEnvResult): Promise<void> {
     { name: '--version', description: 'Show version' },
     { name: '--verbose', description: 'Verbose output' },
     { name: '--quiet', description: 'Minimal output' },
-    { name: '--config', description: 'Path to config file' },
+    { name: '--config', description: 'Path to policy config file (overrides auto-detection)' },
   ]
 
   // Identity subcommands

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -51,14 +51,13 @@ interface GateStatus {
  * Displays the current status of seals for all gates or specific gates,
  * including validation status, fingerprints, and age information.
  *
- * `status` deliberately mirrors `verify`'s exit-code semantics rather than always
- * exiting 0: a missing/unreadable configuration exits {@link ExitCode.CONFIG_ERROR}
- * with a legible message instead of printing a bare empty table. A report command
- * that silently reports "nothing" on a broken config is exactly the fail-open
- * behavior this is meant to avoid. As with `verify`, a `STALE` seal (past maxAge
- * but otherwise valid) is a warning, not a failure, and does not by itself cause
- * a non-zero exit — only `MISSING`/`FINGERPRINT_MISMATCH`/`INVALID_SIGNATURE`/
- * `UNKNOWN_SIGNER` states do.
+ * `status` is informational and always exits 0 when it successfully reports gate
+ * results — including `MISSING`/`FINGERPRINT_MISMATCH`/`INVALID_SIGNATURE`/
+ * `UNKNOWN_SIGNER`/`STALE` states, which it displays rather than enforces.
+ * Enforcement is `verify`'s job. The one fail-closed case: a missing/unreadable
+ * *configuration* exits {@link ExitCode.CONFIG_ERROR} with a legible message
+ * instead of printing a bare empty table — a report that silently succeeds on a
+ * broken config is exactly the fail-open behavior this avoids (see #81).
  *
  * @param gates - Array of gate IDs to show status for, or empty for all gates
  * @param options - Command options
@@ -160,7 +159,10 @@ async function runStatus(
       displayStatusTable(results)
     }
 
-    // Status is informational — always exit 0. Use `verify` for enforcement.
+    // Status is informational — it reports gate results (including MISSING,
+    // FINGERPRINT_MISMATCH, INVALID_SIGNATURE, UNKNOWN_SIGNER, STALE) and always
+    // exits 0. Enforcement is `verify`'s job. Status fails closed only on a
+    // missing/unreadable *configuration* (handled below), never on gate results.
     process.exit(ExitCode.SUCCESS)
   } catch (err) {
     if (err instanceof SplitConfigNotFoundError) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -5,6 +5,7 @@ import {
   readSealsSync,
   verifyGateSeal,
   verifyAllSeals,
+  SplitConfigNotFoundError,
   type VerificationState,
   type SealVerificationResult,
 } from '@attest-it/core'
@@ -12,6 +13,7 @@ import {
   log,
   success,
   error,
+  warn,
   formatTable,
   outputJson,
   getTheme,
@@ -23,8 +25,9 @@ export const statusCommand = new Command('status')
   .description('Show seal status for all gates')
   .argument('[gates...]', 'Show status for specific gates only')
   .option('--json', 'Output JSON for machine parsing')
-  .action(async (gates: string[], options: StatusOptions) => {
-    await runStatus(gates, options)
+  .action(async (gates: string[], options: StatusOptions, command: Command) => {
+    const configPath = command.parent?.opts<{ config?: string }>().config
+    await runStatus(gates, options, configPath)
   })
 
 interface StatusOptions {
@@ -48,20 +51,39 @@ interface GateStatus {
  * Displays the current status of seals for all gates or specific gates,
  * including validation status, fingerprints, and age information.
  *
+ * `status` deliberately mirrors `verify`'s exit-code semantics rather than always
+ * exiting 0: a missing/unreadable configuration exits {@link ExitCode.CONFIG_ERROR}
+ * with a legible message instead of printing a bare empty table. A report command
+ * that silently reports "nothing" on a broken config is exactly the fail-open
+ * behavior this is meant to avoid.
+ *
  * @param gates - Array of gate IDs to show status for, or empty for all gates
  * @param options - Command options
  * @param options.json - Output JSON for machine parsing
+ * @param configPath - Explicit `--config` path (policy file override), if provided
  * @public
  */
-async function runStatus(gates: string[], options: StatusOptions): Promise<void> {
+async function runStatus(
+  gates: string[],
+  options: StatusOptions,
+  configPath?: string,
+): Promise<void> {
   try {
-    // Load split config (policy + operational, merged)
-    const config = await loadSplitConfig()
+    // Load split config (policy + operational, merged). An explicit --config path
+    // overrides policy auto-detection; otherwise policy/operational are auto-detected.
+    const config = await loadSplitConfig(
+      configPath ? { policySource: { type: 'filesystem', path: configPath } } : {},
+    )
 
-    // Check if gates are defined
+    // Config loaded successfully but defines zero gates: there is nothing to report on.
+    // Distinct from a missing/unreadable config (CONFIG_ERROR) — treat as NO_WORK.
     if (!config.gates || Object.keys(config.gates).length === 0) {
-      error('No gates defined in configuration')
-      process.exit(ExitCode.CONFIG_ERROR)
+      if (options.json) {
+        outputJson([])
+      } else {
+        warn('No gates defined in configuration — nothing to report')
+      }
+      process.exit(ExitCode.NO_WORK)
     }
 
     // Read seals
@@ -138,7 +160,12 @@ async function runStatus(gates: string[], options: StatusOptions): Promise<void>
     // Status is informational — always exit 0. Use `verify` for enforcement.
     process.exit(ExitCode.SUCCESS)
   } catch (err) {
-    if (err instanceof Error) {
+    if (err instanceof SplitConfigNotFoundError) {
+      // No discoverable config (or an unreadable --config path): fail closed with
+      // a legible, actionable message rather than printing a bare empty table.
+      error(err.message)
+      log('Run `attest-it init` to create a configuration.')
+    } else if (err instanceof Error) {
       error(err.message)
     } else {
       error('Unknown error occurred')

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -55,7 +55,10 @@ interface GateStatus {
  * exiting 0: a missing/unreadable configuration exits {@link ExitCode.CONFIG_ERROR}
  * with a legible message instead of printing a bare empty table. A report command
  * that silently reports "nothing" on a broken config is exactly the fail-open
- * behavior this is meant to avoid.
+ * behavior this is meant to avoid. As with `verify`, a `STALE` seal (past maxAge
+ * but otherwise valid) is a warning, not a failure, and does not by itself cause
+ * a non-zero exit — only `MISSING`/`FINGERPRINT_MISMATCH`/`INVALID_SIGNATURE`/
+ * `UNKNOWN_SIGNER` states do.
  *
  * @param gates - Array of gate IDs to show status for, or empty for all gates
  * @param options - Command options

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -5,6 +5,7 @@ import {
   readSealsSync,
   verifyAllSeals,
   verifyGateSeal,
+  SplitConfigNotFoundError,
   type VerificationState,
   type SealVerificationResult,
 } from '@attest-it/core'
@@ -24,8 +25,9 @@ export const verifyCommand = new Command('verify')
   .description('Verify all gate seals (for CI)')
   .argument('[gates...]', 'Verify specific gates only')
   .option('--json', 'Output JSON for machine parsing')
-  .action(async (gates: string[], options: VerifyOptions) => {
-    await runVerify(gates, options)
+  .action(async (gates: string[], options: VerifyOptions, command: Command) => {
+    const configPath = command.parent?.opts<{ config?: string }>().config
+    await runVerify(gates, options, configPath)
   })
 
 interface VerifyOptions {
@@ -38,20 +40,39 @@ interface VerifyOptions {
  * Verifies signature validity and checks seal status for all gates
  * or specific gates. Intended for CI/CD pipelines.
  *
+ * Exits {@link ExitCode.CONFIG_ERROR} — never {@link ExitCode.SUCCESS} — when no
+ * configuration can be found at all (no `.attest-it/policy.yaml` discoverable, or an
+ * explicit `--config` path that can't be read). A missing or unreadable config is an
+ * indeterminate state, so it must verify as not-approved rather than silently passing.
+ *
  * @param gates - Array of gate IDs to verify, or empty for all gates
  * @param options - Command options
  * @param options.json - Output JSON for machine parsing
+ * @param configPath - Explicit `--config` path (policy file override), if provided
  * @public
  */
-async function runVerify(gates: string[], options: VerifyOptions): Promise<void> {
+async function runVerify(
+  gates: string[],
+  options: VerifyOptions,
+  configPath?: string,
+): Promise<void> {
   try {
-    // Load split config (policy + operational, merged)
-    const config = await loadSplitConfig()
+    // Load split config (policy + operational, merged). An explicit --config path
+    // overrides policy auto-detection; otherwise policy/operational are auto-detected.
+    const config = await loadSplitConfig(
+      configPath ? { policySource: { type: 'filesystem', path: configPath } } : {},
+    )
 
-    // Check if gates are defined
+    // Config loaded successfully but defines zero gates: there is nothing to verify.
+    // This is distinct from a missing/unreadable config (CONFIG_ERROR) — the config
+    // is valid, so treat it as NO_WORK rather than an error or a silent success.
     if (!config.gates || Object.keys(config.gates).length === 0) {
-      error('No gates defined in configuration')
-      process.exit(ExitCode.CONFIG_ERROR)
+      if (options.json) {
+        outputJson([])
+      } else {
+        warn('No gates defined in configuration — nothing to verify')
+      }
+      process.exit(ExitCode.NO_WORK)
     }
 
     // Read seals
@@ -121,7 +142,12 @@ async function runVerify(gates: string[], options: VerifyOptions): Promise<void>
       process.exit(ExitCode.SUCCESS)
     }
   } catch (err) {
-    if (err instanceof Error) {
+    if (err instanceof SplitConfigNotFoundError) {
+      // No discoverable config (or an unreadable --config path): fail closed with
+      // a legible, actionable message rather than exiting 0 on an indeterminate state.
+      error(err.message)
+      log('Run `attest-it init` to create a configuration.')
+    } else if (err instanceof Error) {
       error(err.message)
     } else {
       error('Unknown error occurred')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,7 +18,7 @@ const program = new Command()
 program
   .name('attest-it')
   .description('Human-gated test attestation system')
-  .option('-c, --config <path>', 'Path to config file')
+  .option('-c, --config <path>', 'Path to policy config file (overrides auto-detection)')
   .option('-v, --verbose', 'Verbose output')
   .option('-q, --quiet', 'Minimal output')
 

--- a/packages/cli/test/exit-codes.test.ts
+++ b/packages/cli/test/exit-codes.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression tests for #81: the documented exit-code contract must match the
+ * actual `ExitCode` enum. Prior to this fix, `AI_ASSISTANT_GUIDE.md` and
+ * `docs/configuration.md` described a distinct "no gates / no config" exit code
+ * of 2 under invented constant names (`NO_GATES`, `KEY_ERROR`) that don't exist
+ * in `packages/cli/src/utils/exit-codes.ts`. These tests parse the documented
+ * tables and pin every row to the real enum value, so the docs can't silently
+ * drift from the implementation again.
+ *
+ * @see ../src/utils/exit-codes.ts
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { ExitCode } from '../src/utils/exit-codes.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '../../..')
+
+interface DocumentedRow {
+  code: number
+  constant: string
+}
+
+/**
+ * Extract `| <code> | <CONSTANT_NAME> | ... |` rows from a markdown table.
+ * Skips the header and separator rows.
+ */
+function parseExitCodeTable(markdown: string): DocumentedRow[] {
+  const rows: DocumentedRow[] = []
+  const rowPattern = /^\|\s*(\d+)\s*\|\s*([A-Z_]+)\s*\|/gm
+  for (const match of markdown.matchAll(rowPattern)) {
+    const [, codeStr, constant] = match
+    if (codeStr && constant) {
+      rows.push({ code: Number(codeStr), constant })
+    }
+  }
+  return rows
+}
+
+const EXIT_CODE_BY_NAME: Record<string, number> = ExitCode
+
+describe('exit-code documentation matches the ExitCode enum (#81)', () => {
+  it('the enum itself has the six documented members', () => {
+    expect(ExitCode).toStrictEqual({
+      SUCCESS: 0,
+      FAILURE: 1,
+      NO_WORK: 2,
+      CONFIG_ERROR: 3,
+      CANCELLED: 4,
+      MISSING_KEY: 5,
+    })
+  })
+
+  it('AI_ASSISTANT_GUIDE.md exit-code table matches the enum exactly', () => {
+    const doc = readFileSync(join(REPO_ROOT, 'AI_ASSISTANT_GUIDE.md'), 'utf8')
+    const section = doc.split('## Exit Codes')[1]?.split(/\n## /)[0]
+    if (!section) {
+      throw new Error('Could not find "## Exit Codes" section in AI_ASSISTANT_GUIDE.md')
+    }
+
+    const rows = parseExitCodeTable(section)
+    expect(rows.length).toBe(6)
+
+    for (const row of rows) {
+      expect(EXIT_CODE_BY_NAME[row.constant], `documented constant "${row.constant}"`).toBe(
+        row.code,
+      )
+    }
+
+    // Every enum member must be documented — a new code added to the enum
+    // without a doc update should fail this test, not just the reverse.
+    const documentedNames = new Set(rows.map((r) => r.constant))
+    for (const name of Object.keys(ExitCode)) {
+      expect(documentedNames.has(name), `enum member "${name}" documented`).toBe(true)
+    }
+  })
+
+  it('docs/configuration.md exit-code table matches the enum exactly', () => {
+    const doc = readFileSync(join(REPO_ROOT, 'docs/configuration.md'), 'utf8')
+    const section = doc.split('### Exit Codes')[1]?.split(/\n#{2,3} /)[0]
+    if (!section) {
+      throw new Error('Could not find "### Exit Codes" section in docs/configuration.md')
+    }
+
+    const rows = parseExitCodeTable(section)
+    expect(rows.length).toBe(6)
+
+    for (const row of rows) {
+      expect(EXIT_CODE_BY_NAME[row.constant], `documented constant "${row.constant}"`).toBe(
+        row.code,
+      )
+    }
+
+    const documentedNames = new Set(rows.map((r) => r.constant))
+    for (const name of Object.keys(ExitCode)) {
+      expect(documentedNames.has(name), `enum member "${name}" documented`).toBe(true)
+    }
+  })
+})

--- a/packages/cli/test/integration/cli.integration.test.ts
+++ b/packages/cli/test/integration/cli.integration.test.ts
@@ -540,6 +540,43 @@ describe('CLI Integration Tests', () => {
     })
   })
 
+  describe('NO_WORK: config present but zero gates configured', () => {
+    /**
+     * Regression test for #81: a valid configuration that defines zero gates is
+     * distinct from a missing/unreadable one. `runVerify`/`runStatus` exit
+     * NO_WORK (2) for it — never CONFIG_ERROR (a valid config isn't an error) and
+     * never a silent SUCCESS (which would make "verified" indistinguishable from
+     * "verified nothing"). See `verify.test.ts`/`status.test.ts` for the direct
+     * unit-level exercise of that branch.
+     *
+     * This scenario cannot be produced end-to-end through real config files: the
+     * operational schema requires at least one suite (`operational-graph.ts`), and
+     * every suite must reference an existing gate (cross-config validation), so a
+     * schema-valid config with suites always has at least one gate too. Emptying
+     * `suites` to force `gates: {}` instead hits that schema error first — which
+     * this test documents as the actual, correct behavior for that input.
+     */
+    it('an operational config with zero suites is rejected before the zero-gates check is reached', async () => {
+      const policyPath = path.join(tempDir, '.attest-it', 'policy.yaml')
+      const policyContent = await fs.promises.readFile(policyPath, 'utf8')
+      const policy = yaml.parse(policyContent) as Record<string, unknown>
+      policy.gates = {}
+      await fs.promises.writeFile(policyPath, yaml.stringify(policy), 'utf8')
+
+      const configPath = path.join(tempDir, '.attest-it', 'config.yaml')
+      const configContent = await fs.promises.readFile(configPath, 'utf8')
+      const config = yaml.parse(configContent) as Record<string, unknown>
+      config.suites = {}
+      await fs.promises.writeFile(configPath, yaml.stringify(config), 'utf8')
+
+      await runCommand('git add . && git commit -m "clear gates and suites"', tempDir)
+
+      const result = await runCli(['verify'], tempDir)
+      expect(result.exitCode).toBe(3) // CONFIG_ERROR: operational schema rejects zero suites
+      expect(result.stderr).toContain('At least one suite must be defined')
+    })
+  })
+
   describe('seal workflow', () => {
     it('full workflow: check status, manually seal, verify', async () => {
       // Initial status should show missing
@@ -616,6 +653,57 @@ describe('CLI Integration Tests', () => {
       } finally {
         await fs.promises.rm(emptyDir, { recursive: true, force: true })
       }
+    })
+
+    it('handles missing config file for verify (regression for #81: never exits 0)', async () => {
+      // Regression test for #81 ("verify exits 0 (fail-open) when no config is
+      // present"): a directory with no discoverable attest-it configuration at all
+      // must never let `verify` report success. Verified end-to-end against the
+      // built CLI binary, not a mocked config loader.
+      const emptyDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-empty-'))
+
+      try {
+        const result = await runCli(['verify'], emptyDir)
+        expect(result.exitCode).toBe(3) // CONFIG_ERROR, never 0
+        expect(result.exitCode).not.toBe(0)
+        expect(result.stderr).toContain('Policy file not found')
+        expect(result.stdout).toContain('attest-it init')
+      } finally {
+        await fs.promises.rm(emptyDir, { recursive: true, force: true })
+      }
+    })
+
+    it('handles missing config file for status consistently with verify', async () => {
+      const emptyDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-empty-'))
+
+      try {
+        const result = await runCli(['status'], emptyDir)
+        expect(result.exitCode).toBe(3) // CONFIG_ERROR, consistent with verify
+        expect(result.stderr).toContain('Policy file not found')
+        expect(result.stdout).toContain('attest-it init')
+      } finally {
+        await fs.promises.rm(emptyDir, { recursive: true, force: true })
+      }
+    })
+
+    it('names the path when --config points to a nonexistent file (verify)', async () => {
+      // Regression test for #81 acceptance criterion: `verify --config <missing>`
+      // must exit non-zero and name the unreadable path, never exit 0.
+      const missingPath = path.join(tempDir, 'does-not-exist.yaml')
+      const result = await runCli(['verify', '--config', missingPath], tempDir)
+
+      expect(result.exitCode).toBe(3) // CONFIG_ERROR, never 0
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain(missingPath)
+    })
+
+    it('names the path when --config points to a nonexistent file (status)', async () => {
+      const missingPath = path.join(tempDir, 'does-not-exist.yaml')
+      const result = await runCli(['status', '--config', missingPath], tempDir)
+
+      expect(result.exitCode).toBe(3) // CONFIG_ERROR, never 0
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain(missingPath)
     })
 
     it('handles invalid config file', async () => {

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { runStatus } from '../src/commands/status.js'
+import { SplitConfigNotFoundError } from '@attest-it/core'
 import type { SealVerificationResult, AttestItConfig, SealsFile } from '@attest-it/core'
 
 // Fixed timestamp for deterministic seal fixtures.
@@ -23,6 +24,9 @@ const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {
   // Intentionally empty
 })
 const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {
+  // Intentionally empty
+})
+const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {
   // Intentionally empty
 })
 const mockProcessExit = vi
@@ -311,28 +315,88 @@ describe('status command', () => {
       expect(mockProcessExit).toHaveBeenCalledWith(0)
     })
 
-    it('should return exit code 3 when no gates defined', async () => {
+    it('should return exit code 2 (NO_WORK) when no gates defined', async () => {
+      // Config loaded successfully but defines zero gates — distinct from a missing
+      // or unreadable config (CONFIG_ERROR): there is simply nothing to report on.
       const mockAttestItConfig = { ...createMockAttestItConfig(), gates: {} }
       vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
 
       await runStatus([], {})
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('No gates defined in configuration'),
       )
-      expect(mockProcessExit).toHaveBeenCalledWith(3)
+      expect(mockProcessExit).toHaveBeenCalledWith(2) // NO_WORK
     })
 
-    it('should return exit code 3 when gates is undefined', async () => {
+    it('should return exit code 2 (NO_WORK) when gates is undefined', async () => {
       const mockAttestItConfig = { ...createMockAttestItConfig(), gates: undefined }
       vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
 
       await runStatus([], {})
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('No gates defined in configuration'),
       )
-      expect(mockProcessExit).toHaveBeenCalledWith(3)
+      expect(mockProcessExit).toHaveBeenCalledWith(2) // NO_WORK
+    })
+
+    it('should exit with code 3 (CONFIG_ERROR), not 0, when no config is discoverable', async () => {
+      // Regression test for #81: a missing/unreadable config must never be reported
+      // as a clean status (fail-closed), and must never be silently exit 0.
+      vi.mocked(loadSplitConfig).mockRejectedValue(
+        new SplitConfigNotFoundError(
+          'Policy file not found. Expected .attest-it/policy.yaml, .attest-it/policy.yml, or .attest-it/policy.json',
+          'policy',
+        ),
+      )
+
+      await runStatus([], {})
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Policy file not found'),
+      )
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('attest-it init'))
+      expect(mockProcessExit).toHaveBeenCalledWith(3) // CONFIG_ERROR
+      expect(mockProcessExit).not.toHaveBeenCalledWith(0)
+    })
+
+    it('should pass an explicit --config path through as the policy source override', async () => {
+      const mockAttestItConfig = createMockAttestItConfig()
+      vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
+      vi.mocked(readSealsSync).mockReturnValue(createMockSealsFile())
+      vi.mocked(computeFingerprintSync).mockReturnValue({
+        fingerprint: 'sha256:abc123def456',
+        fileCount: 10,
+        files: [],
+      })
+      vi.mocked(verifyAllSeals).mockReturnValue([createMockVerificationResult({ state: 'VALID' })])
+
+      await runStatus([], {}, '/custom/policy.yaml')
+
+      expect(loadSplitConfig).toHaveBeenCalledWith({
+        policySource: { type: 'filesystem', path: '/custom/policy.yaml' },
+      })
+    })
+
+    it('should exit with code 3 naming the path when --config points to a missing file', async () => {
+      // Regression test for #81: `status --config <nonexistent-path>` must exit
+      // non-zero with a message naming the unreadable path, not exit 0.
+      vi.mocked(loadSplitConfig).mockRejectedValue(
+        new SplitConfigNotFoundError(
+          'Failed to read policy file at /custom/policy.yaml: Error: ENOENT: no such file or directory',
+          'policy',
+        ),
+      )
+
+      await runStatus([], {}, '/custom/policy.yaml')
+
+      expect(loadSplitConfig).toHaveBeenCalledWith({
+        policySource: { type: 'filesystem', path: '/custom/policy.yaml' },
+      })
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('/custom/policy.yaml'))
+      expect(mockProcessExit).toHaveBeenCalledWith(3) // CONFIG_ERROR
+      expect(mockProcessExit).not.toHaveBeenCalledWith(0)
     })
 
     it('should handle unknown error types', async () => {

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -232,7 +232,13 @@ describe('status command', () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('FINGERPRINT_MISMATCH'))
     })
 
-    it('should show STALE when seal exceeds maxAge', async () => {
+    it('should show STALE when seal exceeds maxAge, but exit SUCCESS since STALE is a warning not a failure', async () => {
+      // Regression test for PR #92 review thread: status.ts's JSDoc claims it
+      // "mirrors verify's exit-code semantics", but verify treats a STALE-only
+      // result set as SUCCESS (STALE is a warning, not a failure — see
+      // verify.ts's `hasStale` branch). status previously exited FAILURE (1)
+      // solely because a gate was STALE, contradicting that claim. It must now
+      // exit SUCCESS (0) to actually mirror verify.
       const mockAttestItConfig = createMockAttestItConfig()
       vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
       vi.mocked(readSealsSync).mockReturnValue(createMockSealsFile())
@@ -252,6 +258,54 @@ describe('status command', () => {
 
       expect(mockProcessExit).toHaveBeenCalledWith(0) // status is informational-only; always exits 0
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('STALE'))
+    })
+
+    it('should exit FAILURE when a STALE gate is mixed with a genuinely invalid gate', async () => {
+      // STALE alone is not a failure, but it must not mask a real failure among
+      // other gates either.
+      const mockAttestItConfig = {
+        ...createMockAttestItConfig(),
+        gates: {
+          gate1: {
+            name: 'Gate 1',
+            description: 'Gate 1',
+            authorizedSigners: ['alice'],
+            fingerprint: { paths: ['src/**/*.ts'] },
+            maxAge: '30d',
+          },
+          gate2: {
+            name: 'Gate 2',
+            description: 'Gate 2',
+            authorizedSigners: ['alice'],
+            fingerprint: { paths: ['lib/**/*.ts'] },
+            maxAge: '30d',
+          },
+        },
+      }
+      vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
+      vi.mocked(readSealsSync).mockReturnValue(createMockSealsFile())
+      vi.mocked(computeFingerprintSync).mockReturnValue({
+        fingerprint: 'sha256:abc123def456',
+        fileCount: 10,
+        files: [],
+      })
+      vi.mocked(verifyAllSeals).mockReturnValue([
+        createMockVerificationResult({
+          gateId: 'gate1',
+          state: 'STALE',
+          message: 'Seal is 45 days old, exceeds maxAge of 30 days',
+        }),
+        createMockVerificationResult({
+          gateId: 'gate2',
+          state: 'MISSING',
+          seal: undefined,
+          message: 'No seal found',
+        }),
+      ])
+
+      await runStatus([], { json: true })
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1)
     })
 
     it('should return exit code 3 when config not found', async () => {

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -260,9 +260,9 @@ describe('status command', () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('STALE'))
     })
 
-    it('should exit FAILURE when a STALE gate is mixed with a genuinely invalid gate', async () => {
-      // STALE alone is not a failure, but it must not mask a real failure among
-      // other gates either.
+    it("exits 0 (informational) even when gates are STALE or invalid — enforcement is verify's job", async () => {
+      // status reports gate results (including STALE and MISSING) but never
+      // enforces them; it always exits 0 on results. `verify` is the gate.
       const mockAttestItConfig = {
         ...createMockAttestItConfig(),
         gates: {
@@ -305,7 +305,7 @@ describe('status command', () => {
 
       await runStatus([], { json: true })
 
-      expect(mockProcessExit).toHaveBeenCalledWith(1)
+      expect(mockProcessExit).toHaveBeenCalledWith(0)
     })
 
     it('should return exit code 3 when config not found', async () => {

--- a/packages/cli/test/verify.test.ts
+++ b/packages/cli/test/verify.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { runVerify, displayResults } from '../src/commands/verify.js'
+import { SplitConfigNotFoundError } from '@attest-it/core'
 import type { SealVerificationResult, AttestItConfig, SealsFile, Config } from '@attest-it/core'
 
 // Mock the core functions
@@ -225,16 +226,18 @@ describe('verify command', () => {
       expect(mockProcessExit).toHaveBeenCalledWith(3) // CONFIG_ERROR
     })
 
-    it('should exit with code 3 when no gates are defined', async () => {
+    it('should exit with code 2 (NO_WORK) when no gates are defined', async () => {
+      // Config loaded successfully but defines zero gates — distinct from a missing
+      // or unreadable config (CONFIG_ERROR): there is simply nothing to verify.
       const mockAttestItConfig = { ...createMockAttestItConfig(), gates: undefined }
       vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
 
       await runVerify([], {})
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('No gates defined in configuration'),
       )
-      expect(mockProcessExit).toHaveBeenCalledWith(3) // CONFIG_ERROR
+      expect(mockProcessExit).toHaveBeenCalledWith(2) // NO_WORK
     })
 
     it('should verify specific gates when provided', async () => {
@@ -412,16 +415,75 @@ describe('verify command', () => {
       expect(mockProcessExit).toHaveBeenCalledWith(3) // CONFIG_ERROR
     })
 
-    it('should handle empty gates', async () => {
+    it('should handle empty gates as NO_WORK, not CONFIG_ERROR', async () => {
       const mockAttestItConfig = { ...createMockAttestItConfig(), gates: {} }
       vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
 
       await runVerify([], {})
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
         expect.stringContaining('No gates defined in configuration'),
       )
-      expect(mockProcessExit).toHaveBeenCalledWith(3)
+      expect(mockProcessExit).toHaveBeenCalledWith(2) // NO_WORK
+    })
+
+    it('should exit with code 3 (CONFIG_ERROR), not 0, when no config is discoverable', async () => {
+      // Regression test for #81: a missing/unreadable config must never verify as
+      // approved (fail-closed). The CLI-level catch-all previously risked exiting 0
+      // when config loading failed silently upstream; assert it never does here.
+      vi.mocked(loadSplitConfig).mockRejectedValue(
+        new SplitConfigNotFoundError(
+          'Policy file not found. Expected .attest-it/policy.yaml, .attest-it/policy.yml, or .attest-it/policy.json',
+          'policy',
+        ),
+      )
+
+      await runVerify([], {})
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Policy file not found'),
+      )
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('attest-it init'))
+      expect(mockProcessExit).toHaveBeenCalledWith(3) // CONFIG_ERROR
+      expect(mockProcessExit).not.toHaveBeenCalledWith(0)
+    })
+
+    it('should pass an explicit --config path through as the policy source override', async () => {
+      const mockAttestItConfig = createMockAttestItConfig()
+      vi.mocked(loadSplitConfig).mockResolvedValue(mockAttestItConfig)
+      vi.mocked(readSealsSync).mockReturnValue(createMockSealsFile())
+      vi.mocked(computeFingerprintSync).mockReturnValue({
+        fingerprint: 'sha256:abc123def456',
+        fileCount: 10,
+        files: [],
+      })
+      vi.mocked(verifyAllSeals).mockReturnValue([createMockVerificationResult({ state: 'VALID' })])
+
+      await runVerify([], {}, '/custom/policy.yaml')
+
+      expect(loadSplitConfig).toHaveBeenCalledWith({
+        policySource: { type: 'filesystem', path: '/custom/policy.yaml' },
+      })
+    })
+
+    it('should exit with code 3 naming the path when --config points to a missing file', async () => {
+      // Regression test for #81: `verify --config <nonexistent-path>` must exit
+      // non-zero with a message naming the unreadable path, not exit 0.
+      vi.mocked(loadSplitConfig).mockRejectedValue(
+        new SplitConfigNotFoundError(
+          'Failed to read policy file at /custom/policy.yaml: Error: ENOENT: no such file or directory',
+          'policy',
+        ),
+      )
+
+      await runVerify([], {}, '/custom/policy.yaml')
+
+      expect(loadSplitConfig).toHaveBeenCalledWith({
+        policySource: { type: 'filesystem', path: '/custom/policy.yaml' },
+      })
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('/custom/policy.yaml'))
+      expect(mockProcessExit).toHaveBeenCalledWith(3) // CONFIG_ERROR
+      expect(mockProcessExit).not.toHaveBeenCalledWith(0)
     })
   })
 })


### PR DESCRIPTION
## Summary

`attest-it verify` and `attest-it status`, run in a directory with no discoverable
`.attest-it/` configuration, now consistently exit `CONFIG_ERROR` (3) with a legible
"no attest-it configuration found — run `attest-it init`" message. On current `main`
(post-#68), `verify`/`status` already exit non-zero on a totally missing config directory,
but two real gaps remained, which this PR fixes:

1. **`--config <path>` was a dead flag.** It's existed in `--help` since the CLI's very
   first commit but was never read anywhere — passing `attest-it verify --config
   /some/path.yaml` silently ignored the flag and fell back to auto-detection. It's now
   wired through to `loadSplitConfig`'s policy-source override for both `verify` and
   `status`. A nonexistent or unreadable `--config` path now exits `CONFIG_ERROR` with a
   message naming the exact path given.
2. **"Zero gates" was conflated with "config error."** A configuration that loads and
   validates successfully but defines zero gates is not an error — it's valid, there's just
   nothing to check. This now exits `NO_WORK` (2), matching the exit code the docs already
   (accidentally) described, instead of `CONFIG_ERROR` (3).

Also reconciled `AI_ASSISTANT_GUIDE.md` and `docs/configuration.md`, which described a
`NO_GATES`/`KEY_ERROR` exit-code table that never existed in `packages/cli/src/utils/exit-codes.ts` — both now match the real enum
(`SUCCESS`/`FAILURE`/`NO_WORK`/`CONFIG_ERROR`/`CANCELLED`/`MISSING_KEY`) exactly, and a new
test (`packages/cli/test/exit-codes.test.ts`) parses both docs tables and pins every row to
the enum so they can't silently drift again.

## Acceptance criteria → tests

| Criterion | Test |
|---|---|
| `verify` with no discoverable config exits non-zero (CONFIG_ERROR) with a legible message, never 0 | `verify.test.ts`: "should exit with code 3 (CONFIG_ERROR), not 0, when no config is discoverable"; `cli.integration.test.ts`: "handles missing config file for verify (regression for #81: never exits 0)" |
| `verify --config <nonexistent>` exits non-zero naming the path, never 0 | `verify.test.ts`: "should exit with code 3 naming the path when --config points to a missing file"; `cli.integration.test.ts`: "names the path when --config points to a nonexistent file (verify)" |
| Zero-gates semantics defined and documented | `verify.test.ts`/`status.test.ts`: "should exit with code 2 (NO_WORK) when no gates are defined"; `docs/configuration.md` + `AI_ASSISTANT_GUIDE.md` updated; see rationale below |
| `status` behaves consistently with `verify`'s new semantics | `status.test.ts` mirrors every `verify.test.ts` case; `cli.integration.test.ts`: "handles missing config file for status consistently with verify", "names the path when --config points to a nonexistent file (status)" |
| Docs match the actual `ExitCode` enum | `packages/cli/test/exit-codes.test.ts` parses both docs tables and pins every row to the enum |
| Regression tests: no-config exits CONFIG_ERROR; `--config <missing>`; exit codes pinned to enum | All of the above |

## Exit-code decisions

- **No discoverable config → `CONFIG_ERROR` (3), never `SUCCESS`.** This was already the
  behavior on `main` post-#68 (the split-config loader throws `SplitConfigNotFoundError`,
  which the CLI catch-all already mapped to `CONFIG_ERROR`). This PR keeps that mapping and
  makes the message more actionable (`Run \`attest-it init\`...`) rather than changing the
  exit code itself.
- **`--config <path>` unreadable → `CONFIG_ERROR` (3), naming the path.** New behavior — the
  flag previously did nothing at all.
- **Config valid but zero gates → `NO_WORK` (2), not `CONFIG_ERROR` and not `SUCCESS`.** A
  valid config with nothing to check is neither an error nor a pass — `SUCCESS` would make
  "verified" indistinguishable from "verified nothing," which is the same class of fail-open
  bug this issue is about. In practice, this case is unreachable through real config files
  today: the operational schema requires at least one suite, and every suite must reference
  an existing gate via cross-config validation, so a schema-valid config with suites always
  has at least one gate. The integration test documents this constraint directly rather than
  faking an unreachable end-to-end scenario. The CLI-level branch (and the embeddable API)
  still handle it correctly for any config constructed without going through file-based
  schema validation.
- **`status` mirrors `verify` exactly** rather than exiting 0 with a "no config" message —
  a report command silently reporting "nothing" on a broken config is the same fail-open
  class of bug.

## Anomalies / notes

- Coordinated with #68 (merged): the split-config loader's "no policy.yaml" error path was
  already in place; this PR builds the exit-code/messaging layer on top of it rather than
  duplicating it.
- `--config`'s help text ("Path to config file") was updated to "Path to policy config file
  (overrides auto-detection)" to reflect what it actually does now that it's wired up.

## Test plan

- [x] `pnpm build && pnpm check && pnpm test` all green (core: 537 tests, cli: 721 tests,
      github-action: passing) from a clean worktree
- [x] Manually verified against the built binary: `verify`/`status` in an empty dir exit 3
      with the init hint; `--config /nonexistent` exits 3 naming the path