### PR TITLE
fix: identity remove deletes VaultKeeper secret instead of orphaning it

### DIFF
--- a/.changeset/fix-identity-remove-orphaned-vaultkeeper-secret.md
+++ b/.changeset/fix-identity-remove-orphaned-vaultkeeper-secret.md
@@ -1,0 +1,20 @@
+---
+'@attest-it/cli': minor
+'@attest-it/core': minor
+'attest-it': minor
+---
+
+**Fixed `identity remove` leaving orphaned private-key material in VaultKeeper (security P1, issue #101).**
+
+`identity remove <slug>` previously reported `✓ Identity "<slug>" removed` and exited `0` without
+deleting the underlying VaultKeeper-backed secret -- only the `config.yaml` entry was removed, so
+the encrypted private-key `.enc` file stayed on disk indefinitely.
+
+- `identity remove` now deletes the private key by default for backends attest-it exclusively
+  owns (`file`, and the legacy `filesystem` type). A new `--keep-key` flag opts out and leaves the
+  key material in place; this replaces the previous opt-in `--delete-key` flag, which is removed.
+- For backends attest-it does not delete from unilaterally (`1password`, macOS `keychain`,
+  `yubikey`), the command now always prints an explicit, actionable warning naming the secret and
+  how to remove it yourself -- it never silently reports full removal while key material remains.
+- `@attest-it/core` gains a new `deletePrivateKey(backendType, secretId)` export (mirroring
+  `storePrivateKey`) that idempotently deletes a VaultKeeper-managed secret.

--- a/packages/cli/src/commands/identity/remove.ts
+++ b/packages/cli/src/commands/identity/remove.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander'
 import { confirm } from '@inquirer/prompts'
-import { loadLocalConfig, saveLocalConfig } from '@attest-it/core'
-import { log, success, error, getTheme } from '../../utils/output.js'
+import { loadLocalConfig, saveLocalConfig, deletePrivateKey } from '@attest-it/core'
+import type { PrivateKeyRef } from '@attest-it/core'
+import { log, success, warn, error, getTheme } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
 import { formatKeyLocation } from '../../utils/format-key-location.js'
 import { handlePromptableError, resolveConfirmation } from '../../utils/prompts.js'
@@ -10,12 +11,12 @@ import { homedir } from 'node:os'
 import * as path from 'node:path'
 
 export const removeCommand = new Command('remove')
-  .description('Delete identity and optionally delete private key')
+  .description('Delete identity and its private key')
   .argument('<slug>', 'Identity slug to remove')
   .option('-y, --yes', 'Skip the confirmation prompt(s) and remove non-interactively')
   .option(
-    '--delete-key',
-    'Also delete the private key from storage when used with --yes (interactively, this is still asked separately; default: false)',
+    '--keep-key',
+    'Do not delete the underlying private key material -- only remove the local identity entry (default: also delete the key)',
   )
   .action(async (slug: string, options: RemoveOptions) => {
     await runRemove(slug, options)
@@ -23,18 +24,26 @@ export const removeCommand = new Command('remove')
 
 interface RemoveOptions {
   yes?: boolean
-  deleteKey?: boolean
+  keepKey?: boolean
 }
 
 /**
  * Run the remove command to delete an identity.
  *
- * Non-interactive with `--yes`: both confirmations resolve without prompting
- * (identity removal proceeds; private-key deletion defaults to `false`
- * unless `--delete-key` is also given -- the more destructive of the two
- * actions is opt-in, not implied by `--yes` alone). Without `--yes`, a
- * closed/piped stdin fails fast naming `--yes` instead of hanging on (or
- * looping through) a prompt that can never resolve. See issue #94.
+ * @remarks
+ * Non-interactive with `--yes`: proceeds without prompting. Without
+ * `--yes`, a closed/piped stdin fails fast naming `--yes` instead of
+ * hanging on (or looping through) a prompt that can never resolve. See
+ * issue #94.
+ *
+ * By default, removing an identity also deletes its private key material
+ * for backends attest-it can safely clean up on its own (`file` --
+ * VaultKeeper-managed, and the legacy `filesystem` type). Pass `--keep-key`
+ * to leave the key material in place. For backends attest-it does not
+ * delete from unilaterally (`1password`, `keychain`, `yubikey`), the key
+ * always remains and the command prints an explicit, actionable message
+ * saying so -- it is never left behind silently under a success message.
+ * See issue #101.
  *
  * @public
  */
@@ -80,62 +89,16 @@ export async function runRemove(slug: string, options: RemoveOptions = {}): Prom
       process.exit(ExitCode.CANCELLED)
     }
 
-    // Ask about deleting private key, showing where it's stored
     const keyLocation = formatKeyLocation(identity.privateKey)
     log(`  Private key: ${keyLocation}`)
     log('')
 
-    // Reaching this point already proved --yes was supplied or stdin is an
-    // interactive TTY (resolveConfirmation above would have thrown
-    // otherwise), so no separate non-interactive guard is needed here --
-    // only which default to use.
-    const deletePrivateKey = options.yes
-      ? (options.deleteKey ?? false)
-      : await confirm({
-          message: 'Also delete the private key from storage?',
-          default: false,
-        })
+    const keepKey = options.keepKey ?? false
 
-    // Delete private key if requested
-    if (deletePrivateKey) {
-      switch (identity.privateKey.type) {
-        case 'file':
-        case 'keychain':
-        case '1password':
-        case 'yubikey': {
-          // VaultKeeper-managed keys: deletion is handled by VaultKeeper's backend.
-          // For now, log a note — full backend deletion will be wired when the
-          // VaultKeeper vault instance is available here.
-          log(
-            `  Note: To delete the key from VaultKeeper storage, use the VaultKeeper CLI with ID: ${identity.privateKey.id}`,
-          )
-          break
-        }
-        case 'filesystem': {
-          // Legacy filesystem key — delete the file directly. The stored path
-          // may contain a leading `~` (from a hand-edited v1 config); Node's
-          // fs APIs don't expand it, so resolve it explicitly before deleting.
-          // Mirrors `resolveLegacyPath` in
-          // `@attest-it/core`'s `key-provider/legacy-filesystem-provider.ts` —
-          // not shared via export because that module's internals are
-          // intentionally not part of the package's public API.
-          try {
-            const rawPath = identity.privateKey.path
-            const resolvedPath =
-              rawPath === '~' || rawPath.startsWith('~/')
-                ? path.join(homedir(), rawPath.slice(1))
-                : rawPath
-            await unlink(resolvedPath)
-            log(`  Deleted legacy private key file: ${rawPath}`)
-          } catch (err) {
-            // Ignore file not found errors
-            if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
-              throw err
-            }
-          }
-          break
-        }
-      }
+    if (keepKey) {
+      log(`  Keeping private key (--keep-key): ${keyLocation}`)
+    } else {
+      await deleteKeyMaterial(identity.privateKey)
     }
 
     // Remove from config
@@ -175,5 +138,114 @@ export async function runRemove(slug: string, options: RemoveOptions = {}): Prom
     log('')
   } catch (err) {
     handlePromptableError(err, ExitCode.CONFIG_ERROR)
+  }
+}
+
+/**
+ * Delete (or explain how to delete) the private key material behind a
+ * `PrivateKeyRef`.
+ *
+ * @remarks
+ * For backends attest-it exclusively owns (`file`, `filesystem`), this
+ * actually deletes the secret and reports success. For backends attest-it
+ * cannot unilaterally clean up (`1password`, `keychain`, `yubikey`), this
+ * never attempts deletion -- it always prints an explicit warning that key
+ * material remains, along with how the user can remove it themselves. See
+ * issue #101.
+ */
+async function deleteKeyMaterial(privateKey: PrivateKeyRef): Promise<void> {
+  switch (privateKey.type) {
+    case 'file': {
+      await deletePrivateKey('file', privateKey.id)
+      log('  Deleted private key from storage')
+      break
+    }
+    case 'filesystem': {
+      // Legacy filesystem key — delete the file directly. The stored path
+      // may contain a leading `~` (from a hand-edited v1 config); Node's
+      // fs APIs don't expand it, so resolve it explicitly before deleting.
+      // Mirrors `resolveLegacyPath` in
+      // `@attest-it/core`'s `key-provider/legacy-filesystem-provider.ts` —
+      // not shared via export because that module's internals are
+      // intentionally not part of the package's public API.
+      try {
+        const rawPath = privateKey.path
+        const resolvedPath =
+          rawPath === '~' || rawPath.startsWith('~/')
+            ? path.join(homedir(), rawPath.slice(1))
+            : rawPath
+        await unlink(resolvedPath)
+        log(`  Deleted legacy private key file: ${rawPath}`)
+      } catch (err) {
+        // Ignore file not found errors
+        if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
+          throw err
+        }
+      }
+      break
+    }
+    case 'keychain':
+    case '1password':
+    case 'yubikey': {
+      warnKeyMaterialRemains(privateKey)
+      break
+    }
+  }
+}
+
+/**
+ * Print an explicit, actionable warning that key material was left behind
+ * for a backend attest-it does not delete from unilaterally (`1password`,
+ * `keychain`, `yubikey`). See issue #101.
+ */
+function warnKeyMaterialRemains(
+  privateKey: Exclude<PrivateKeyRef, { type: 'file' | 'filesystem' }>,
+): void {
+  const location = formatKeyLocation(privateKey)
+
+  warn(`Private key material was NOT deleted. attest-it does not automatically remove keys`)
+  log(`    from ${backendDisplayName(privateKey.type)} — that store may be shared with other tools`)
+  log(`    or devices you manage outside attest-it.`)
+  log(`    Location: ${location}`)
+  log(`    Secret ID: ${privateKey.id}`)
+  log('')
+  log(`    To remove it yourself:`)
+  for (const line of manualRemovalInstructions(privateKey)) {
+    log(`      - ${line}`)
+  }
+}
+
+function backendDisplayName(type: 'keychain' | '1password' | 'yubikey'): string {
+  switch (type) {
+    case 'keychain':
+      return 'macOS Keychain'
+    case '1password':
+      return '1Password'
+    case 'yubikey':
+      return 'YubiKey'
+  }
+}
+
+function manualRemovalInstructions(
+  privateKey: Exclude<PrivateKeyRef, { type: 'file' | 'filesystem' }>,
+): string[] {
+  switch (privateKey.type) {
+    case 'keychain':
+      return [
+        'Open Keychain Access.app and locate the entry, or run',
+        `  \`security delete-generic-password -a "${privateKey.id}"\` (adjust for your keychain's exact service/account naming).`,
+      ]
+    case '1password': {
+      const vaultFlag = privateKey.vault ? ` --vault "${privateKey.vault}"` : ''
+      return [
+        'Open the 1Password app and delete the item, or run',
+        `  \`op item delete "${privateKey.id}"${vaultFlag}\` (if the id matches the item name/ID).`,
+      ]
+    }
+    case 'yubikey':
+      return [
+        'This key material lives on the physical YubiKey hardware, not on this machine.',
+        'Use `ykman` or the vendor management tooling for your device to manage or reset the associated credential.',
+      ]
   }
 }

