### PR TITLE
docs: clarify status's always-exit-0 contract; fix config-v2 schema example + clean-tree order

### DIFF
--- a/AI_ASSISTANT_GUIDE.md
+++ b/AI_ASSISTANT_GUIDE.md
@@ -21,6 +21,7 @@ This document is designed for AI assistants (including those using RAG systems) 
 Your Ed25519 keypair and identity information:
 
 ```yaml
+version: 2
 activeIdentity: work
 identities:
   work:
@@ -29,9 +30,12 @@ identities:
     publicKey: MCowBQYDK2VwAyEA...
     privateKey:
       type: keychain # or 'file' or '1password'
-      service: attest-it
-      account: alice
+      id: attest-it-work-1a2b3c4d-5678-90ab-cdef-1234567890ab
 ```
+
+`id` is an opaque VaultKeeper secret ID that `identity create` generates -- never a raw file
+path, vault name, or keychain service string (see [Configuration Reference: Local Identity
+Configuration](docs/configuration.md#local-identity-configuration) for the full schema).
 
 ### 2. Project Configuration (split across two files)
 
@@ -197,7 +201,10 @@ User can rotate keys to a new provider: `npx attest-it identity create` (create 
 ## Exit Codes
 
 These are the actual constants exported from `packages/cli/src/utils/exit-codes.ts` — the
-only authoritative source. `verify` and `status` share this contract.
+only authoritative source. `verify` and `status` both use these constants, but **not for the
+same thing**: `verify` uses them to report gate validity; `status` uses only `SUCCESS`,
+`NO_WORK`, and `CONFIG_ERROR` (never `FAILURE`, `CANCELLED`, or `MISSING_KEY`), because
+`status` is informational and does not enforce gate results.
 
 | Code | Constant     | Meaning                                                                                |
 | ---- | ------------ | -------------------------------------------------------------------------------------- |
@@ -208,11 +215,20 @@ only authoritative source. `verify` and `status` share this contract.
 | 4    | CANCELLED    | User cancelled the operation                                                           |
 | 5    | MISSING_KEY  | Required private key file is missing                                                   |
 
+**`attest-it status` always exits `SUCCESS` (0) on gate results, even `MISSING`,
+`FINGERPRINT_MISMATCH`, `INVALID_SIGNATURE`, `UNKNOWN_SIGNER`, or `STALE` — it displays
+these states rather than enforcing them.** `attest-it verify` is the command that exits
+`FAILURE` (1) when a gate is invalid. **Never suggest `status`'s exit code as a CI gate or
+as proof that gates are valid** — if a user asks how to fail a build on a bad gate, or an
+automated workflow needs to check gate validity, point them at `verify`, not `status`.
+
 **Missing configuration fails closed.** `attest-it verify` and `attest-it status` exit
 `CONFIG_ERROR`, never `SUCCESS`, when no `.attest-it/policy.yaml` is discoverable (or an
 explicit `--config` path can't be read) — including in a directory with no `.attest-it/` at
 all. Do not tell a user that a bare `SUCCESS` from a directory lacking `.attest-it/` means
 "nothing to worry about" — treat it as a real failure and point them at `attest-it init`.
+This `CONFIG_ERROR` fail-closed behavior is the only thing `status`'s exit code shares with
+`verify`'s enforcement semantics — it does not extend to gate validity.
 
 ## What AI Assistants Should NOT Do
 
@@ -223,6 +239,8 @@ all. Do not tell a user that a bare `SUCCESS` from a directory lacking `.attest-
 - Bypass signature verification
 - Edit identity configuration files directly
 - Suggest workarounds that bypass security
+- Use `attest-it status`'s exit code to gate CI or as proof a gate is valid -- it always
+  exits `0` on gate results; use `attest-it verify` for enforcement
 
 **DO:**
 

--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ See [Configuration Reference](docs/configuration.md) for all options.
 
 ### Sealing and Verification
 
-| Command             | Description                      |
-| ------------------- | -------------------------------- |
-| `seal [gates...]`   | Create seals for specified gates |
-| `verify [gates...]` | Verify seals (for CI)            |
-| `status`            | Show seal status for all gates   |
-| `run --suite`       | Run tests and optionally seal    |
+| Command             | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `seal [gates...]`   | Create seals for specified gates                                         |
+| `verify [gates...]` | Verify seals -- **use this to gate CI**; exits non-zero on invalid gates |
+| `status`            | Show seal status for all gates -- informational only, always exits 0     |
+| `run --suite`       | Run tests and optionally seal                                            |
 
 ### Project Setup
 

--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ See [Configuration Reference](docs/configuration.md) for all options.
 
 ### Sealing and Verification
 
-| Command             | Description                                                              |
-| ------------------- | ------------------------------------------------------------------------ |
-| `seal [gates...]`   | Create seals for specified gates                                         |
-| `verify [gates...]` | Verify seals -- **use this to gate CI**; exits non-zero on invalid gates |
-| `status`            | Show seal status for all gates -- informational only, always exits 0     |
-| `run --suite`       | Run tests and optionally seal                                            |
+| Command             | Description                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `seal [gates...]`   | Create seals for specified gates                                                                        |
+| `verify [gates...]` | Verify seals -- **use this to gate CI**; exits non-zero on invalid gates                                |
+| `status`            | Show seal status for all gates -- informational; exits 0 on gate results, fails closed on config errors |
+| `run --suite`       | Run tests and optionally seal                                                                           |
 
 ### Project Setup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -374,9 +374,13 @@ npx attest-it run --filter 'unit-*'
 
 ## Local Identity Configuration
 
-Your identity is stored at `~/.config/attest-it/config.yaml`.
+Your identity is stored at `~/.config/attest-it/config.yaml`. This file uses the v2 schema:
+a top-level `version: 2`, and a flat VaultKeeper `id` per identity's `privateKey` (instead of
+the old per-provider fields like `path`/`vault`/`item`/`service`). This is the actual shape
+`attest-it identity create` writes — verified by generating a fresh identity, not hand-written:
 
 ```yaml
+version: 2
 activeIdentity: work
 
 identities:
@@ -387,9 +391,8 @@ identities:
     publicKey: MCowBQYDK2VwAyEAabc123...
     privateKey:
       type: 1password
+      id: attest-it-work-1a2b3c4d-5678-90ab-cdef-1234567890ab
       vault: Work
-      item: attest-it-signing-key
-      account: alice@example.com
 
   personal:
     name: Alice Smith
@@ -397,8 +400,7 @@ identities:
     publicKey: MCowBQYDK2VwAyEAdef456...
     privateKey:
       type: keychain
-      service: attest-it-personal
-      account: alice
+      id: attest-it-personal-2b3c4d5e-6789-01bc-def2-234567890abc
 ```
 
 ### Identity Fields
@@ -413,33 +415,35 @@ identities:
 
 ### Private Key Storage Options
 
+All backends store the private key itself via VaultKeeper, keyed by an opaque `id` that
+`identity create` generates -- `config.yaml` never holds a raw file path, vault name, or
+keychain service string directly (those were the old v1 per-provider fields).
+
 #### Filesystem
 
 ```yaml
 privateKey:
   type: file
-  path: ~/.config/attest-it/key.pem
+  id: attest-it-work-1a2b3c4d-5678-90ab-cdef-1234567890ab
 ```
 
-| Field  | Type   | Required | Description          |
-| ------ | ------ | -------- | -------------------- |
-| `type` | `file` | Yes      | Provider type        |
-| `path` | string | Yes      | Path to PEM key file |
+| Field  | Type   | Required | Description                              |
+| ------ | ------ | -------- | ---------------------------------------- |
+| `type` | `file` | Yes      | Provider type                            |
+| `id`   | string | Yes      | Opaque VaultKeeper secret ID for the key |
 
 #### macOS Keychain
 
 ```yaml
 privateKey:
   type: keychain
-  service: attest-it
-  account: alice
+  id: attest-it-personal-2b3c4d5e-6789-01bc-def2-234567890abc
 ```
 
-| Field     | Type       | Required | Description           |
-| --------- | ---------- | -------- | --------------------- |
-| `type`    | `keychain` | Yes      | Provider type         |
-| `service` | string     | Yes      | Keychain service name |
-| `account` | string     | Yes      | Keychain account name |
+| Field  | Type       | Required | Description                              |
+| ------ | ---------- | -------- | ---------------------------------------- |
+| `type` | `keychain` | Yes      | Provider type                            |
+| `id`   | string     | Yes      | Opaque VaultKeeper secret ID for the key |
 
 **Requirements:** macOS only
 
@@ -448,17 +452,15 @@ privateKey:
 ```yaml
 privateKey:
   type: 1password
-  vault: Private
-  item: attest-it-signing-key
-  account: user@example.com # optional
+  id: attest-it-work-3c4d5e6f-7890-12cd-ef34-34567890abcd
+  vault: Work
 ```
 
-| Field     | Type        | Required | Description                     |
-| --------- | ----------- | -------- | ------------------------------- |
-| `type`    | `1password` | Yes      | Provider type                   |
-| `vault`   | string      | Yes      | 1Password vault name            |
-| `item`    | string      | Yes      | Item name in vault              |
-| `account` | string      | No       | 1Password account (if multiple) |
+| Field   | Type        | Required | Description                              |
+| ------- | ----------- | -------- | ---------------------------------------- |
+| `type`  | `1password` | Yes      | Provider type                            |
+| `id`    | string      | Yes      | Opaque VaultKeeper secret ID for the key |
+| `vault` | string      | No       | 1Password vault name, for display/lookup |
 
 **Requirements:** 1Password CLI (`op`) must be installed
 
@@ -466,21 +468,26 @@ privateKey:
 
 ## Verification States
 
-When `attest-it verify` runs, each gate returns one of these states:
+Both `attest-it verify` and `attest-it status` evaluate each gate to one of the same states
+below and display it. The **Exit** column applies only to `verify` — it is the enforcement
+command, and this is the exit code it returns when a gate is in that state. `status` is
+purely informational: it always exits `0` (`SUCCESS`) after displaying these states,
+including `MISSING`, `FINGERPRINT_MISMATCH`, `INVALID_SIGNATURE`, and `UNKNOWN_SIGNER`. See
+[Exit Codes](#exit-codes) below.
 
-| State                  | Exit | Description                             |
-| ---------------------- | ---- | --------------------------------------- |
-| `VALID`                | 0    | Seal valid, signature verified, current |
-| `MISSING`              | 1    | No seal found for gate                  |
-| `STALE`                | 0    | Seal exceeds maxAge (warning only)      |
-| `FINGERPRINT_MISMATCH` | 1    | Code changed since seal was created     |
-| `INVALID_SIGNATURE`    | 1    | Signature verification failed           |
-| `UNKNOWN_SIGNER`       | 1    | Signer not in team configuration        |
+| State                  | `verify` Exit | Description                             |
+| ---------------------- | ------------- | --------------------------------------- |
+| `VALID`                | 0             | Seal valid, signature verified, current |
+| `MISSING`              | 1             | No seal found for gate                  |
+| `STALE`                | 0             | Seal exceeds maxAge (warning only)      |
+| `FINGERPRINT_MISMATCH` | 1             | Code changed since seal was created     |
+| `INVALID_SIGNATURE`    | 1             | Signature verification failed           |
+| `UNKNOWN_SIGNER`       | 1             | Signer not in team configuration        |
 
 ### Exit Codes
 
-`attest-it verify` and `attest-it status` share the same exit-code contract, defined in
-`packages/cli/src/utils/exit-codes.ts`:
+The exit codes below are defined once in `packages/cli/src/utils/exit-codes.ts` and used
+across commands, but `verify` and `status` use them differently:
 
 | Code | Constant     | Meaning                                                                                |
 | ---- | ------------ | -------------------------------------------------------------------------------------- |
@@ -491,6 +498,15 @@ When `attest-it verify` runs, each gate returns one of these states:
 | 4    | CANCELLED    | User cancelled the operation                                                           |
 | 5    | MISSING_KEY  | Required private key file is missing                                                   |
 
+**`status` is informational and always exits `SUCCESS` on gate results -- use `verify` to
+gate CI.** `status` reports gate states (`MISSING`, `FINGERPRINT_MISMATCH`,
+`INVALID_SIGNATURE`, `UNKNOWN_SIGNER`, `STALE`, etc.) so you can see what's wrong, but it
+never exits `FAILURE` for them -- it exits `SUCCESS` (0) as long as it successfully produced
+a report. Only `verify` returns `FAILURE` (1) when a gate is invalid. **Do not wire `status`
+into a CI gate expecting it to fail the build** -- it won't; wire `verify` instead. The one
+case where `status` _does_ fail closed is a missing/unreadable **configuration** itself (see
+below), which is a different concern from a gate's verification state.
+
 **Missing configuration is fail-closed, not fail-open.** If no `.attest-it/policy.yaml` (or
 `.yml`/`.json`) can be found — and no `--config <path>` override resolves either — both
 `verify` and `status` exit `CONFIG_ERROR`, never `SUCCESS`. This applies even when the
@@ -500,7 +516,8 @@ fails loudly instead of reporting a false green. Run `attest-it init` to scaffol
 A configuration that loads successfully but defines zero gates is different from a missing
 configuration — the config is valid, there is simply nothing to check. That case exits
 `NO_WORK` (2) rather than `CONFIG_ERROR`, and rather than silently exiting `SUCCESS` (which
-would make "verified" indistinguishable from "verified nothing").
+would make "verified" indistinguishable from "verified nothing"). This `NO_WORK` behavior is
+also shared by both `verify` and `status`.
 
 ---
 
@@ -519,10 +536,16 @@ settings:
 
 ```yaml
 privateKey:
-  type: file
+  type: filesystem
   path: ~/.config/attest-it/key.pem
   # Resolves to: /Users/alice/.config/attest-it/key.pem
 ```
+
+`type: filesystem` is the legacy shape that a v1-to-v2 migration produces for an old
+path-based key; it still supports `~` expansion. A fresh `identity create` instead writes
+`type: file` with an opaque VaultKeeper `id` (see [Local Identity
+Configuration](#local-identity-configuration)) — there is no raw path to resolve for that
+shape.
 
 ---
 
@@ -660,6 +683,24 @@ configuration must never be reported as a passing verification.
 
 If you passed `--config <path>` explicitly and that path doesn't exist or can't be read, the
 error names the path you gave instead of the auto-detected candidates.
+
+### Working Tree Has Uncommitted Changes
+
+```
+✗ Working tree has uncommitted changes. Please commit or stash before attesting.
+```
+
+**Cause:** `attest-it run --suite` (and `run` in interactive mode) refuses to run and seal
+against a dirty working tree -- this includes untracked files, so newly-created config or
+source files that haven't been added and committed yet will trigger it, not just modified
+tracked files. This precondition exists so the fingerprint a seal signs always corresponds
+to a specific commit, not to working-tree state that could change or vanish afterward.
+
+**Solution:** Commit (or stash) all pending changes -- including any `.attest-it/policy.yaml`
+/ `.attest-it/config.yaml` edits from setup -- before running `attest-it run --suite`. See
+[Step 4 of Getting Started](getting-started.md#step-4-run-tests-and-create-seal) for the
+documented order. To opt out (e.g. for local dogfooding of this repo on itself), set
+`ATTEST_IT_ALLOW_DIRTY=1`; this is not recommended for normal project use.
 
 ### Version Incompatible Error
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -375,9 +375,11 @@ npx attest-it run --filter 'unit-*'
 ## Local Identity Configuration
 
 Your identity is stored at `~/.config/attest-it/config.yaml`. This file uses the v2 schema:
-a top-level `version: 2`, and a flat VaultKeeper `id` per identity's `privateKey` (instead of
-the old per-provider fields like `path`/`vault`/`item`/`service`). This is the actual shape
-`attest-it identity create` writes — verified by generating a fresh identity, not hand-written:
+a top-level `version: 2`, and a flat VaultKeeper `id` per identity's `privateKey` in place of
+the old v1 per-provider identifier fields (`item`, `service`, `account`). One v1 field
+survives in v2: the `1password` backend can still carry an optional `vault` name alongside
+its opaque `id` (see [1Password](#1password) below). This is the actual shape `attest-it
+identity create` writes — verified by generating a fresh identity, not hand-written:
 
 ```yaml
 version: 2
@@ -416,8 +418,11 @@ identities:
 ### Private Key Storage Options
 
 All backends store the private key itself via VaultKeeper, keyed by an opaque `id` that
-`identity create` generates -- `config.yaml` never holds a raw file path, vault name, or
-keychain service string directly (those were the old v1 per-provider fields).
+`identity create` generates -- `config.yaml` never holds a keychain service string or
+1Password item name directly (those were the old v1 per-provider fields). Two exceptions:
+the `1password` variant can still carry an optional `vault` name (see below), and the legacy
+`filesystem` variant produced by a v1-to-v2 migration still stores a raw `path` (see
+[Path Resolution](#path-resolution)).
 
 #### Filesystem
 
@@ -698,7 +703,7 @@ to a specific commit, not to working-tree state that could change or vanish afte
 
 **Solution:** Commit (or stash) all pending changes -- including any `.attest-it/policy.yaml`
 / `.attest-it/config.yaml` edits from setup -- before running `attest-it run --suite`. See
-[Step 4 of Getting Started](getting-started.md#step-4-run-tests-and-create-seal) for the
+[Step 3b of Getting Started](getting-started.md#step-3b-commit-your-configuration) for the
 documented order. To opt out (e.g. for local dogfooding of this repo on itself), set
 `ATTEST_IT_ALLOW_DIRTY=1`; this is not recommended for normal project use.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -407,11 +407,13 @@ Age: 2 days
 Overall: All gates valid
 ```
 
-**`status` is informational and always exits `0`**, even when a gate is `MISSING`,
-`FINGERPRINT_MISMATCH`, or otherwise invalid -- it reports what it finds rather than
-enforcing it. Don't wire `status` into CI expecting it to fail the build on a bad gate; use
-`attest-it verify` for that (see [Step 6](#step-6-set-up-ci-verification) and
-[Exit Codes](configuration.md#exit-codes)).
+**`status` is informational and exits `0` when it successfully reports gate results** --
+even when a gate is `MISSING`, `FINGERPRINT_MISMATCH`, or otherwise invalid, it reports what
+it finds rather than enforcing it. Don't wire `status` into CI expecting it to fail the build
+on a bad gate; use `attest-it verify` for that (see [Step 6](#step-6-set-up-ci-verification)).
+`status` still fails closed on the configuration itself, though: it exits `CONFIG_ERROR` on a
+missing/unreadable config and `NO_WORK` when the config defines zero gates -- see
+[Exit Codes](configuration.md#exit-codes).
 
 ## Common Workflows
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -250,9 +250,31 @@ npx attest-it team add --slug bob --name "Bob Jones" \
   --public-key "MCowBQYDK2VwAyEA..." --gates desktop-tests < /dev/null
 ```
 
+## Step 3b: Commit Your Configuration
+
+Before running tests, commit everything you've changed so far -- the `package.json` update
+from `init`, and the `.attest-it/policy.yaml` / `.attest-it/config.yaml` edits from Steps 2b
+and 3:
+
+```bash
+git add package.json .attest-it/
+git commit -m "Configure attest-it: gate, suite, and team"
+```
+
+**This step must come before Step 4.** `attest-it run` refuses to seal against a dirty
+working tree -- including newly-created, not-yet-committed files -- so if you run it with
+the config edits above still uncommitted, it fails with:
+
+```
+✗ Working tree has uncommitted changes. Please commit or stash before attesting.
+```
+
+See [Working Tree Has Uncommitted Changes](configuration.md#working-tree-has-uncommitted-changes)
+for why this precondition exists.
+
 ## Step 4: Run Tests and Create Seal
 
-Run your test suite and create a seal:
+With a clean working tree (Step 3b), run your test suite and create a seal:
 
 ```bash
 npx attest-it run --suite desktop-tests
@@ -311,10 +333,11 @@ npx attest-it seal desktop-tests
 
 ## Step 5: Commit the Seal
 
-Add the seal file to version control:
+`policy.yaml` and `config.yaml` are already committed (Step 3b), so the only new file `run`
+produced is the seal itself. Add it to version control:
 
 ```bash
-git add .attest-it/seals.json .attest-it/policy.yaml .attest-it/config.yaml
+git add .attest-it/seals.json
 git commit -m "Add seal for desktop-tests"
 git push
 ```
@@ -383,6 +406,12 @@ Age: 2 days
 
 Overall: All gates valid
 ```
+
+**`status` is informational and always exits `0`**, even when a gate is `MISSING`,
+`FINGERPRINT_MISMATCH`, or otherwise invalid -- it reports what it finds rather than
+enforcing it. Don't wire `status` into CI expecting it to fail the build on a bad gate; use
+`attest-it verify` for that (see [Step 6](#step-6-set-up-ci-verification) and
+[Exit Codes](configuration.md#exit-codes)).
 
 ## Common Workflows
 

--- a/packages/cli/test/integration/getting-started.integration.test.ts
+++ b/packages/cli/test/integration/getting-started.integration.test.ts
@@ -253,10 +253,32 @@ describe('documented getting-started flow end-to-end (issue #84)', () => {
       }
       expect(teamMember.publicKey).toBe(publicKey)
 
+      // AC (issue #93): `run` refuses on an uncommitted working tree, and the
+      // old getting-started.md order (commit *after* running) failed on a
+      // literal first read because the Step 2b/3 config edits were still
+      // uncommitted here. Assert the failure mode directly, before fixing
+      // it, so a regression that silently drops the clean-tree gate -- or
+      // reintroduces the bad doc order -- is caught by this test either way.
+      const dirtyRunResult = await runCliNonInteractive(
+        ['run', '--suite', 'smoke', '--yes'],
+        projectDir,
+        env,
+      )
+      expect(dirtyRunResult.exitCode).not.toBe(0)
+      expect(dirtyRunResult.stderr).toContain(
+        'Working tree has uncommitted changes. Please commit or stash before attesting.',
+      )
+
+      // Step 3b: commit your configuration (docs/getting-started.md "Step 3b")
+      // -- must happen before Step 4 for `run` to succeed, per the assertion
+      // above. This is the fix for issue #93: the docs previously placed the
+      // config commit after "Run Tests and Create Seal" with no earlier
+      // commit step, which is the exact sequence that just failed.
       await runGit(['add', '.'], projectDir)
       await runGit(['commit', '-m', 'configure gate, suite, and team'], projectDir)
 
-      // Step 4: run --suite ... --yes (docs/getting-started.md "Step 4")
+      // Step 4: run --suite ... --yes (docs/getting-started.md "Step 4"),
+      // now succeeding because Step 3b left a clean working tree.
       const runResult = await runCliNonInteractive(
         ['run', '--suite', 'smoke', '--yes'],
         projectDir,


### PR DESCRIPTION
## Summary

Docs-truth pass per #93, verified against a fresh build of the CLI (identity generation, `run`'s dirty-tree check, and `status`'s exit code were all exercised against the real binary, not documented from memory).

- **`status` exit-code semantics**: `status` has always exited `0` on gate results -- it displays `MISSING`/`FINGERPRINT_MISMATCH`/`STALE`/etc. rather than enforcing them; `verify` is the enforcement command. The docs (README, `docs/configuration.md`, `docs/getting-started.md`, `AI_ASSISTANT_GUIDE.md`) previously implied `status` "shares the same exit-code contract" as `verify` for these states, which is misleading and was flagged as a false-green CI risk. Aligned all four docs to the real, tested contract. No runtime behavior changed.
- **config-v2 schema example**: `docs/configuration.md`'s "Local Identity Configuration" example (and the AI guide's) showed the old v1 `privateKey: { type: file, path: ... }` shape. Generated a fresh identity locally to confirm the real post-config-v2 shape: `{ type, id }` (opaque VaultKeeper secret ID) with a top-level `version: 2`. Fixed the example and the per-backend (`file`/`keychain`/`1password`) field tables to match. Also fixed a second stale `type: file, path:` example under "Path Resolution" that didn't correspond to any valid `PrivateKeyRef` shape.
- **Clean-tree precondition + getting-started order**: confirmed live that `attest-it run --suite` refuses with `Working tree has uncommitted changes...` when config edits from earlier steps are uncommitted. `docs/getting-started.md`'s old order committed the seal *after* running tests, with no earlier commit step for the Step 2b/3 config edits -- so following it verbatim failed on first read. Added "Step 3b: Commit Your Configuration" before "Run Tests and Create Seal", and documented the precondition in `docs/configuration.md`'s troubleshooting section.

## Test plan

- [x] Extended `packages/cli/test/integration/getting-started.integration.test.ts` to assert the dirty-tree failure directly (running `run --suite` before committing config now asserts a non-zero exit and the exact error message) before the fixed commit-then-run sequence -- so the documented order is what's tested, and a regression to either the clean-tree gate or the doc order is caught.
- [x] `pnpm build && pnpm check && pnpm test` all green (740 tests passing across 37 files).
- [x] Verified live against the built CLI: generated a real identity (`file` backend) and confirmed the `{ type, id }` / `version: 2` shape; reproduced the dirty-tree `run` failure and the clean-run success; confirmed `status` exits 0 on a `MISSING` gate.
- [x] No changeset (docs + test only, no published-package source changes).

Refs #93