### PR TITLE
Make identity/team remove and seal non-interactive; fix exit-code overloading

### DIFF
--- a/.changeset/headless-identity-remove-and-exit-code-remapping.md
+++ b/.changeset/headless-identity-remove-and-exit-code-remapping.md
@@ -23,9 +23,9 @@
 
 - A cancelled interactive prompt — declined, or force-closed/interrupted (Ctrl-C, or a piped
   stdin that closes mid-prompt) — now always exits `CANCELLED` (4), never `CONFIG_ERROR` (3),
-  across every command that prompts (`identity create`/`remove`, `init`, `team
-add`/`join`/`remove`, `run`). A force-closed prompt also now reports a clean `Cancelled` message
-  instead of `@inquirer/core`'s raw `User force closed the prompt with 0 null`.
+  across every command that prompts (`identity create`/`remove`, `init`,
+  `team add`/`join`/`remove`, `run`). A force-closed prompt also now reports a clean `Cancelled`
+  message instead of `@inquirer/core`'s raw `User force closed the prompt with 0 null`.
 - `run`'s dirty-working-tree refusal now exits a new dedicated code, **`DIRTY_WORKING_TREE` (6)**,
   instead of `CONFIG_ERROR` (3) — a dirty tree is a precondition failure, not a configuration
   problem, and automation consuming exit codes needs to tell the two apart.

--- a/.changeset/headless-identity-remove-and-exit-code-remapping.md
+++ b/.changeset/headless-identity-remove-and-exit-code-remapping.md
@@ -1,0 +1,35 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+**Headless `identity remove`, non-interactive `seal`, and a corrected exit-code contract.**
+
+- **`identity remove <slug>` is now fully non-interactive** with a new `-y, --yes` flag that
+  skips both confirmations (removing the identity, and — opt-in via the also-new `--delete-key`
+  flag — deleting the private key file). Without `--yes`, a non-TTY stdin now **fails fast** with
+  a legible message instead of ever handing that stdin to the interactive prompt library.
+- **Fixed a runaway prompt-render loop.** Piping input into `identity remove` (or `team remove`,
+  which had the same gap despite already having `--force`) with no non-interactive flag previously
+  produced an unbounded (~20MB+) terminal-escape-code render loop that never exited — a real
+  hang/DoS risk in CI or agent automation. Every confirmation in the CLI is now gated behind an
+  explicit TTY check before it ever reaches the prompt library.
+- **`seal` now supports passphrase-encrypted file-backed keys.** Previously `seal` had no
+  passphrase handling at all, so a key created with `identity create --passphrase-stdin` simply
+  failed to sign. `seal` now shares `run`'s existing passphrase resolution (env var
+  `ATTEST_IT_KEY_PASSPHRASE` → interactive prompt → fail fast).
+
+**Exit-code contract correction (may affect scripts checking specific exit codes):**
+
+- A cancelled interactive prompt — declined, or force-closed/interrupted (Ctrl-C, or a piped
+  stdin that closes mid-prompt) — now always exits `CANCELLED` (4), never `CONFIG_ERROR` (3),
+  across every command that prompts (`identity create`/`remove`, `init`, `team
+add`/`join`/`remove`, `run`). A force-closed prompt also now reports a clean `Cancelled` message
+  instead of `@inquirer/core`'s raw `User force closed the prompt with 0 null`.
+- `run`'s dirty-working-tree refusal now exits a new dedicated code, **`DIRTY_WORKING_TREE` (6)**,
+  instead of `CONFIG_ERROR` (3) — a dirty tree is a precondition failure, not a configuration
+  problem, and automation consuming exit codes needs to tell the two apart.
+- `CONFIG_ERROR` (3) is unchanged for its original, documented meaning: no discoverable
+  configuration, an unreadable `--config` path, or invalid configuration.
+
+See the updated exit-code tables in `AI_ASSISTANT_GUIDE.md` and `docs/configuration.md`.