--- a/packages/cli/test/identity-remove.test.ts
+++ b/packages/cli/test/identity-remove.test.ts
@@ -1,22 +1,38 @@
 /**
  * Tests for `identity remove`.
  *
- * Regression: deleting a legacy (`type: 'filesystem'`) identity's private key
- * called `unlink` with the raw stored path, so a hand-edited v1 config
- * carrying a `~`-prefixed path (e.g. `~/attest-it/private.pem`) silently
- * failed to delete the real file -- Node's fs APIs don't perform shell tilde
- * expansion. The path must be resolved before `unlink`, mirroring the same
- * fix in `LegacyFilesystemKeyProvider`.
+ * Regression (issue #94): deleting a legacy (`type: 'filesystem'`) identity's
+ * private key called `unlink` with the raw stored path, so a hand-edited v1
+ * config carrying a `~`-prefixed path (e.g. `~/attest-it/private.pem`)
+ * silently failed to delete the real file -- Node's fs APIs don't perform
+ * shell tilde expansion. The path must be resolved before `unlink`,
+ * mirroring the same fix in `LegacyFilesystemKeyProvider`.
+ *
+ * Regression (issue #101): `identity remove <slug> --yes` reported success
+ * and exited 0 without deleting the underlying VaultKeeper-backed secret --
+ * only the `config.yaml` entry was removed, leaving the encrypted
+ * private-key `.enc` file on disk indefinitely. See the "VaultKeeper `file`
+ * secrets" and "cannot auto-delete externally-managed backends" describe
+ * blocks below.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import * as os from 'node:os'
-import { unlink } from 'node:fs/promises'
+import * as path from 'node:path'
+import { unlink, mkdtemp, readdir, rm } from 'node:fs/promises'
 import type { LocalConfig } from '@attest-it/core'
 import { ExitCode } from '../src/utils/exit-codes.js'
 
-vi.mock('node:fs/promises', () => ({
-  unlink: vi.fn().mockResolvedValue(undefined),
-}))
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  return {
+    ...actual,
+    // Only `unlink` is mocked (and asserted on) by the legacy-filesystem
+    // tests below. Every other fs function passes through to the real
+    // implementation so the VaultKeeper `file`-backend tests can exercise
+    // real files on disk.
+    unlink: vi.fn().mockResolvedValue(undefined),
+  }
+})
 
 vi.mock('@inquirer/prompts', () => ({
   confirm: vi.fn(),
@@ -34,6 +50,9 @@ vi.mock('@attest-it/core', async () => {
 const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {
   // Intentionally empty
 })
+const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {
+  // Intentionally empty
+})
 const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {
   // Intentionally empty
 })
@@ -43,7 +62,7 @@ const mockProcessExit = vi
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   .mockImplementation(() => {})
 
-const { loadLocalConfig, saveLocalConfig } = await import('@attest-it/core')
+const { loadLocalConfig, saveLocalConfig, storePrivateKey } = await import('@attest-it/core')
 const { confirm } = await import('@inquirer/prompts')
 const { runRemove } = await import('../src/commands/identity/remove.js')
 
@@ -67,6 +86,11 @@ function mockLocalConfig(overrides?: Partial<LocalConfig>): LocalConfig {
   }
 }
 
+const SAMPLE_PEM = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ0yoMOEeaMjH9BXmKmBFH32eysYFkBZMhJRbqsZjzax
+-----END PRIVATE KEY-----
+`
+
 describe('identity remove', () => {
   const originalIsTTY = process.stdin.isTTY
 
@@ -85,7 +109,9 @@ describe('identity remove', () => {
 
   it('resolves a leading ~ in a legacy filesystem key path before deleting it', async () => {
     vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
-    vi.mocked(confirm).mockResolvedValueOnce(true).mockResolvedValueOnce(true)
+    // Only one confirmation now: deleting the key defaults to "on" and is
+    // no longer gated behind a second interactive prompt (issue #101).
+    vi.mocked(confirm).mockResolvedValueOnce(true)
     const home = os.homedir()
 
     await runRemove('alice')
@@ -97,18 +123,18 @@ describe('identity remove', () => {
 
   it('deletes a legacy filesystem key path with no leading ~ unchanged', async () => {
     vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
-    vi.mocked(confirm).mockResolvedValueOnce(true).mockResolvedValueOnce(true)
+    vi.mocked(confirm).mockResolvedValueOnce(true)
 
     await runRemove('bob')
 
     expect(unlink).toHaveBeenCalledWith('/tmp/bob.pem')
   })
 
-  it('does not delete the key file when the user declines', async () => {
+  it('does not delete the key file when --keep-key is passed', async () => {
     vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
-    vi.mocked(confirm).mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    vi.mocked(confirm).mockResolvedValueOnce(true)
 
-    await runRemove('alice')
+    await runRemove('alice', { keepKey: true })
 
     expect(unlink).not.toHaveBeenCalled()
     expect(saveLocalConfig).toHaveBeenCalled()
@@ -128,24 +154,25 @@ describe('identity remove — non-interactive (--yes) (issue #94)', () => {
     vi.clearAllMocks()
   })
 
-  it('removes non-interactively with --yes, never invoking the prompt library', async () => {
+  it('removes non-interactively with --yes, deleting the private key by default (issue #101)', async () => {
     vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
 
     await runRemove('bob', { yes: true })
 
     expect(confirm).not.toHaveBeenCalled()
-    expect(unlink).not.toHaveBeenCalled() // --delete-key not given: safer default
+    expect(unlink).toHaveBeenCalledWith('/tmp/bob.pem') // default is to delete the key material
     expect(saveLocalConfig).toHaveBeenCalled()
     expect(mockProcessExit).not.toHaveBeenCalled()
   })
 
-  it('--yes with --delete-key also deletes the private key file, still without prompting', async () => {
+  it('--yes with --keep-key skips key deletion, still without prompting', async () => {
     vi.mocked(loadLocalConfig).mockResolvedValue(mockLocalConfig())
 
-    await runRemove('bob', { yes: true, deleteKey: true })
+    await runRemove('bob', { yes: true, keepKey: true })
 
     expect(confirm).not.toHaveBeenCalled()
-    expect(unlink).toHaveBeenCalledWith('/tmp/bob.pem')
+    expect(unlink).not.toHaveBeenCalled()
+    expect(saveLocalConfig).toHaveBeenCalled()
   })
 
   it(
@@ -189,5 +216,159 @@ describe('identity remove — cancelled prompt maps to CANCELLED, not CONFIG_ERR
     expect(mockConsoleLog).toHaveBeenCalledWith('Cancelled')
     expect(mockConsoleError).not.toHaveBeenCalledWith(expect.stringContaining(rawInquirerMessage))
     expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CANCELLED)
+  })
+})
+
+// Regression coverage for issue #101: `identity remove <slug> --yes` reported
+// success and exited 0 without deleting the underlying VaultKeeper-managed
+// secret -- only the config.yaml entry was removed, leaving the encrypted
+// private-key `.enc` file on disk indefinitely. This test stores a real
+// secret via the real VaultKeeper `file` backend (redirected to a temp
+// directory via `VAULTKEEPER_CONFIG_DIR`), then asserts -- via a genuine
+// before/after diff of the backend's on-disk store -- that `identity remove`
+// deletes exactly that secret's `.enc` file. Against the pre-fix
+// implementation (which only logged an inert "use the VaultKeeper CLI" note
+// and never called any deletion API) this test fails: the `.enc` file for
+// the removed identity is still present in `after`.
+describe('identity remove — deletes VaultKeeper `file` secrets by default (issue #101)', () => {
+  let configDir: string
+  const originalConfigDir = process.env.VAULTKEEPER_CONFIG_DIR
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+    configDir = await mkdtemp(path.join(os.tmpdir(), 'attest-it-identity-remove-'))
+    process.env.VAULTKEEPER_CONFIG_DIR = configDir
+  })
+
+  afterEach(async () => {
+    vi.clearAllMocks()
+    if (originalConfigDir === undefined) {
+      delete process.env.VAULTKEEPER_CONFIG_DIR
+    } else {
+      process.env.VAULTKEEPER_CONFIG_DIR = originalConfigDir
+    }
+    await rm(configDir, { recursive: true, force: true })
+  })
+
+  it('deletes the underlying .enc secret file, not just the config entry', async () => {
+    const { secretId } = await storePrivateKey('file', SAMPLE_PEM, 'carol')
+
+    vi.mocked(loadLocalConfig).mockResolvedValue(
+      mockLocalConfig({
+        activeIdentity: 'bob',
+        identities: {
+          carol: {
+            name: 'Carol',
+            publicKey: 'pk-carol',
+            privateKey: { type: 'file', id: secretId },
+          },
+          bob: {
+            name: 'Bob',
+            publicKey: 'pk-bob',
+            privateKey: { type: 'filesystem', path: '/tmp/bob.pem' },
+          },
+        },
+      }),
+    )
+
+    const storeDir = path.join(configDir, 'file')
+    const before = await readdir(storeDir)
+    // Sanity check: the secret really is on disk before removal, and the
+    // stored filename is the hex-encoded secret id -- matching the
+    // reproduction in issue #101 ("filenames hex-decode to
+    // attest-it-<display name>-<uuid>").
+    const secretFilename = `${Buffer.from(secretId, 'utf8').toString('hex')}.enc`
+    expect(before).toContain(secretFilename)
+
+    await runRemove('carol', { yes: true })
+
+    const after = await readdir(storeDir)
+    expect(after).not.toContain(secretFilename)
+
+    // Before/after diff: exactly the removed identity's secret is gone;
+    // nothing else in the store (e.g. the backend's own wrap key file) was
+    // touched.
+    const removedFiles = before.filter((f) => !after.includes(f))
+    expect(removedFiles).toEqual([secretFilename])
+
+    expect(saveLocalConfig).toHaveBeenCalled()
+    expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Deleted private key'))
+  })
+})
+
+// Regression coverage for issue #101: for backends attest-it cannot
+// unilaterally delete from (1Password, macOS Keychain, YubiKey), the
+// pre-fix code logged an inert note pointing at a nonexistent "VaultKeeper
+// CLI" and still reported `Identity "<slug>" removed` as an unqualified
+// success -- silently implying full cleanup. The fix must always print an
+// explicit, actionable warning (never hidden behind the success message)
+// whenever key material remains.
+describe('identity remove — cannot auto-delete externally-managed backends (issue #101)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('prints an actionable warning for a 1Password-backed key instead of silently leaving it', async () => {
+    vi.mocked(loadLocalConfig).mockResolvedValue(
+      mockLocalConfig({
+        activeIdentity: 'bob',
+        identities: {
+          dave: {
+            name: 'Dave',
+            publicKey: 'pk-dave',
+            privateKey: { type: '1password', id: 'attest-it-dave-secret-id', vault: 'Private' },
+          },
+          bob: {
+            name: 'Bob',
+            publicKey: 'pk-bob',
+            privateKey: { type: 'filesystem', path: '/tmp/bob.pem' },
+          },
+        },
+      }),
+    )
+
+    await runRemove('dave', { yes: true })
+
+    // Explicit, actionable warning -- names the secret id and gives a
+    // concrete removal command, not just "it wasn't deleted".
+    expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('NOT deleted'))
+    expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('attest-it-dave-secret-id'))
+    expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('op item delete'))
+
+    // The identity entry is still removed from config -- this is not a
+    // failure of the `remove` operation, only of automatic key cleanup.
+    expect(saveLocalConfig).toHaveBeenCalled()
+    expect(mockProcessExit).not.toHaveBeenCalled()
+  })
+
+  it('prints an actionable warning for a macOS Keychain-backed key instead of silently leaving it', async () => {
+    vi.mocked(loadLocalConfig).mockResolvedValue(
+      mockLocalConfig({
+        activeIdentity: 'bob',
+        identities: {
+          erin: {
+            name: 'Erin',
+            publicKey: 'pk-erin',
+            privateKey: { type: 'keychain', id: 'attest-it-erin-secret-id' },
+          },
+          bob: {
+            name: 'Bob',
+            publicKey: 'pk-bob',
+            privateKey: { type: 'filesystem', path: '/tmp/bob.pem' },
+          },
+        },
+      }),
+    )
+
+    await runRemove('erin', { yes: true })
+
+    expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('NOT deleted'))
+    expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('attest-it-erin-secret-id'))
+    expect(saveLocalConfig).toHaveBeenCalled()
   })
 })

--- a/packages/cli/test/integration/non-interactive-setup.integration.test.ts
+++ b/packages/cli/test/integration/non-interactive-setup.integration.test.ts
@@ -194,6 +194,41 @@ async function readCreatedPublicKey(homeDir: string, slug: string): Promise<stri
   return identity.publicKey
 }
 
+/**
+ * Read the VaultKeeper `privateKey.id` attest-it just wrote for `slug` under
+ * a temp ATTEST_IT_HOME (used to locate the corresponding `.enc` secret file
+ * on disk for issue #101's deletion assertion).
+ */
+async function readCreatedPrivateKeyId(homeDir: string, slug: string): Promise<string> {
+  const content = await fs.promises.readFile(path.join(homeDir, 'config.yaml'), 'utf8')
+  const parsed: unknown = parseYaml(content)
+  if (!isRecordOfUnknown(parsed) || !isRecordOfUnknown(parsed.identities)) {
+    throw new Error('Expected local config to contain an identities map')
+  }
+  const identity = parsed.identities[slug]
+  if (
+    !isRecordOfUnknown(identity) ||
+    !isRecordOfUnknown(identity.privateKey) ||
+    typeof identity.privateKey.id !== 'string'
+  ) {
+    throw new Error(`Expected identity "${slug}" to have a string privateKey.id`)
+  }
+  return identity.privateKey.id
+}
+
+/**
+ * Path to the VaultKeeper `file`-backend `.enc` secret for a given secret id
+ * under `vaultKeeperConfigDir` (mirrors `getEntryPath` in vaultkeeper's
+ * file-backend implementation: `<configDir>/file/<hex(id)>.enc`).
+ */
+function vaultKeeperFileSecretPath(vaultKeeperConfigDir: string, secretId: string): string {
+  return path.join(
+    vaultKeeperConfigDir,
+    'file',
+    `${Buffer.from(secretId, 'utf8').toString('hex')}.enc`,
+  )
+}
+
 describe('non-interactive setup end-to-end (issue #80)', () => {
   let projectDir: string
   let homeDir: string
@@ -393,9 +428,14 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
 
   describe('identity remove headless operation (issue #94)', () => {
     it(
-      'removes an identity non-interactively with --yes and closed stdin',
+      'removes an identity non-interactively with --yes and closed stdin, ' +
+        'and deletes the underlying VaultKeeper secret (issue #101)',
       async () => {
-        const env = { ATTEST_IT_HOME: homeDir }
+        // VAULTKEEPER_CONFIG_DIR is redirected to the same isolated per-test
+        // homeDir used for ATTEST_IT_HOME, so the `file`-backend secret this
+        // test creates and deletes never touches the real machine's
+        // `~/.config/vaultkeeper`.
+        const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
         await runCliNonInteractive(
           ['identity', 'create', '--name', 'A', '--slug', 'a', '--storage', 'file'],
           projectDir,
@@ -407,6 +447,10 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
           env,
         )
 
+        const secretId = await readCreatedPrivateKeyId(homeDir, 'b')
+        const secretPath = vaultKeeperFileSecretPath(homeDir, secretId)
+        await expect(fs.promises.access(secretPath)).resolves.toBeUndefined()
+
         const result = await runCliNonInteractive(
           ['identity', 'remove', 'b', '--yes'],
           projectDir,
@@ -415,6 +459,11 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
 
         expect(result.exitCode).toBe(0)
         expect(result.stdout).toContain('removed')
+
+        // The regression this guards against: pre-fix, `identity remove`
+        // only removed the config.yaml entry and left this `.enc` file on
+        // disk indefinitely.
+        await expect(fs.promises.access(secretPath)).rejects.toThrow()
       },
       CLI_CALL_TIMEOUT_MS * 3,
     )
@@ -422,7 +471,7 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
     it(
       'fails fast (never hangs) when identity remove is given no --yes with no TTY',
       async () => {
-        const env = { ATTEST_IT_HOME: homeDir }
+        const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
         await runCliNonInteractive(
           ['identity', 'create', '--name', 'A', '--slug', 'a', '--storage', 'file'],
           projectDir,
@@ -446,7 +495,7 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
       'never enters the runaway prompt-render loop when stdin is piped from `yes`, ' +
         'and produces bounded output',
       async () => {
-        const env = { ATTEST_IT_HOME: homeDir }
+        const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
         await runCliNonInteractive(
           ['identity', 'create', '--name', 'A', '--slug', 'a', '--storage', 'file'],
           projectDir,

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -110,6 +110,9 @@ export interface CryptoVerifyOptions {
 }
 
 // @public
+export function deletePrivateKey(backendType: PrivateKeyBackendType, secretId: string): Promise<void>;
+
+// @public
 export interface Ed25519GenerateKeyPairOptions {
     passphrase?: string;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,6 +132,7 @@ export {
   type VaultKeyProviderOptions,
   type KeyProviderFactory,
   storePrivateKey,
+  deletePrivateKey,
   type StorePrivateKeyResult,
   type PrivateKeyBackendType,
 } from './key-provider/index.js'

--- a/packages/core/src/key-provider/index.ts
+++ b/packages/core/src/key-provider/index.ts
@@ -48,5 +48,5 @@ export { KeyProviderRegistry } from './registry.js'
 export type { KeyProviderFactory } from './registry.js'
 
 // High-level storage helpers
-export { storePrivateKey } from './store.js'
+export { storePrivateKey, deletePrivateKey } from './store.js'
 export type { StorePrivateKeyResult, PrivateKeyBackendType } from './store.js'

--- a/packages/core/src/key-provider/store.ts
+++ b/packages/core/src/key-provider/store.ts
@@ -10,7 +10,7 @@
  */
 
 import * as crypto from 'node:crypto'
-import { BackendRegistry } from 'vaultkeeper'
+import { BackendRegistry, SecretNotFoundError } from 'vaultkeeper'
 
 /**
  * Result of storing a private key via a VaultKeeper backend.
@@ -57,5 +57,37 @@ export async function storePrivateKey(
   return {
     secretId,
     storageDescription: `${displayName}: ${secretId}`,
+  }
+}
+
+/**
+ * Delete a private key previously stored via {@link storePrivateKey} from its
+ * VaultKeeper backend.
+ *
+ * @remarks
+ * Idempotent: deleting a secret that no longer exists in the backend (e.g.
+ * already removed by a prior cleanup) is treated as success rather than an
+ * error, since the desired end state -- no secret with this id -- already
+ * holds.
+ *
+ * @param backendType - The VaultKeeper backend the key was stored in
+ * @param secretId - The VaultKeeper secret id to delete (as returned by
+ * {@link storePrivateKey} / recorded on the identity's `privateKey.id`)
+ * @public
+ */
+export async function deletePrivateKey(
+  backendType: PrivateKeyBackendType,
+  secretId: string,
+): Promise<void> {
+  const vaultKeeperBackendType = backendType === 'file' ? 'file' : backendType
+
+  const backend = BackendRegistry.create(vaultKeeperBackendType)
+  try {
+    await backend.delete(secretId)
+  } catch (err) {
+    if (err instanceof SecretNotFoundError) {
+      return
+    }
+    throw err
   }
 }

--- a/packages/core/test/key-provider/store.test.ts
+++ b/packages/core/test/key-provider/store.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for `storePrivateKey`/`deletePrivateKey` -- the high-level VaultKeeper
+ * storage helpers.
+ *
+ * Regression coverage for issue #101: `identity remove` previously had no
+ * way to delete a VaultKeeper-managed secret at all, so it silently left the
+ * `.enc` file behind. `deletePrivateKey` is the primitive the CLI now calls
+ * to do that; these tests exercise it directly against the real `file`
+ * backend (redirected to a temp directory), plus its idempotent handling of
+ * an already-missing secret.
+ */
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { deletePrivateKey, storePrivateKey } from '../../src/key-provider/store.js'
+
+const SAMPLE_PEM = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ0yoMOEeaMjH9BXmKmBFH32eysYFkBZMhJRbqsZjzax
+-----END PRIVATE KEY-----
+`
+
+describe('deletePrivateKey', () => {
+  let configDir: string
+  const originalConfigDir = process.env.VAULTKEEPER_CONFIG_DIR
+
+  beforeEach(async () => {
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-core-store-test-'))
+    process.env.VAULTKEEPER_CONFIG_DIR = configDir
+  })
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) {
+      delete process.env.VAULTKEEPER_CONFIG_DIR
+    } else {
+      process.env.VAULTKEEPER_CONFIG_DIR = originalConfigDir
+    }
+    await fs.rm(configDir, { recursive: true, force: true })
+  })
+
+  it('deletes a secret previously written by storePrivateKey', async () => {
+    const { secretId } = await storePrivateKey('file', SAMPLE_PEM, 'alice')
+    const entryPath = path.join(
+      configDir,
+      'file',
+      `${Buffer.from(secretId, 'utf8').toString('hex')}.enc`,
+    )
+
+    // Sanity check: the secret is really on disk before deletion.
+    await expect(fs.access(entryPath)).resolves.toBeUndefined()
+
+    await deletePrivateKey('file', secretId)
+
+    await expect(fs.access(entryPath)).rejects.toThrow()
+  })
+
+  it('leaves other secrets in the same store untouched', async () => {
+    const kept = await storePrivateKey('file', SAMPLE_PEM, 'bob')
+    const removed = await storePrivateKey('file', SAMPLE_PEM, 'carol')
+
+    await deletePrivateKey('file', removed.secretId)
+
+    const keptEntryPath = path.join(
+      configDir,
+      'file',
+      `${Buffer.from(kept.secretId, 'utf8').toString('hex')}.enc`,
+    )
+    await expect(fs.access(keptEntryPath)).resolves.toBeUndefined()
+  })
+
+  it('is idempotent: deleting an already-missing secret resolves without throwing', async () => {
+    // Negative-path regression: a naive implementation would propagate
+    // vaultkeeper's SecretNotFoundError here, but the desired end state --
+    // no secret with this id -- already holds, so this must succeed.
+    await expect(deletePrivateKey('file', 'attest-it-never-stored-uuid')).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

`identity remove <slug> --yes` reported `✓ Identity "<slug>" removed` and exited `0`, but never
deleted the underlying VaultKeeper-backed secret -- only the `config.yaml` entry was removed,
leaving the encrypted private-key `.enc` file on disk indefinitely (confirmed by DX round-3, see
issue #101).

- `identity remove` now deletes the private key **by default** for backends attest-it exclusively
  owns: the VaultKeeper `file` backend, and the legacy `filesystem` type. A new `--keep-key` flag
  opts out of this; it replaces the previous opt-in `--delete-key` flag (removed).
- For backends attest-it cannot unilaterally delete from (`1password`, macOS `keychain`,
  `yubikey`), the command never attempts deletion -- it always prints an explicit, actionable
  warning naming the secret id/location and how to remove it yourself. It never silently reports
  full success while key material remains.
- `@attest-it/core` gains `deletePrivateKey(backendType, secretId)`, mirroring the existing
  `storePrivateKey`, which idempotently deletes a VaultKeeper-managed secret (a repeat/late delete
  of an already-gone secret is treated as success, not an error).

## Acceptance criteria mapping

1. **"`identity remove <slug>` ... deletes the underlying VaultKeeper-backed secret ... no orphaned
   `.enc` left behind. Verify via a before/after diff of the backend store in a test."**
   - `packages/cli/test/identity-remove.test.ts` >
     `identity remove — deletes VaultKeeper 'file' secrets by default (issue #101)` > `deletes the
     underlying .enc secret file, not just the config entry` -- stores a real secret via the real
     `file` backend (redirected to a temp dir via `VAULTKEEPER_CONFIG_DIR`), then asserts a
     before/after `readdir` diff shows exactly that secret's hex-encoded `.enc` filename removed
     and nothing else touched.
   - `packages/cli/test/integration/non-interactive-setup.integration.test.ts` >
     `identity remove headless operation (issue #94)` > `removes an identity non-interactively
     with --yes and closed stdin, and deletes the underlying VaultKeeper secret (issue #101)` --
     drives the real built CLI binary end-to-end (UAT layer) and asserts the `.enc` file is gone
     from disk after `identity remove --yes`.
   - `packages/core/test/key-provider/store.test.ts` -- unit coverage for the new
     `deletePrivateKey` primitive itself (deletes the right file, leaves other secrets untouched,
     idempotent on an already-missing secret).
2. **"For backends where the CLI cannot delete the secret ... prints an explicit, actionable
   message ... never silently leaves it with a success message."**
   - `identity-remove.test.ts` > `identity remove — cannot auto-delete externally-managed backends
     (issue #101)` -- one test per non-deletable backend (`1password`, `keychain`) asserting a
     `console.warn` naming "NOT deleted" plus a concrete removal command, while the identity entry
     is still removed from config (the command still succeeds overall).
3. **"Consider a `--keep-key` opt-out; default is remove."**
   - Implemented as described above; covered by `does not delete the key file when --keep-key is
     passed` (legacy filesystem) and `--yes with --keep-key skips key deletion, still without
     prompting` (VaultKeeper-eligible path).
4. **"Note the pre-existing accumulation ... coordinate the broader GC with #96/#73."**
   - Out of scope per the issue's own non-goals; not addressed here. Go-forward `remove` no longer
     adds to the pile, which is the stated scope.

## Notes for reviewers

- While adding the UAT-level assertion in `non-interactive-setup.integration.test.ts`, I found
  that identity-remove's real-CLI-subprocess tests (which use `--storage file`) had no
  `VAULTKEEPER_CONFIG_DIR` override, so they were writing/deleting real secrets in the *actual
  developer/CI machine's* `~/.config/vaultkeeper/file/` directory. I isolated the three tests in
  the `identity remove headless operation` describe block by setting
  `VAULTKEEPER_CONFIG_DIR: homeDir` alongside the existing per-test `ATTEST_IT_HOME`. **This same
  leak exists in several other tests in this file** (e.g. the main `identity create -> init ->
  run -> verify` flow) and in other integration test files that pass `--storage file` -- that's a
  pre-existing, broader test-isolation gap unrelated to this bug, so I left it alone outside the
  tests this PR directly touches. Worth a follow-up issue.

## Test plan

- [x] `pnpm build` (all packages)
- [x] `pnpm run check` (lint, types, API report) -- clean
- [x] `pnpm test` (all packages) -- 771 CLI + 542 core tests green
- [x] Manual smoke test with the built binary: `file`-backed delete (`.enc` removed),
      `1password`-backed non-delete (actionable warning printed), `--keep-key` opt-out (`.enc`
      retained)

Refs #101