--- a/AI_ASSISTANT_GUIDE.md
+++ b/AI_ASSISTANT_GUIDE.md
@@ -199,14 +199,28 @@ User can rotate keys to a new provider: `npx attest-it identity create` (create 
 These are the actual constants exported from `packages/cli/src/utils/exit-codes.ts` — the
 only authoritative source. `verify` and `status` share this contract.
 
-| Code | Constant     | Meaning                                                                                |
-| ---- | ------------ | -------------------------------------------------------------------------------------- |
-| 0    | SUCCESS      | Operation completed successfully (all seals valid)                                     |
-| 1    | FAILURE      | Tests failed, or one or more gate seals are invalid                                    |
-| 2    | NO_WORK      | Configuration loaded successfully, but zero gates are defined — nothing to verify      |
-| 3    | CONFIG_ERROR | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
-| 4    | CANCELLED    | User cancelled the operation                                                           |
-| 5    | MISSING_KEY  | Required private key file is missing                                                   |
+| Code | Constant           | Meaning                                                                                |
+| ---- | ------------------ | -------------------------------------------------------------------------------------- |
+| 0    | SUCCESS            | Operation completed successfully (all seals valid)                                     |
+| 1    | FAILURE            | Tests failed, or one or more gate seals are invalid                                    |
+| 2    | NO_WORK            | Configuration loaded successfully, but zero gates are defined — nothing to verify      |
+| 3    | CONFIG_ERROR       | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
+| 4    | CANCELLED          | User cancelled the operation (a declined or force-closed/interrupted prompt)           |
+| 5    | MISSING_KEY        | Required private key file is missing                                                   |
+| 6    | DIRTY_WORKING_TREE | `run`/`seal` refused because the git working tree has uncommitted changes              |
+
+**A cancelled prompt is always `CANCELLED` (4), never `CONFIG_ERROR`.** This applies to every
+interactive confirmation in the CLI (`identity create`/`remove`, `init`, `team add`/`join`/`remove`,
+`run`) — whether the user explicitly declines, or the prompt is interrupted/force-closed (e.g.
+Ctrl-C, or a piped stdin that closes mid-prompt). Prior to issue #95, a force-closed prompt fell
+through to `CONFIG_ERROR` with `@inquirer/core`'s raw, unpolished message; it's now reported as a
+clean `Cancelled` line under the documented `CANCELLED` code.
+
+**A dirty working tree is `DIRTY_WORKING_TREE` (6), never `CONFIG_ERROR`.** `run` refuses to
+execute a suite (and create its seal) when `git status --porcelain` reports uncommitted changes,
+unless `ATTEST_IT_ALLOW_DIRTY` is set. This is a precondition failure on an otherwise-valid
+configuration, not a configuration problem — so it gets its own code, distinguishable from "no
+configuration found" by an automation/CI consumer.
 
 **Missing configuration fails closed.** `attest-it verify` and `attest-it status` exit
 `CONFIG_ERROR`, never `SUCCESS`, when no `.attest-it/policy.yaml` is discoverable (or an

--- a/AI_ASSISTANT_GUIDE.md
+++ b/AI_ASSISTANT_GUIDE.md
@@ -207,7 +207,7 @@ only authoritative source. `verify` and `status` share this contract.
 | 3    | CONFIG_ERROR       | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
 | 4    | CANCELLED          | User cancelled the operation (a declined or force-closed/interrupted prompt)           |
 | 5    | MISSING_KEY        | Required private key file is missing                                                   |
-| 6    | DIRTY_WORKING_TREE | `run`/`seal` refused because the git working tree has uncommitted changes              |
+| 6    | DIRTY_WORKING_TREE | `run` refused because the git working tree has uncommitted changes                     |
 
 **A cancelled prompt is always `CANCELLED` (4), never `CONFIG_ERROR`.** This applies to every
 interactive confirmation in the CLI (`identity create`/`remove`, `init`, `team add`/`join`/`remove`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -490,7 +490,7 @@ When `attest-it verify` runs, each gate returns one of these states:
 | 3    | CONFIG_ERROR       | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
 | 4    | CANCELLED          | User cancelled the operation (a declined or force-closed/interrupted prompt)           |
 | 5    | MISSING_KEY        | Required private key file is missing                                                   |
-| 6    | DIRTY_WORKING_TREE | `run`/`seal` refused because the git working tree has uncommitted changes              |
+| 6    | DIRTY_WORKING_TREE | `run` refused because the git working tree has uncommitted changes                     |
 
 **A cancelled prompt is `CANCELLED` (4), never `CONFIG_ERROR`** — whether declined or
 force-closed/interrupted (e.g. Ctrl-C, or a piped stdin that closes mid-prompt).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -482,14 +482,22 @@ When `attest-it verify` runs, each gate returns one of these states:
 `attest-it verify` and `attest-it status` share the same exit-code contract, defined in
 `packages/cli/src/utils/exit-codes.ts`:
 
-| Code | Constant     | Meaning                                                                                |
-| ---- | ------------ | -------------------------------------------------------------------------------------- |
-| 0    | SUCCESS      | All gates valid (STALE is a warning only)                                              |
-| 1    | FAILURE      | One or more gates invalid                                                              |
-| 2    | NO_WORK      | Configuration loaded successfully, but zero gates are defined — nothing to verify      |
-| 3    | CONFIG_ERROR | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
-| 4    | CANCELLED    | User cancelled the operation                                                           |
-| 5    | MISSING_KEY  | Required private key file is missing                                                   |
+| Code | Constant           | Meaning                                                                                |
+| ---- | ------------------ | -------------------------------------------------------------------------------------- |
+| 0    | SUCCESS            | All gates valid (STALE is a warning only)                                              |
+| 1    | FAILURE            | One or more gates invalid                                                              |
+| 2    | NO_WORK            | Configuration loaded successfully, but zero gates are defined — nothing to verify      |
+| 3    | CONFIG_ERROR       | No discoverable configuration, an unreadable `--config` path, or invalid configuration |
+| 4    | CANCELLED          | User cancelled the operation (a declined or force-closed/interrupted prompt)           |
+| 5    | MISSING_KEY        | Required private key file is missing                                                   |
+| 6    | DIRTY_WORKING_TREE | `run`/`seal` refused because the git working tree has uncommitted changes              |
+
+**A cancelled prompt is `CANCELLED` (4), never `CONFIG_ERROR`** — whether declined or
+force-closed/interrupted (e.g. Ctrl-C, or a piped stdin that closes mid-prompt).
+
+**A dirty working tree is `DIRTY_WORKING_TREE` (6), never `CONFIG_ERROR`.** `run` refuses to run
+a suite when the working tree has uncommitted changes (unless `ATTEST_IT_ALLOW_DIRTY` is set) —
+a precondition failure, not a configuration problem.
 
 **Missing configuration is fail-closed, not fail-open.** If no `.attest-it/policy.yaml` (or
 `.yml`/`.json`) can be found — and no `--config <path>` override resolves either — both

--- a/packages/cli/src/commands/identity/create.ts
+++ b/packages/cli/src/commands/identity/create.ts
@@ -28,6 +28,7 @@ import {
   resolveOptionalOrPrompt,
   isInteractiveTTY,
   readStdin,
+  handlePromptableError,
 } from '../../utils/prompts.js'
 import { join } from 'node:path'
 
@@ -794,12 +795,7 @@ async function runCreate(options: CreateOptions): Promise<void> {
     // Offer to install shell completions
     await offerCompletionInstall()
   } catch (err) {
-    if (err instanceof Error) {
-      error(err.message)
-    } else {
-      error('Unknown error occurred')
-    }
-    process.exit(ExitCode.CONFIG_ERROR)
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
 }
 

--- a/packages/cli/src/commands/identity/remove.ts
+++ b/packages/cli/src/commands/identity/remove.ts
@@ -4,6 +4,7 @@ import { loadLocalConfig, saveLocalConfig } from '@attest-it/core'
 import { log, success, error, getTheme } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
 import { formatKeyLocation } from '../../utils/format-key-location.js'
+import { handlePromptableError, resolveConfirmation } from '../../utils/prompts.js'
 import { unlink } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import * as path from 'node:path'
@@ -11,15 +12,33 @@ import * as path from 'node:path'
 export const removeCommand = new Command('remove')
   .description('Delete identity and optionally delete private key')
   .argument('<slug>', 'Identity slug to remove')
-  .action(async (slug: string) => {
-    await runRemove(slug)
+  .option('-y, --yes', 'Skip the confirmation prompt(s) and remove non-interactively')
+  .option(
+    '--delete-key',
+    'Also delete the private key from storage when used with --yes (interactively, this is still asked separately; default: false)',
+  )
+  .action(async (slug: string, options: RemoveOptions) => {
+    await runRemove(slug, options)
   })
+
+interface RemoveOptions {
+  yes?: boolean
+  deleteKey?: boolean
+}
 
 /**
  * Run the remove command to delete an identity.
+ *
+ * Non-interactive with `--yes`: both confirmations resolve without prompting
+ * (identity removal proceeds; private-key deletion defaults to `false`
+ * unless `--delete-key` is also given -- the more destructive of the two
+ * actions is opt-in, not implied by `--yes` alone). Without `--yes`, a
+ * closed/piped stdin fails fast naming `--yes` instead of hanging on (or
+ * looping through) a prompt that can never resolve. See issue #94.
+ *
  * @public
  */
-export async function runRemove(slug: string): Promise<void> {
+export async function runRemove(slug: string, options: RemoveOptions = {}): Promise<void> {
   try {
     const config = await loadLocalConfig()
 
@@ -45,11 +64,16 @@ export async function runRemove(slug: string): Promise<void> {
     }
     log('')
 
-    // Confirm deletion
-    const confirmDelete = await confirm({
-      message: 'Are you sure you want to delete this identity?',
-      default: false,
-    })
+    // Confirm deletion. Gated behind "flag not supplied AND stdin is an
+    // interactive TTY": with --yes this proceeds without prompting; a closed
+    // or piped stdin with no flag fails fast instead of ever handing that
+    // stdin to the prompt library. See issue #94.
+    const confirmDelete = await resolveConfirmation(options.yes, '--yes', () =>
+      confirm({
+        message: 'Are you sure you want to delete this identity?',
+        default: false,
+      }),
+    )
 
     if (!confirmDelete) {
       log('Cancelled')
@@ -61,10 +85,16 @@ export async function runRemove(slug: string): Promise<void> {
     log(`  Private key: ${keyLocation}`)
     log('')
 
-    const deletePrivateKey = await confirm({
-      message: 'Also delete the private key from storage?',
-      default: false,
-    })
+    // Reaching this point already proved --yes was supplied or stdin is an
+    // interactive TTY (resolveConfirmation above would have thrown
+    // otherwise), so no separate non-interactive guard is needed here --
+    // only which default to use.
+    const deletePrivateKey = options.yes
+      ? (options.deleteKey ?? false)
+      : await confirm({
+          message: 'Also delete the private key from storage?',
+          default: false,
+        })
 
     // Delete private key if requested
     if (deletePrivateKey) {
@@ -144,11 +174,6 @@ export async function runRemove(slug: string): Promise<void> {
     success(`Identity "${slug}" removed`)
     log('')
   } catch (err) {
-    if (err instanceof Error) {
-      error(err.message)
-    } else {
-      error('Unknown error occurred')
-    }
-    process.exit(ExitCode.CONFIG_ERROR)
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path'
 import { stringify as stringifyYaml } from 'yaml'
 import { migrateUnifiedContent } from '@attest-it/core'
 import { log, success, error } from '../utils/output.js'
-import { confirmAction, isInteractiveTTY } from '../utils/prompts.js'
+import { confirmAction, isInteractiveTTY, handlePromptableError } from '../utils/prompts.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { offerCompletionInstall } from '../utils/completion-offer.js'
 import { getPackageVersion } from '../utils/version.js'
@@ -303,12 +303,7 @@ async function runInit(options: InitOptions): Promise<void> {
     // Offer to install shell completions
     await offerCompletionInstall()
   } catch (err) {
-    if (err instanceof Error) {
-      error(err.message)
-    } else {
-      error('Unknown error occurred')
-    }
-    process.exit(ExitCode.CONFIG_ERROR)
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
 }
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -5,7 +5,6 @@
 import { Command } from 'commander'
 import { spawn } from 'node:child_process'
 import { parse as parseShellCommand } from 'shell-quote'
-import { password } from '@inquirer/prompts'
 import {
   loadSplitConfig,
   computeFingerprint,
@@ -22,13 +21,11 @@ import {
   type Identity,
 } from '@attest-it/core'
 import { log, success, error, warn, verbose } from '../utils/output.js'
-import { confirmAction, isInteractiveTTY } from '../utils/prompts.js'
+import { confirmAction, isInteractiveTTY, handlePromptableError } from '../utils/prompts.js'
+import { resolveKeyPassphrase } from '../utils/passphrase.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { runInteractive } from './run-interactive.js'
 import { getAllSuiteStatuses } from './run-utils.js'
-
-/** Env var read for the passphrase of an encrypted file-backed identity key. */
-const KEY_PASSPHRASE_ENV = 'ATTEST_IT_KEY_PASSPHRASE'
 
 export const runCommand = new Command('run')
   .description('Execute tests and create attestation')
@@ -92,12 +89,7 @@ async function runTests(options: RunOptions): Promise<void> {
       filter: options.filter,
     })
   } catch (err) {
-    if (err instanceof Error) {
-      error(err.message)
-    } else {
-      error('Unknown error occurred')
-    }
-    process.exit(ExitCode.CONFIG_ERROR)
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
 }
 
@@ -271,7 +263,7 @@ async function runDirectMode(options: RunOptions): Promise<void> {
     const isDirty = await checkDirtyWorkingTree()
     if (isDirty) {
       error('Working tree has uncommitted changes. Please commit or stash before attesting.')
-      process.exit(ExitCode.CONFIG_ERROR)
+      process.exit(ExitCode.DIRTY_WORKING_TREE)
     }
   }
 
@@ -325,7 +317,7 @@ async function runAllPending(options: RunOptions): Promise<void> {
     const isDirty = await checkDirtyWorkingTree()
     if (isDirty) {
       error('Working tree has uncommitted changes. Please commit or stash before attesting.')
-      process.exit(ExitCode.CONFIG_ERROR)
+      process.exit(ExitCode.DIRTY_WORKING_TREE)
     }
   }
 
@@ -545,34 +537,6 @@ async function promptForSeal(
 }
 
 /**
- * Resolve the passphrase needed to sign with an encrypted file-backed
- * private key (created via `identity create --storage file --passphrase-stdin`).
- *
- * Order: the `ATTEST_IT_KEY_PASSPHRASE` env var, then (interactively) a
- * masked prompt, then fail fast naming the env var -- this never hangs on a
- * prompt that can never resolve. See issue #80.
- *
- * @returns The resolved passphrase
- * @throws Error if non-interactive and the env var is not set
- */
-async function resolveKeyPassphrase(): Promise<string> {
-  const fromEnv = process.env[KEY_PASSPHRASE_ENV]
-  if (fromEnv !== undefined && fromEnv.length > 0) {
-    return fromEnv
-  }
-  if (isInteractiveTTY()) {
-    return password({
-      message: 'Passphrase for encrypted private key:',
-      validate: (value) => (value.length > 0 ? true : 'Passphrase cannot be empty'),
-    })
-  }
-  throw new Error(
-    `This identity's private key is passphrase-encrypted. Set ${KEY_PASSPHRASE_ENV} ` +
-      '(no interactive terminal available to prompt for it).',
-  )
-}
-
-/**
  * Create a key provider from an identity's private key reference.
  *
  * @param identity - The identity containing the private key reference
@@ -641,4 +605,4 @@ function getKeyRefFromIdentity(identity: Identity): string {
 }
 
 // Export for testing
-export { buildCommand, parseCommand, executeCommand, checkDirtyWorkingTree, resolveKeyPassphrase }
+export { buildCommand, parseCommand, executeCommand, checkDirtyWorkingTree }

--- a/packages/cli/src/commands/seal.ts
+++ b/packages/cli/src/commands/seal.ts
@@ -15,6 +15,7 @@ import {
   readSealsSync,
   writeSealsSync,
   verifyGateSeal,
+  isEncryptedPrivateKeyPem,
   KeyProviderRegistry,
   API_SCHEMA_VERSION,
   type AttestItConfig,
@@ -25,6 +26,7 @@ import {
 } from '@attest-it/core'
 import { log, success, error, warn, verbose, outputJson } from '../utils/output.js'
 import { ExitCode } from '../utils/exit-codes.js'
+import { resolveKeyPassphrase } from '../utils/passphrase.js'
 
 export const sealCommand = new Command('seal')
   .description('Create seals for gates')
@@ -301,12 +303,21 @@ async function processSingleGate(
   // Clean up after reading
   await keyResult.cleanup()
 
+  // A file-backed key created with `identity create --passphrase-stdin` is
+  // encrypted; resolve the passphrase needed to sign with it from the
+  // environment, an interactive prompt, or fail fast. Shared with `run`'s
+  // seal-creation path -- see issue #94.
+  const passphrase = isEncryptedPrivateKeyPem(privateKeyPem)
+    ? await resolveKeyPassphrase()
+    : undefined
+
   // Create seal using identity slug (not display name) for verification lookup
   const seal = createSeal({
     gateId,
     fingerprint: fingerprintResult.fingerprint,
     sealedBy: identitySlug,
     privateKey: privateKeyPem,
+    ...(passphrase !== undefined && { passphrase }),
   })
 
   // Add seal to seals file

--- a/packages/cli/src/commands/team/add.ts
+++ b/packages/cli/src/commands/team/add.ts
@@ -1,11 +1,11 @@
 import { Command } from 'commander'
 import { input } from '@inquirer/prompts'
-import { log, success, error } from '../../utils/output.js'
+import { log, success } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
 import { getTheme } from '../../components/theme.js'
 import { writeFile } from 'node:fs/promises'
 import { stringify as stringifyYaml } from 'yaml'
-import { resolveOrPrompt, isInteractiveTTY } from '../../utils/prompts.js'
+import { resolveOrPrompt, isInteractiveTTY, handlePromptableError } from '../../utils/prompts.js'
 import { resolveGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
 
 interface AddOptions {
@@ -182,12 +182,7 @@ async function runAdd(options: AddOptions = {}): Promise<void> {
 
     log('')
   } catch (err) {
-    if (err instanceof Error) {
-      error(err.message)
-    } else {
-      error('Unknown error occurred')
-    }
-    process.exit(ExitCode.CONFIG_ERROR)
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
 }
 

--- a/packages/cli/src/commands/team/join.ts
+++ b/packages/cli/src/commands/team/join.ts
@@ -6,7 +6,7 @@ import { ExitCode } from '../../utils/exit-codes.js'
 import { getTheme } from '../../components/theme.js'
 import { writeFile } from 'node:fs/promises'
 import { stringify as stringifyYaml } from 'yaml'
-import { resolveOrPrompt } from '../../utils/prompts.js'
+import { resolveOrPrompt, handlePromptableError } from '../../utils/prompts.js'
 import { resolveGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
 
 interface JoinOptions {
@@ -132,11 +132,6 @@ export async function runJoin(options: JoinOptions = {}): Promise<void> {
 
     log('')
   } catch (err) {
-    if (err instanceof Error) {
-      error(err.message)
-    } else {
-      error('Unknown error occurred')
-    }
-    process.exit(ExitCode.CONFIG_ERROR)
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
 }

--- a/packages/cli/src/commands/team/remove.ts
+++ b/packages/cli/src/commands/team/remove.ts
@@ -3,6 +3,7 @@ import { confirm } from '@inquirer/prompts'
 import { readSealsSync, type PolicyConfig } from '@attest-it/core'
 import { log, success, error, warn } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
+import { handlePromptableError, resolveConfirmation } from '../../utils/prompts.js'
 import { getTheme } from '../../components/theme.js'
 import { writeFile } from 'node:fs/promises'
 import { stringify as stringifyYaml } from 'yaml'
@@ -18,8 +19,15 @@ export const removeCommand = new Command('remove')
 
 /**
  * Run the remove command to delete a team member.
+ *
+ * Non-interactive with `--force`: the confirmation resolves without
+ * prompting. Without `--force`, a closed/piped stdin fails fast naming
+ * `--force` instead of ever handing that stdin to the prompt library. See
+ * issue #94.
+ *
+ * @public
  */
-async function runRemove(slug: string, options: { force?: boolean }): Promise<void> {
+export async function runRemove(slug: string, options: { force?: boolean }): Promise<void> {
   try {
     const theme = getTheme()
 
@@ -91,17 +99,20 @@ async function runRemove(slug: string, options: { force?: boolean }): Promise<vo
       log('')
     }
 
-    // Confirm removal
-    if (!options.force) {
-      const confirmed = await confirm({
+    // Confirm removal. Gated behind "--force not supplied AND stdin is an
+    // interactive TTY": a closed or piped stdin without --force fails fast
+    // instead of ever handing that stdin to the prompt library, which either
+    // hangs or throws a raw, illegible error once stdin closes. See issue #94.
+    const confirmed = await resolveConfirmation(options.force, '--force', () =>
+      confirm({
         message: `Are you sure you want to remove "${slug}"?`,
         default: false,
-      })
+      }),
+    )
 
-      if (!confirmed) {
-        error('Removal cancelled')
-        process.exit(ExitCode.CANCELLED)
-      }
+    if (!confirmed) {
+      error('Removal cancelled')
+      process.exit(ExitCode.CANCELLED)
     }
 
     // Remove from team
@@ -130,11 +141,6 @@ async function runRemove(slug: string, options: { force?: boolean }): Promise<vo
     success(`Team member "${slug}" removed successfully`)
     log('')
   } catch (err) {
-    if (err instanceof Error) {
-      error(err.message)
-    } else {
-      error('Unknown error occurred')
-    }
-    process.exit(ExitCode.CONFIG_ERROR)
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
 }

--- a/packages/cli/src/utils/exit-codes.ts
+++ b/packages/cli/src/utils/exit-codes.ts
@@ -30,10 +30,9 @@ export const ExitCode = {
    * @remarks
    * Distinct from `CONFIG_ERROR`: a dirty working tree is a precondition
    * failure on an otherwise-valid configuration, not a problem with the
-   * configuration itself. Prior to this code's introduction, `run`/`seal`
-   * reused `CONFIG_ERROR` for this refusal, which made it indistinguishable
-   * from "no configuration found" to an automation/CI consumer. See issue
-   * #95.
+   * configuration itself. Prior to this code's introduction, `run` reused
+   * `CONFIG_ERROR` for this refusal, which made it indistinguishable from
+   * "no configuration found" to an automation/CI consumer. See issue #95.
    */
   DIRTY_WORKING_TREE: 6,
 } as const

--- a/packages/cli/src/utils/exit-codes.ts
+++ b/packages/cli/src/utils/exit-codes.ts
@@ -24,6 +24,18 @@ export const ExitCode = {
   CANCELLED: 4,
   /** Missing required key file */
   MISSING_KEY: 5,
+  /**
+   * Refused to proceed because the git working tree has uncommitted changes.
+   *
+   * @remarks
+   * Distinct from `CONFIG_ERROR`: a dirty working tree is a precondition
+   * failure on an otherwise-valid configuration, not a problem with the
+   * configuration itself. Prior to this code's introduction, `run`/`seal`
+   * reused `CONFIG_ERROR` for this refusal, which made it indistinguishable
+   * from "no configuration found" to an automation/CI consumer. See issue
+   * #95.
+   */
+  DIRTY_WORKING_TREE: 6,
 } as const
 
 /**

--- a/packages/cli/src/utils/passphrase.ts
+++ b/packages/cli/src/utils/passphrase.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared passphrase resolution for signing with a passphrase-encrypted
+ * file-backed private key (created via `identity create --storage file
+ * --passphrase-stdin`).
+ *
+ * Extracted from `run.ts` (issue #87) so `seal.ts` can share the exact same
+ * non-interactive-safe resolution instead of re-implementing it -- `seal` had
+ * no passphrase handling at all, so an encrypted key simply failed signing
+ * with no path to supply the passphrase. See issue #94.
+ */
+import { password } from '@inquirer/prompts'
+import { isInteractiveTTY } from './prompts.js'
+
+/** Env var read for the passphrase of an encrypted file-backed identity key. */
+const KEY_PASSPHRASE_ENV = 'ATTEST_IT_KEY_PASSPHRASE'
+
+/**
+ * Resolve the passphrase needed to sign with an encrypted file-backed
+ * private key.
+ *
+ * Order: the `ATTEST_IT_KEY_PASSPHRASE` env var, then (interactively) a
+ * masked prompt, then fail fast naming the env var -- this never hangs on a
+ * prompt that can never resolve. See issue #80.
+ *
+ * @returns The resolved passphrase
+ * @throws Error if non-interactive and the env var is not set
+ * @public
+ */
+export async function resolveKeyPassphrase(): Promise<string> {
+  const fromEnv = process.env[KEY_PASSPHRASE_ENV]
+  if (fromEnv !== undefined && fromEnv.length > 0) {
+    return fromEnv
+  }
+  if (isInteractiveTTY()) {
+    return password({
+      message: 'Passphrase for encrypted private key:',
+      validate: (value) => (value.length > 0 ? true : 'Passphrase cannot be empty'),
+    })
+  }
+  throw new Error(
+    `This identity's private key is passphrase-encrypted. Set ${KEY_PASSPHRASE_ENV} ` +
+      '(no interactive terminal available to prompt for it).',
+  )
+}

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1,5 +1,7 @@
 import { confirm } from '@inquirer/prompts'
 import { getTheme, BOX_CHARS } from '../components/theme.js'
+import { error, log } from './output.js'
+import { ExitCode } from './exit-codes.js'
 
 export interface ConfirmOptions {
   message: string
@@ -104,6 +106,96 @@ export async function resolveOptionalOrPrompt(
     return (await prompt()).trim()
   }
   return defaultValue
+}
+
+/**
+ * Resolve a yes/no confirmation that may already be supplied via a CLI flag.
+ *
+ * @remarks
+ * Mirrors {@link resolveOrPrompt}'s "flag, or interactive prompt, or fail
+ * fast" resolution order, specialized for confirmations: if `autoConfirm` is
+ * true, resolves to `true` without ever invoking `prompt`. Otherwise, if
+ * stdin is not an interactive TTY, throws naming `flagName` instead of
+ * invoking `prompt` -- every confirmation in the CLI must go through this (or
+ * an equivalent) gate, since handing a closed/piped stdin directly to
+ * `@inquirer/prompts` either hangs (a stream that never closes) or, once
+ * stdin closes, throws its raw `ExitPromptError` ("User force closed the
+ * prompt with 0 null"). See issue #94.
+ *
+ * @param autoConfirm - Already-resolved flag value (e.g. `--yes`); when true,
+ * `prompt` is never invoked
+ * @param flagName - The flag name to report in the fail-fast error (e.g. `--yes`)
+ * @param prompt - Callback that interactively collects the confirmation
+ * @returns Whether the action was confirmed
+ * @throws Error if not auto-confirmed and stdin is not an interactive TTY
+ * @public
+ */
+export async function resolveConfirmation(
+  autoConfirm: boolean | undefined,
+  flagName: string,
+  prompt: () => Promise<boolean>,
+): Promise<boolean> {
+  if (autoConfirm) {
+    return true
+  }
+  if (!isInteractiveTTY()) {
+    throw new Error(
+      `Refusing to proceed without ${flagName} (no interactive terminal available to confirm). ` +
+        `Pass ${flagName} to run non-interactively.`,
+    )
+  }
+  return prompt()
+}
+
+/**
+ * True when `err` is `@inquirer/core`'s signal for an interrupted or
+ * force-closed prompt -- Ctrl-C during an interactive prompt, or (the case
+ * that matters for automation) the process's stdin ending while a prompt is
+ * still awaiting input on it.
+ *
+ * @remarks
+ * Checked by `name` rather than `instanceof`: `@inquirer/core`'s
+ * `ExitPromptError` class is a transitive dependency (only `@inquirer/prompts`
+ * is declared directly), so it is not an importable type here.
+ *
+ * @param err - The caught error
+ * @returns Whether `err` represents a cancelled/force-closed prompt
+ * @public
+ */
+export function isPromptCancellation(err: unknown): boolean {
+  return err instanceof Error && err.name === 'ExitPromptError'
+}
+
+/**
+ * Standard top-level `catch` handler for a command whose action may run an
+ * interactive prompt.
+ *
+ * @remarks
+ * Before this fix, a force-closed/interrupted prompt fell through to each
+ * command's generic error handling, surfacing `@inquirer/core`'s raw message
+ * ("User force closed the prompt with 0 null") under whatever fallback exit
+ * code that command used -- even though the `CANCELLED` exit code exists
+ * specifically for this case. This normalizes that path to the same clean
+ * "Cancelled" message and `CANCELLED` exit code a declined confirmation
+ * already uses, everywhere a command can prompt. See issues #94/#95.
+ *
+ * @param err - The caught error
+ * @param fallbackExitCode - Exit code for a non-cancellation error (commands
+ * differ here, so this is not hardcoded)
+ * @public
+ */
+export function handlePromptableError(err: unknown, fallbackExitCode: ExitCode): never {
+  if (isPromptCancellation(err)) {
+    log('Cancelled')
+    process.exit(ExitCode.CANCELLED)
+  } else {
+    if (err instanceof Error) {
+      error(err.message)
+    } else {
+      error('Unknown error occurred')
+    }
+    process.exit(fallbackExitCode)
+  }
 }
 
 /** Coerce a stdin chunk (Buffer or string, per Node's stream typing) into a Buffer. */

--- a/packages/cli/test/exit-codes.test.ts
+++ b/packages/cli/test/exit-codes.test.ts
@@ -7,6 +7,14 @@
  * tables and pin every row to the real enum value, so the docs can't silently
  * drift from the implementation again.
  *
+ * Extended for #95: exit code 3 (`CONFIG_ERROR`) was overloaded across "no
+ * config found" (correct), a cancelled prompt (should be `CANCELLED`), and a
+ * dirty working tree (should be its own code). `CANCELLED` was already
+ * documented and is covered by the existing per-row pin below; the new
+ * `DIRTY_WORKING_TREE` code added for the dirty-tree case is covered the same
+ * way, and the row-count/enum-membership assertions below now require both
+ * to be present and correctly mapped.
+ *
  * @see ../src/utils/exit-codes.ts
  */
 import { describe, it, expect } from 'vitest'
@@ -42,7 +50,7 @@ function parseExitCodeTable(markdown: string): DocumentedRow[] {
 const EXIT_CODE_BY_NAME: Record<string, number> = ExitCode
 
 describe('exit-code documentation matches the ExitCode enum (#81)', () => {
-  it('the enum itself has the six documented members', () => {
+  it('the enum itself has the seven documented members', () => {
     expect(ExitCode).toStrictEqual({
       SUCCESS: 0,
       FAILURE: 1,
@@ -50,6 +58,7 @@ describe('exit-code documentation matches the ExitCode enum (#81)', () => {
       CONFIG_ERROR: 3,
       CANCELLED: 4,
       MISSING_KEY: 5,
+      DIRTY_WORKING_TREE: 6,
     })
   })
 
@@ -61,7 +70,7 @@ describe('exit-code documentation matches the ExitCode enum (#81)', () => {
     }
 
     const rows = parseExitCodeTable(section)
-    expect(rows.length).toBe(6)
+    expect(rows.length).toBe(7)
 
     for (const row of rows) {
       expect(EXIT_CODE_BY_NAME[row.constant], `documented constant "${row.constant}"`).toBe(
@@ -85,7 +94,7 @@ describe('exit-code documentation matches the ExitCode enum (#81)', () => {
     }
 
     const rows = parseExitCodeTable(section)
-    expect(rows.length).toBe(6)
+    expect(rows.length).toBe(7)
 
     for (const row of rows) {
       expect(EXIT_CODE_BY_NAME[row.constant], `documented constant "${row.constant}"`).toBe(
@@ -97,5 +106,19 @@ describe('exit-code documentation matches the ExitCode enum (#81)', () => {
     for (const name of Object.keys(ExitCode)) {
       expect(documentedNames.has(name), `enum member "${name}" documented`).toBe(true)
     }
+  })
+
+  it('CANCELLED (4) is distinct from CONFIG_ERROR (3) -- issue #95', () => {
+    // A cancelled prompt (declined or force-closed/interrupted) must never
+    // collapse onto the same code as "no configuration found".
+    expect(ExitCode.CANCELLED).toBe(4)
+    expect(ExitCode.CANCELLED).not.toBe(ExitCode.CONFIG_ERROR)
+  })
+
+  it('DIRTY_WORKING_TREE (6) is distinct from CONFIG_ERROR (3) -- issue #95', () => {
+    // A dirty working tree is a precondition failure on valid configuration,
+    // not a configuration error -- it must not share CONFIG_ERROR's code.
+    expect(ExitCode.DIRTY_WORKING_TREE).toBe(6)
+    expect(ExitCode.DIRTY_WORKING_TREE).not.toBe(ExitCode.CONFIG_ERROR)
   })
 })

--- a/packages/cli/test/identity-remove.test.ts
+++ b/packages/cli/test/identity-remove.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as os from 'node:os'
 import { unlink } from 'node:fs/promises'
 import type { LocalConfig } from '@attest-it/core'
+import { ExitCode } from '../src/utils/exit-codes.js'
 
 vi.mock('node:fs/promises', () => ({
   unlink: vi.fn().mockResolvedValue(undefined),
@@ -31,6 +32,9 @@ vi.mock('@attest-it/core', async () => {
 })
 
 const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {
+  // Intentionally empty
+})
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {
   // Intentionally empty
 })
 const mockProcessExit = vi
@@ -64,8 +68,20 @@ function mockLocalConfig(overrides?: Partial<LocalConfig>): LocalConfig {
 }
 
 describe('identity remove', () => {
-  beforeEach(() => vi.clearAllMocks())
-  afterEach(() => vi.clearAllMocks())
+  const originalIsTTY = process.stdin.isTTY
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Most of these tests exercise the interactive confirmation prompts,
+    // only reachable with an interactive TTY (see issue #94's TTY guard).
+    // The dedicated non-interactive describe blocks below override this
+    // per-test.
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
 
   it('resolves a leading ~ in a legacy filesystem key path before deleting it', async () => {
     vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
@@ -96,5 +112,82 @@ describe('identity remove', () => {
 
     expect(unlink).not.toHaveBeenCalled()
     expect(saveLocalConfig).toHaveBeenCalled()
+  })
+})
+
+// Regression coverage for issue #94: `identity remove` had no non-interactive
+// flag at all, and handing a closed/piped stdin directly to `confirm()`
+// either hung (an unclosed pipe) or produced a ~20MB runaway
+// terminal-escape-code render loop (a pipe that does close, e.g. `yes |`).
+describe('identity remove — non-interactive (--yes) (issue #94)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('removes non-interactively with --yes, never invoking the prompt library', async () => {
+    vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
+
+    await runRemove('bob', { yes: true })
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(unlink).not.toHaveBeenCalled() // --delete-key not given: safer default
+    expect(saveLocalConfig).toHaveBeenCalled()
+    expect(mockProcessExit).not.toHaveBeenCalled()
+  })
+
+  it('--yes with --delete-key also deletes the private key file, still without prompting', async () => {
+    vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
+
+    await runRemove('bob', { yes: true, deleteKey: true })
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(unlink).toHaveBeenCalledWith('/tmp/bob.pem')
+  })
+
+  it(
+    'fails fast naming --yes when no flag is given and stdin is not a TTY ' +
+      '(never invokes the prompt library, bounded output)',
+    async () => {
+      vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
+
+      await runRemove('bob')
+
+      expect(confirm).not.toHaveBeenCalled()
+      expect(unlink).not.toHaveBeenCalled()
+      expect(saveLocalConfig).not.toHaveBeenCalled()
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--yes'))
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+    },
+  )
+})
+
+// Regression coverage for issue #95: exit code 3 (CONFIG_ERROR) was
+// overloaded to also cover a force-closed/interrupted prompt, surfacing
+// @inquirer/core's raw "User force closed the prompt with 0 null" message.
+describe('identity remove — cancelled prompt maps to CANCELLED, not CONFIG_ERROR (issue #95)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps a force-closed prompt to a clean "Cancelled" message and exit code 4', async () => {
+    vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
+    const rawInquirerMessage = 'User force closed the prompt with 0 null'
+    const exitPromptError = new Error(rawInquirerMessage)
+    exitPromptError.name = 'ExitPromptError'
+    vi.mocked(confirm).mockRejectedValueOnce(exitPromptError)
+
+    await runRemove('bob')
+
+    expect(mockConsoleLog).toHaveBeenCalledWith('Cancelled')
+    expect(mockConsoleError).not.toHaveBeenCalledWith(expect.stringContaining(rawInquirerMessage))
+    expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CANCELLED)
   })
 })

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -27,10 +27,18 @@ vi.mock('node:fs', async () => {
 // to exercise the interactive overwrite-confirmation prompt unchanged; the
 // dedicated 'non-interactive guard' describe block below overrides it with
 // mockReturnValue(false) to exercise the fail-fast path from issue #80.
-vi.mock('../src/utils/prompts.js', () => ({
-  confirmAction: vi.fn(),
-  isInteractiveTTY: vi.fn(() => true),
-}))
+// handlePromptableError is left as the real implementation (via
+// importActual) -- it doesn't depend on isInteractiveTTY/confirmAction, and
+// tests rely on it actually calling the (separately mocked) process.exit.
+vi.mock('../src/utils/prompts.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/utils/prompts.js')>('../src/utils/prompts.js')
+  return {
+    ...actual,
+    confirmAction: vi.fn(),
+    isInteractiveTTY: vi.fn(() => true),
+  }
+})
 
 // Mock completion offer (no-op in tests)
 vi.mock('../src/utils/completion-offer.js', () => ({

--- a/packages/cli/test/integration/cli.integration.test.ts
+++ b/packages/cli/test/integration/cli.integration.test.ts
@@ -447,7 +447,9 @@ describe('CLI Integration Tests', () => {
 
       // Use --no-attest since attestation signing isn't the focus of this test
       const result = await runCli(['run', '--suite', 'example', '--no-attest'], tempDir)
-      expect(result.exitCode).toBe(3) // CONFIG_ERROR
+      // DIRTY_WORKING_TREE (6) -- distinct from CONFIG_ERROR (3): a dirty tree
+      // is a precondition failure, not a configuration problem. See issue #95.
+      expect(result.exitCode).toBe(6)
       expect(result.stderr).toContain('uncommitted')
     })
   })

--- a/packages/cli/test/integration/non-interactive-setup.integration.test.ts
+++ b/packages/cli/test/integration/non-interactive-setup.integration.test.ts
@@ -85,6 +85,77 @@ function runCliNonInteractive(
   })
 }
 
+/**
+ * Result of {@link runCliWithPipedYes}: `killed` distinguishes "exited on its
+ * own" from "the test's safety-net timeout had to SIGKILL it" -- the whole
+ * point of the regression this guards against (issue #94) is that the
+ * process must exit on its own well before any external timeout.
+ */
+interface PipedYesResult extends RunResult {
+  killed: boolean
+}
+
+/**
+ * Run the built CLI with its stdin fed by a real, continuously-producing
+ * `yes` process -- the exact scenario issue #94 reports: piping infinite
+ * input into a command with no non-interactive flag caused `@inquirer/core`'s
+ * readline-based prompt to enter an unbounded (~20MB) terminal-escape-code
+ * render loop that never exited on its own. A hard timeout kills both
+ * processes as a safety net if the regression reappears, but the assertions
+ * that matter are that the CLI exits on its own (`killed: false`) with a
+ * small, bounded amount of output.
+ */
+function runCliWithPipedYes(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<PipedYesResult> {
+  return new Promise((resolve, reject) => {
+    const yesProc = spawn('yes', [], { stdio: ['ignore', 'pipe', 'ignore'] })
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    // The whole point of this regression guard is that the CLI exits (and
+    // closes its stdin) almost immediately, well before `yes` stops
+    // producing output -- `yes` writing into that now-closed pipe raises
+    // EPIPE, which must be swallowed rather than left to crash the test
+    // process as an unhandled exception.
+    child.stdin.on('error', () => undefined)
+    yesProc.stdout.on('error', () => undefined)
+    yesProc.stdout.pipe(child.stdin)
+
+    let stdout = ''
+    let stderr = ''
+    let killed = false
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      killed = true
+      child.kill('SIGKILL')
+      yesProc.kill('SIGKILL')
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      yesProc.kill('SIGKILL')
+      resolve({ exitCode: code ?? 1, stdout, stderr, killed })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      yesProc.kill('SIGKILL')
+      reject(err)
+    })
+  })
+}
+
 async function runGit(args: string[], cwd: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn('git', args, { cwd, stdio: 'ignore' })
@@ -319,4 +390,86 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
     },
     CLI_CALL_TIMEOUT_MS * 2,
   )
+
+  describe('identity remove headless operation (issue #94)', () => {
+    it(
+      'removes an identity non-interactively with --yes and closed stdin',
+      async () => {
+        const env = { ATTEST_IT_HOME: homeDir }
+        await runCliNonInteractive(
+          ['identity', 'create', '--name', 'A', '--slug', 'a', '--storage', 'file'],
+          projectDir,
+          env,
+        )
+        await runCliNonInteractive(
+          ['identity', 'create', '--name', 'B', '--slug', 'b', '--storage', 'file'],
+          projectDir,
+          env,
+        )
+
+        const result = await runCliNonInteractive(
+          ['identity', 'remove', 'b', '--yes'],
+          projectDir,
+          env,
+        )
+
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout).toContain('removed')
+      },
+      CLI_CALL_TIMEOUT_MS * 3,
+    )
+
+    it(
+      'fails fast (never hangs) when identity remove is given no --yes with no TTY',
+      async () => {
+        const env = { ATTEST_IT_HOME: homeDir }
+        await runCliNonInteractive(
+          ['identity', 'create', '--name', 'A', '--slug', 'a', '--storage', 'file'],
+          projectDir,
+          env,
+        )
+        await runCliNonInteractive(
+          ['identity', 'create', '--name', 'B', '--slug', 'b', '--storage', 'file'],
+          projectDir,
+          env,
+        )
+
+        const result = await runCliNonInteractive(['identity', 'remove', 'b'], projectDir, env)
+
+        expect(result.exitCode).not.toBe(0)
+        expect(result.stderr).toMatch(/--yes/)
+      },
+      CLI_CALL_TIMEOUT_MS * 3,
+    )
+
+    it(
+      'never enters the runaway prompt-render loop when stdin is piped from `yes`, ' +
+        'and produces bounded output',
+      async () => {
+        const env = { ATTEST_IT_HOME: homeDir }
+        await runCliNonInteractive(
+          ['identity', 'create', '--name', 'A', '--slug', 'a', '--storage', 'file'],
+          projectDir,
+          env,
+        )
+        await runCliNonInteractive(
+          ['identity', 'create', '--name', 'B', '--slug', 'b', '--storage', 'file'],
+          projectDir,
+          env,
+        )
+
+        const result = await runCliWithPipedYes(['identity', 'remove', 'b'], projectDir, env)
+
+        // Regression guard: prior to the fix, a piped `yes` with no --yes flag
+        // caused an unbounded (~20MB) terminal-escape-code render loop that
+        // never exited on its own -- this asserts the process exits by itself
+        // (never needed the safety-net SIGKILL) with a small, bounded amount
+        // of combined output.
+        expect(result.killed).toBe(false)
+        expect(result.exitCode).not.toBe(0)
+        expect(result.stdout.length + result.stderr.length).toBeLessThan(10_000)
+      },
+      CLI_CALL_TIMEOUT_MS,
+    )
+  })
 })

--- a/packages/cli/test/integration/non-interactive-setup.integration.test.ts
+++ b/packages/cli/test/integration/non-interactive-setup.integration.test.ts
@@ -44,7 +44,7 @@ function runCliNonInteractive(
   env: NodeJS.ProcessEnv = {},
 ): Promise<RunResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn('node', [CLI_PATH, ...args], {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
       cwd,
       env: { ...process.env, NO_COLOR: '1', ...env },
       // stdin: 'ignore' is Node's equivalent of `< /dev/null` -- there is
@@ -112,7 +112,7 @@ function runCliWithPipedYes(
 ): Promise<PipedYesResult> {
   return new Promise((resolve, reject) => {
     const yesProc = spawn('yes', [], { stdio: ['ignore', 'pipe', 'ignore'] })
-    const child = spawn('node', [CLI_PATH, ...args], {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
       cwd,
       env: { ...process.env, NO_COLOR: '1', ...env },
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/cli/test/prompts.test.ts
+++ b/packages/cli/test/prompts.test.ts
@@ -2,14 +2,24 @@
  * Tests for the non-interactive setup helpers (issue #80): every CLI prompt
  * must be gated behind "flag not supplied AND stdin is an interactive TTY",
  * failing fast with a legible error instead of hanging when it is not.
+ *
+ * Also covers issues #94/#95: `resolveConfirmation` (the shared guard behind
+ * every yes/no confirmation) and `handlePromptableError`/
+ * `isPromptCancellation` (mapping a cancelled/force-closed prompt to the
+ * `CANCELLED` exit code with a clean message instead of `@inquirer/core`'s
+ * raw error under whatever fallback code a command uses).
  */
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   isInteractiveTTY,
   resolveOrPrompt,
   resolveOptionalOrPrompt,
+  resolveConfirmation,
+  isPromptCancellation,
+  handlePromptableError,
   readStdin,
 } from '../src/utils/prompts.js'
+import { ExitCode } from '../src/utils/exit-codes.js'
 import { Readable } from 'node:stream'
 
 describe('isInteractiveTTY', () => {
@@ -152,5 +162,109 @@ describe('readStdin', () => {
   it('should only trim one trailing newline, preserving internal newlines', async () => {
     const result = await withFakeStdin('line1\nline2\n', () => readStdin())
     expect(result).toBe('line1\nline2')
+  })
+})
+
+describe('resolveConfirmation (issue #94)', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  it('resolves to true without invoking the prompt when autoConfirm is true', async () => {
+    const prompt = vi.fn().mockResolvedValue(false)
+
+    const result = await resolveConfirmation(true, '--yes', prompt)
+
+    expect(result).toBe(true)
+    expect(prompt).not.toHaveBeenCalled()
+  })
+
+  it('invokes the prompt when autoConfirm is falsy and stdin is an interactive TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    const prompt = vi.fn().mockResolvedValue(true)
+
+    const result = await resolveConfirmation(undefined, '--yes', prompt)
+
+    expect(result).toBe(true)
+    expect(prompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws naming the flag when autoConfirm is falsy and stdin is not a TTY (never hangs)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    const prompt = vi.fn().mockResolvedValue(true)
+
+    await expect(resolveConfirmation(undefined, '--yes', prompt)).rejects.toThrow('--yes')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+
+  it('treats an explicit false autoConfirm the same as undefined (still gated by TTY)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    const prompt = vi.fn().mockResolvedValue(true)
+
+    await expect(resolveConfirmation(false, '--force', prompt)).rejects.toThrow('--force')
+    expect(prompt).not.toHaveBeenCalled()
+  })
+})
+
+describe('isPromptCancellation (issue #95)', () => {
+  it('returns true for an error named ExitPromptError', () => {
+    const err = new Error('User force closed the prompt with 0 null')
+    err.name = 'ExitPromptError'
+    expect(isPromptCancellation(err)).toBe(true)
+  })
+
+  it('returns false for a plain Error', () => {
+    expect(isPromptCancellation(new Error('some other failure'))).toBe(false)
+  })
+
+  it('returns false for a non-Error thrown value', () => {
+    expect(isPromptCancellation('a string error')).toBe(false)
+    expect(isPromptCancellation(undefined)).toBe(false)
+    expect(isPromptCancellation(null)).toBe(false)
+  })
+})
+
+describe('handlePromptableError (issue #95)', () => {
+  const mockProcessExit = vi
+    .spyOn(process, 'exit')
+    // @ts-expect-error - Mocking process.exit which has a complex signature
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    .mockImplementation(() => {})
+  const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps a cancelled/force-closed prompt to a clean "Cancelled" message and CANCELLED, ignoring the fallback code', () => {
+    const rawMessage = 'User force closed the prompt with 0 null'
+    const err = new Error(rawMessage)
+    err.name = 'ExitPromptError'
+
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
+
+    expect(mockConsoleLog).toHaveBeenCalledWith('Cancelled')
+    expect(mockConsoleError).not.toHaveBeenCalled()
+    expect(mockProcessExit).toHaveBeenCalledTimes(1)
+    expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CANCELLED)
+  })
+
+  it('reports a plain Error message under the given fallback exit code', () => {
+    handlePromptableError(new Error('boom'), ExitCode.CONFIG_ERROR)
+
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('boom'))
+    expect(mockConsoleLog).not.toHaveBeenCalledWith('Cancelled')
+    expect(mockProcessExit).toHaveBeenCalledTimes(1)
+    expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+  })
+
+  it('reports a generic message for a non-Error thrown value under the fallback exit code', () => {
+    handlePromptableError('a string throw', ExitCode.FAILURE)
+
+    expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('Unknown error'))
+    expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.FAILURE)
   })
 })

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -4,8 +4,8 @@ import {
   parseCommand,
   executeCommand,
   checkDirtyWorkingTree,
-  resolveKeyPassphrase,
 } from '../src/commands/run.js'
+import { resolveKeyPassphrase } from '../src/utils/passphrase.js'
 import type { Config } from '@attest-it/core'
 import type { ChildProcess } from 'node:child_process'
 
@@ -38,11 +38,18 @@ vi.mock('../src/utils/output.js', () => ({
   info: vi.fn(),
 }))
 
-// Mock prompts
-vi.mock('../src/utils/prompts.js', () => ({
-  confirmAction: vi.fn(),
-  isInteractiveTTY: vi.fn(() => false),
-}))
+// Mock prompts. handlePromptableError is left as the real implementation
+// (via importActual) -- it doesn't depend on isInteractiveTTY/confirmAction,
+// and nothing here should silently swallow a call to it.
+vi.mock('../src/utils/prompts.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/utils/prompts.js')>('../src/utils/prompts.js')
+  return {
+    ...actual,
+    confirmAction: vi.fn(),
+    isInteractiveTTY: vi.fn(() => false),
+  }
+})
 
 // Mock @inquirer/prompts' password() -- used to prompt for an encrypted
 // identity key's passphrase interactively (issue #80)

--- a/packages/cli/test/seal.test.ts
+++ b/packages/cli/test/seal.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import type { AttestItConfig, Identity, LocalConfig } from '@attest-it/core'
+import type { AttestItConfig, Identity, LocalConfig, Seal } from '@attest-it/core'
 
 vi.mock('@attest-it/core', async () => {
   const actual = await vi.importActual<typeof import('@attest-it/core')>('@attest-it/core')
@@ -20,8 +20,28 @@ vi.mock('@attest-it/core', async () => {
     readSealsSync: vi.fn(),
     writeSealsSync: vi.fn(),
     verifyGateSeal: vi.fn(),
+    isEncryptedPrivateKeyPem: vi.fn(),
+    createSeal: vi.fn(),
+    KeyProviderRegistry: { create: vi.fn() },
   }
 })
+
+// node:fs/promises.readFile is used to read the resolved key file's PEM
+// content before signing -- mocked so the encrypted-key passphrase tests
+// don't need a real file on disk.
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}))
+
+// @inquirer/prompts' password() -- used to prompt for an encrypted identity
+// key's passphrase interactively (shared with `run`, issue #94).
+vi.mock('@inquirer/prompts', () => ({
+  password: vi.fn(),
+}))
+
+vi.mock('../src/utils/prompts.js', () => ({
+  isInteractiveTTY: vi.fn(() => false),
+}))
 
 const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {
   // Intentionally empty
@@ -45,7 +65,13 @@ const {
   readSealsSync,
   writeSealsSync,
   verifyGateSeal,
+  isEncryptedPrivateKeyPem,
+  createSeal,
+  KeyProviderRegistry,
 } = await import('@attest-it/core')
+const { readFile } = await import('node:fs/promises')
+const { password } = await import('@inquirer/prompts')
+const { isInteractiveTTY } = await import('../src/utils/prompts.js')
 const { runSeal } = await import('../src/commands/seal.js')
 
 function mockConfig(): AttestItConfig {
@@ -223,5 +249,129 @@ describe('seal --json', () => {
     // The human error() path must not be used on the --json surface.
     expect(mockConsoleError).not.toHaveBeenCalled()
     expect(mockProcessExit).toHaveBeenCalledWith(3)
+  })
+})
+
+// Regression coverage for issue #94: `seal` read a private key's raw PEM and
+// signed with it directly, with no passphrase handling at all -- so a
+// passphrase-encrypted file-backed key (created via `identity create
+// --passphrase-stdin`) simply failed to sign. `run`'s seal-creation path
+// already resolved this in #87; `seal` now shares that same
+// non-interactive-safe resolution (env var -> interactive prompt -> fail
+// fast) via `resolveKeyPassphrase`.
+describe('seal — encrypted private key passphrase (issue #94)', () => {
+  const PASSPHRASE_ENV = 'ATTEST_IT_KEY_PASSPHRASE'
+  const originalEnvValue = process.env[PASSPHRASE_ENV]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env[PASSPHRASE_ENV]
+    vi.mocked(isInteractiveTTY).mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    if (originalEnvValue === undefined) {
+      delete process.env[PASSPHRASE_ENV]
+    } else {
+      process.env[PASSPHRASE_ENV] = originalEnvValue
+    }
+  })
+
+  /** Wire up everything `processSingleGate` needs to reach the signing step. */
+  function setupSigningMocks(): AttestItConfig {
+    const config = mockConfig()
+    vi.mocked(loadSplitConfig).mockResolvedValue(config)
+    vi.mocked(loadLocalConfigSync).mockReturnValue(mockLocalConfig('alice'))
+    vi.mocked(getActiveIdentity).mockReturnValue(mockIdentity('alice'))
+    vi.mocked(readSealsSync).mockReturnValue({ version: 1, seals: {} })
+    vi.mocked(getGate).mockReturnValue(config.gates?.['test-gate'])
+    vi.mocked(computeFingerprintSync).mockReturnValue({
+      fingerprint: 'sha256:abc',
+      fileCount: 1,
+      files: [],
+    })
+    vi.mocked(isAuthorizedSigner).mockReturnValue(true)
+    vi.mocked(KeyProviderRegistry.create).mockReturnValue({
+      getPrivateKey: vi.fn().mockResolvedValue({ keyPath: '/tmp/key.pem', cleanup: vi.fn() }),
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal test double
+    } as unknown as ReturnType<typeof KeyProviderRegistry.create>)
+    vi.mocked(readFile).mockResolvedValue(
+      '-----BEGIN ENCRYPTED PRIVATE KEY-----\nfake\n-----END ENCRYPTED PRIVATE KEY-----\n',
+    )
+    return config
+  }
+
+  function fakeSeal(): Seal {
+    return {
+      gateId: 'test-gate',
+      fingerprint: 'sha256:abc',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      sealedBy: 'alice',
+      signature: 'sig',
+    }
+  }
+
+  it('resolves the passphrase from ATTEST_IT_KEY_PASSPHRASE and signs without prompting', async () => {
+    setupSigningMocks()
+    process.env[PASSPHRASE_ENV] = 'env-secret'
+    vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(true)
+    vi.mocked(createSeal).mockReturnValue(fakeSeal())
+
+    await runSeal(['test-gate'], { json: true })
+
+    expect(createSeal).toHaveBeenCalledWith(expect.objectContaining({ passphrase: 'env-secret' }))
+    expect(password).not.toHaveBeenCalled()
+    expect(mockProcessExit).toHaveBeenCalledWith(0)
+  })
+
+  it('does not resolve or pass a passphrase for an unencrypted key', async () => {
+    setupSigningMocks()
+    vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(false)
+    vi.mocked(createSeal).mockReturnValue(fakeSeal())
+
+    await runSeal(['test-gate'], { json: true })
+
+    expect(createSeal).toHaveBeenCalledTimes(1)
+    const [options] = vi.mocked(createSeal).mock.calls[0] ?? []
+    expect(options).not.toHaveProperty('passphrase')
+    expect(password).not.toHaveBeenCalled()
+  })
+
+  it(
+    'fails fast (does not hang) when the key is encrypted, the env var is unset, ' +
+      'and stdin is not a TTY',
+    async () => {
+      setupSigningMocks()
+      vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(true)
+
+      await runSeal(['test-gate'], { json: true })
+
+      // Never invokes the prompt library, and never signs.
+      expect(password).not.toHaveBeenCalled()
+      expect(createSeal).not.toHaveBeenCalled()
+
+      const printed = mockConsoleLog.mock.calls.map((c) => String(c[0])).join('\n')
+      expect(printed).toContain('passphrase-encrypted')
+      expect(printed).toContain(PASSPHRASE_ENV)
+      // The failure is scoped to this gate (summary.failed), not a hang and
+      // not CONFIG_ERROR -- it surfaces as FAILURE (1).
+      expect(mockProcessExit).toHaveBeenCalledWith(1)
+    },
+  )
+
+  it('prompts interactively for the passphrase when the env var is unset and stdin is a TTY', async () => {
+    setupSigningMocks()
+    vi.mocked(isInteractiveTTY).mockReturnValue(true)
+    vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(true)
+    vi.mocked(password).mockResolvedValue('prompted-secret')
+    vi.mocked(createSeal).mockReturnValue(fakeSeal())
+
+    await runSeal(['test-gate'], { json: true })
+
+    expect(password).toHaveBeenCalledTimes(1)
+    expect(createSeal).toHaveBeenCalledWith(
+      expect.objectContaining({ passphrase: 'prompted-secret' }),
+    )
   })
 })

--- a/packages/cli/test/team-remove.test.ts
+++ b/packages/cli/test/team-remove.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for `team remove`'s non-interactive flag and cancellation handling
+ * (issues #94/#95).
+ *
+ * Regression: unlike `team add`/`join`, `team remove` already had a `--force`
+ * flag, but the confirmation prompt below it called `confirm()` directly
+ * whenever `--force` was omitted -- with no check that stdin was actually an
+ * interactive TTY. A closed/piped stdin without `--force` either hung or
+ * produced a runaway render loop, the exact class of bug #94 fixed for
+ * `identity remove`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { runRemove } from '../src/commands/team/remove.js'
+import * as core from '@attest-it/core'
+import type { PolicyConfig } from '@attest-it/core'
+import * as fs from 'node:fs/promises'
+import * as prompts from '@inquirer/prompts'
+import { ExitCode } from '../src/utils/exit-codes.js'
+
+vi.mock('@attest-it/core', async () => {
+  const actual = await vi.importActual<typeof import('@attest-it/core')>('@attest-it/core')
+  return {
+    ...actual,
+    findPolicyPath: vi.fn(),
+    parsePolicyContent: vi.fn(),
+    readSealsSync: vi.fn(),
+  }
+})
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => ''),
+}))
+
+vi.mock('@inquirer/prompts', () => ({
+  confirm: vi.fn(),
+}))
+
+const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+const mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+  throw new Error('process.exit called')
+})
+
+function mockPolicy(policy: PolicyConfig, path = '/test/policy.yaml'): void {
+  vi.mocked(core.findPolicyPath).mockReturnValue(path)
+  vi.mocked(core.parsePolicyContent).mockReturnValue(policy)
+}
+
+const BASE_POLICY: PolicyConfig = {
+  version: 1,
+  settings: {
+    maxAgeDays: 30,
+    publicKeyPath: '.attest-it/pubkey.pem',
+    attestationsPath: '.attest-it/attestations.json',
+    sealsPath: '.attest-it/seals.json',
+  },
+  team: {
+    alice: { name: 'Alice', publicKey: 'pk-alice', publicKeyAlgorithm: 'ed25519' },
+  },
+  gates: {},
+}
+
+describe('team remove command', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  beforeEach(() => {
+    mockConsoleLog.mockClear()
+    mockConsoleError.mockClear()
+    mockProcessExit.mockClear()
+    vi.clearAllMocks()
+    mockPolicy(structuredClone(BASE_POLICY))
+    vi.mocked(core.readSealsSync).mockReturnValue({ version: 1, seals: {} })
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+  })
+
+  it('removes the member after an interactive confirmation', async () => {
+    vi.mocked(prompts.confirm).mockResolvedValue(true)
+
+    await runRemove('alice', {})
+
+    expect(fs.writeFile).toHaveBeenCalled()
+    expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('removed successfully'))
+  })
+
+  it('exits CANCELLED (not CONFIG_ERROR) when the user declines', async () => {
+    vi.mocked(prompts.confirm).mockResolvedValue(false)
+
+    await expect(runRemove('alice', {})).rejects.toThrow('process.exit called')
+
+    expect(fs.writeFile).not.toHaveBeenCalled()
+    expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CANCELLED)
+  })
+
+  describe('non-interactive (--force) (issue #94)', () => {
+    beforeEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    })
+
+    it('removes non-interactively with --force, never invoking the prompt library', async () => {
+      await runRemove('alice', { force: true })
+
+      expect(prompts.confirm).not.toHaveBeenCalled()
+      expect(fs.writeFile).toHaveBeenCalled()
+    })
+
+    it(
+      'fails fast naming --force when no flag is given and stdin is not a TTY ' +
+        '(never invokes the prompt library)',
+      async () => {
+        await expect(runRemove('alice', {})).rejects.toThrow('process.exit called')
+
+        expect(prompts.confirm).not.toHaveBeenCalled()
+        expect(fs.writeFile).not.toHaveBeenCalled()
+        expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--force'))
+        expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+      },
+    )
+  })
+
+  describe('cancelled prompt maps to CANCELLED, not CONFIG_ERROR (issue #95)', () => {
+    it('maps a force-closed prompt to a clean message and exit code 4', async () => {
+      const exitPromptError = new Error('User force closed the prompt with 0 null')
+      exitPromptError.name = 'ExitPromptError'
+      vi.mocked(prompts.confirm).mockRejectedValueOnce(exitPromptError)
+
+      await expect(runRemove('alice', {})).rejects.toThrow('process.exit called')
+
+      expect(mockConsoleLog).toHaveBeenCalledWith('Cancelled')
+      expect(mockConsoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining('force closed the prompt'),
+      )
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CANCELLED)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes the two remaining gaps a fresh-eyes DX evaluation surfaced in the non-interactive/exit-code contract established by #80/#81/#87.

**Refs #94** — `identity remove` had no `--yes`/non-interactive flag at all, and handing a closed/piped stdin directly to the interactive prompt library either hung indefinitely or (with `yes | ...`) produced an unbounded ~20MB terminal-escape-code render loop that never exited on its own — a genuine hang/DoS risk in CI or agent automation. `team remove` had the identical gap despite already having `--force` (it called `confirm()` unconditionally whenever `--force` was omitted, with no TTY check). `seal` had no passphrase handling at all for encrypted file-backed keys, so it simply failed to sign them.

**Refs #95** — exit code 3 (`CONFIG_ERROR`) was overloaded across three different conditions: no config found (correct), a dirty working tree (wrong), and a cancelled prompt (wrong — the enum already defines `CANCELLED = 4` for exactly this, but it wasn't wired up for the cancellation path).

## What changed

- **`packages/cli/src/utils/prompts.ts`**: added `resolveConfirmation(autoConfirm, flagName, prompt)` — the shared guard behind every yes/no confirmation (mirrors the existing `resolveOrPrompt` pattern): resolves to `true` without prompting when the flag is already supplied, fails fast naming the flag when stdin isn't an interactive TTY, otherwise prompts. Also added `isPromptCancellation`/`handlePromptableError`, which map `@inquirer/core`'s `ExitPromptError` (raised on Ctrl-C, or when stdin closes mid-prompt) to a clean `"Cancelled"` message and the `CANCELLED` exit code, replacing the raw `User force closed the prompt with 0 null` text that used to fall through to each command's generic `CONFIG_ERROR` handling.
- **`identity remove`**: new `-y, --yes` flag (skips both confirmations) and `--delete-key` flag (opt-in; `--yes` alone does *not* imply deleting the private key — that's the more destructive of the two actions).
- **`team remove`**: existing `--force` flag now actually gates the TTY check (previously it only skipped the confirmation's *decision*, not the *prompt-library invocation itself* — the same class of bug as `identity remove`).
- **`init`, `identity create`, `team add`/`join`, `run`**: catch blocks now route through `handlePromptableError` so a cancelled/force-closed prompt maps to `CANCELLED` everywhere a prompt can be cancelled, not just in `identity remove`/`team remove`.
- **`seal`**: gained the same passphrase resolution `run` already had for `identity create --passphrase-stdin`-encrypted keys (env var → interactive prompt → fail fast). Extracted into `packages/cli/src/utils/passphrase.ts` so both commands share one implementation instead of `seal` re-implementing it.
- **`packages/cli/src/utils/exit-codes.ts`**: added `DIRTY_WORKING_TREE: 6`. `run`'s two dirty-working-tree refusals (`--suite` and `--all` mode) now exit this code instead of `CONFIG_ERROR`. (Note: `seal` has no dirty-tree check at all today — only `run` does — so nothing changed there; worth a follow-up if that gap matters.)
- **Docs**: `AI_ASSISTANT_GUIDE.md` and `docs/configuration.md` exit-code tables updated with the new code and the corrected cancellation mapping; the existing docs-pin test (`exit-codes.test.ts`, from #81) extended to 7 rows and given two new dedicated regression tests asserting `CANCELLED`/`DIRTY_WORKING_TREE` are distinct from `CONFIG_ERROR`.

### Exit-code decision

Dirty-working-tree gets a **new dedicated code** (`DIRTY_WORKING_TREE = 6`) rather than reusing `FAILURE`/`NO_WORK` — it's a precondition failure on an otherwise-valid configuration (not "tests failed" and not "nothing to do"), and automation needs to distinguish it from both.

## Criteria → test mapping

| Acceptance criterion | Test |
|---|---|
| `identity remove --yes` completes headlessly, no prompt | `identity-remove.test.ts` (non-interactive describe block); `non-interactive-setup.integration.test.ts` ("removes an identity non-interactively with --yes") |
| No flag + non-TTY fails fast, never hangs | `identity-remove.test.ts`; `non-interactive-setup.integration.test.ts` ("fails fast ... when identity remove is given no --yes") |
| Runaway render loop is fixed (bounded output) | `non-interactive-setup.integration.test.ts` ("never enters the runaway prompt-render loop when stdin is piped from `yes`") — pipes a real `yes` process into the built CLI and asserts it exits on its own (not via the safety-net `SIGKILL`) with combined output under 10KB |
| Cancelled prompt → clean message + `CANCELLED` (4) | `prompts.test.ts` (`handlePromptableError`); `identity-remove.test.ts`; `team-remove.test.ts` |
| Dirty tree → distinct, documented code | `exit-codes.test.ts`; `cli.integration.test.ts` ("fails on dirty working tree" now asserts `6`) |
| No-config stays `CONFIG_ERROR` (3) | unchanged, existing coverage in `cli.integration.test.ts`/`exit-codes.test.ts` |
| `seal` non-interactive passphrase handling | `seal.test.ts` (new "encrypted private key passphrase" describe block: env var resolves without prompting, unencrypted key never resolves one, non-TTY without env var fails fast, interactive TTY prompts) |

## Manual verification

Ran the exact regression scenario against the built CLI directly (not just the automated test):

```
$ yes | timeout 5 node dist/bin/attest-it.js identity remove b
Remove Identity: b
  Name:  B
✗ Refusing to proceed without --yes (no interactive terminal available to confirm). Pass --yes to run non-interactively.
# exits in 0.276s, 156 bytes of output (was: never exits, ~20MB of escape codes)

$ yes | timeout 5 node dist/bin/attest-it.js identity remove b --yes
✓ Identity "b" removed
# exits in 0.271s, clean
```

## Test plan

- [x] `pnpm build && pnpm check && pnpm test` all green (768 CLI tests + 539 core tests; no OpenSSL-related failures observed in this environment)
- [x] `pnpm exec eslint src` clean (0 errors; only pre-existing `security/detect-object-injection` warnings)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec knip` clean
- [x] Manual verification against the built CLI (above)
- [x] Changeset added (`@attest-it/cli` + `attest-it` minor, exit-code remapping called out prominently)