### PR TITLE
Sealed root gate: trust-anchor policy.yaml (Refs #72)

### DIFF
--- a/.changeset/sealed-root-gate-policy.md
+++ b/.changeset/sealed-root-gate-policy.md
@@ -1,0 +1,49 @@
+---
+'@attest-it/core': major
+'@attest-it/cli': major
+'attest-it': major
+---
+
+Add a sealed **root gate** that trust-anchors `.attest-it/policy.yaml`.
+
+The policy file (which holds the trust-critical `team` and `gates`) is now itself
+a gated, sealed artifact. A reserved top-level `rootGate` section names the root
+signers — the only identities allowed to authorize a change to `policy.yaml` — and
+verification checks the policy's own seal chain **first**, before evaluating any
+other gate. A gate is never evaluated against a policy whose own root-gate seal
+did not verify. This closes the headline trust gap: a pull request can no longer
+add itself to `team`, authorize itself on a gate, and pass verification.
+
+**Behavior change — trust-critical:**
+
+- **New verification pre-step.** When `policy.yaml` defines a `rootGate`,
+  `attest-it verify` (and the GitHub Action) verify the root seal over the policy
+  before evaluating gates. If the policy was modified without a fresh root seal
+  from an existing root signer, verification **fails**, naming
+  `.attest-it/policy.yaml` as the untrusted change.
+- **Changing root signers requires an existing root signer.** Editing
+  `rootGate.authorizedSigners` changes the policy fingerprint and requires a new
+  root seal from a current root signer — a branch cannot bootstrap a new root of
+  trust for itself. In a pull-request context the Action loads the root signer set
+  from the base branch, so a self-added signer is rejected as `UNKNOWN_SIGNER`.
+- **Reserved gate id.** The slug `__root__` is reserved; it cannot be used as an
+  ordinary gate in `gates`.
+- **The GitHub Action** performs the same root-gate pre-step (it re-verifies on
+  the base branch). Configure the verification job as a required status check.
+
+**Migration for existing repositories.** This change is backward compatible: a
+repository that has not defined a `rootGate` is reported as "not trust-anchored"
+and continues to verify as before. To adopt the trust anchor, run the one-step
+bootstrap ceremony:
+
+```
+attest-it identity create --name "…" --slug you   # if you haven't already
+attest-it init --root-signer you                   # establishes + seals the root
+```
+
+After adopting it, re-seal the root gate with `attest-it seal --root` (as a root
+signer) whenever you change the trust-critical policy.
+
+See `docs/threat-model.md` for the full threat model, including the recommended
+repository posture (branch protection, base-branch policy loading, CODEOWNERS, and
+post-merge re-verification) for workflow-file tampering.

--- a/.changeset/sealed-root-gate-policy.md
+++ b/.changeset/sealed-root-gate-policy.md
@@ -1,7 +1,7 @@
 ---
-'@attest-it/core': major
-'@attest-it/cli': major
-'attest-it': major
+'@attest-it/core': minor
+'@attest-it/cli': minor
+'attest-it': minor
 ---
 
 Add a sealed **root gate** that trust-anchors `.attest-it/policy.yaml`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The primary threat is an AI assistant creating a fake attestation. attest-it pre
 - **Secure storage**: Keys stored in 1Password, macOS Keychain, YubiKey, or encrypted files
 - **Team authorization**: Each gate specifies who can sign
 - **Fingerprinting**: Code changes invalidate seals
+- **Sealed root gate**: `policy.yaml` (the trust data itself) is a sealed artifact — a pull request can't add itself to `team`/`gates` and pass verification. See [threat model](docs/threat-model.md).
 
 ## Configuration
 
@@ -91,6 +92,11 @@ minVersion: '0.9.0' # Optional: minimum attest-it version required
 
 settings:
   maxAgeDays: 30
+
+# Trust anchor: only these signers may authorize changes to policy.yaml itself.
+# Establish it once with `attest-it init --root-signer <slug>`.
+rootGate:
+  authorizedSigners: [alice]
 
 # Team members authorized to create seals
 team:
@@ -128,6 +134,7 @@ suites:
 **Key concepts:**
 
 - **Team** - People authorized to create seals, identified by their public key (in `policy.yaml`)
+- **Root gate** - The trust anchor over `policy.yaml` itself; only `rootGate.authorizedSigners` may authorize changes to the trust data. Established via the `attest-it init --root-signer` bootstrap ceremony (in `policy.yaml`)
 - **Gates** - Define which files require attestation and who can sign, including the fingerprint config (in `policy.yaml`)
 - **Fingerprint** - Files to hash; any change invalidates the seal (lives on the gate)
 - **Suites** - Test commands that reference a gate; every suite must specify `gate` (in `config.yaml`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,8 +60,61 @@ suites:
 | `version`    | `1`    | Yes      | -       | Schema version (must be `1`)                      |
 | `minVersion` | string | No       | -       | Minimum attest-it version required (e.g. "0.9.0") |
 | `settings`   | object | No       | `{}`    | Policy settings                                   |
+| `rootGate`   | object | No       | -       | Trust anchor over `policy.yaml` (see below)       |
 | `team`       | object | No       | -       | Team member definitions                           |
 | `gates`      | object | No       | -       | Gate definitions                                  |
+
+### Root Gate (`rootGate`)
+
+The `rootGate` section makes `policy.yaml` itself a sealed, gated artifact — the
+**trust anchor**. It names the **root signers**: the only identities allowed to
+authorize a change to the trust-critical policy. When present, `attest-it verify`
+(and the GitHub Action) verify the root seal over `policy.yaml` **before**
+evaluating any other gate; a gate is never evaluated against a policy whose own
+root-gate seal did not verify.
+
+```yaml
+rootGate:
+  authorizedSigners:
+    - alice
+  maxAge: 365d
+  description: Trust anchor over .attest-it/policy.yaml
+```
+
+| Field               | Type            | Required | Default | Description                                                |
+| ------------------- | --------------- | -------- | ------- | ---------------------------------------------------------- |
+| `authorizedSigners` | array of string | Yes      | -       | Team member slugs allowed to seal changes to `policy.yaml` |
+| `maxAge`            | duration        | No       | `365d`  | Maximum age before the root seal is considered stale       |
+| `description`       | string          | No       | -       | Optional human-readable description                        |
+
+Notes:
+
+- `rootGate` is a dedicated top-level section, **not** an entry in `gates`. The
+  gate id `__root__` is reserved and cannot be used as an ordinary gate, so a pull
+  request cannot redefine which gate is root.
+- The artifact the root gate covers is fixed to `policy.yaml` (there is no
+  `fingerprint` field), so a branch cannot repoint it at empty content.
+- Changing `authorizedSigners` changes the policy fingerprint and requires a fresh
+  root seal from an **existing** root signer — a branch cannot bootstrap a new root
+  of trust for itself.
+
+**Bootstrap ceremony** (one human-run step establishes the trust anchor):
+
+```bash
+attest-it identity create --name "Alice" --slug alice   # once, general onboarding
+attest-it init --root-signer alice                       # establishes + seals the root gate
+```
+
+After changing the trust-critical policy later, re-anchor it as a root signer:
+
+```bash
+attest-it seal --root
+```
+
+If a repository defines no `rootGate`, it is reported as "not trust-anchored" and
+verification proceeds as before (backward compatible). See
+[`threat-model.md`](./threat-model.md) for the full threat model and the
+recommended repository posture.
 
 ## Operational Configuration Schema (`config.yaml`)
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,155 @@
+# attest-it Threat Model
+
+This document describes the threats attest-it defends against, the mechanisms that
+provide those defenses, and the residual risks that are explicitly out of scope
+(the embedder's or repository operator's responsibility).
+
+The central invariant is the PRD's Goal 3 and the integration contract's
+invariant 5:
+
+> **No sequence of writes an agent can make inside a proposal branch — artifact,
+> gate entry, config edit, seal file, workflow edit — may yield a passing
+> verification without a signature from a key behind a human-presence backend.**
+
+attest-it answers _"does a valid, current seal exist for this content, signed by
+an authorized key?"_ — it never answers _"is this action permitted."_ Permission
+and human-presence enforcement live in the key backend (a signer's private key is
+only reachable with human presence); attest-it verifies the resulting signatures.
+
+## Trust anchor: the sealed root gate over `policy.yaml`
+
+`.attest-it/policy.yaml` holds the trust-critical data: the `team` (public keys)
+and `gates` (who may sign what). Before this mechanism, nothing verified the
+_provenance_ of `policy.yaml` itself — a branch could add itself to `team`,
+authorize itself on a gate, and pass verification.
+
+The **root gate** closes this: `policy.yaml` is itself a gated, sealed artifact.
+
+- A reserved top-level `rootGate` section names the **root signers** — the only
+  identities allowed to authorize a change to `policy.yaml`.
+- `rootGate` is deliberately _not_ an entry in the user-editable `gates` map, and
+  the reserved gate id `__root__` may not be used as an ordinary gate. A pull
+  request therefore cannot redefine _which_ gate is root.
+- The artifact the root gate covers is fixed to `policy.yaml`; it is not
+  user-configurable, so a branch cannot repoint the root gate at empty content.
+- Verification order is mandatory: **load config → verify the config's own seal
+  chain against the root gate → only then evaluate every other gate.** A gate is
+  never evaluated against a policy whose own root-gate seal did not verify.
+- Changing `rootGate.authorizedSigners` changes the policy's content, which
+  changes its fingerprint, which requires a **fresh root seal from an existing
+  root signer**. A branch cannot bootstrap a new root of trust for itself.
+
+The root seal is created and verified with the _same_ primitives as any other
+gate seal (`createSeal` / `verifyGateSeal`), so there is one trust system to
+audit.
+
+### Bootstrap ceremony
+
+The first root signer is established by an explicit, human-run step — never
+silently defaulted:
+
+```
+attest-it identity create --name "…" --slug you        # once, general onboarding
+attest-it init --root-signer you                        # THE ceremony
+```
+
+`attest-it init --root-signer <slug>` (or the interactive confirmation `init`
+offers when a TTY and an active identity are present) records the signer in
+`rootGate`, adds their public key to `team`, and creates the anchoring seal over
+`policy.yaml` — all in a single invocation. From then on, `attest-it verify`
+treats the policy as trust-anchored, and any change to it requires a fresh root
+seal (`attest-it seal --root`) from a current root signer.
+
+## Threats and mitigations
+
+### T1 — An agent edits the config to authorize itself
+
+_Threat:_ a proposal branch edits `policy.yaml` to add a new public key to `team`
+and authorize it on a gate (or modifies an existing gate's `authorizedSigners`),
+then seals an artifact with the newly-added key.
+
+_Mitigation:_ the edit changes the policy's fingerprint. The existing root seal
+covers the _previous_ fingerprint, so the mandatory root-gate pre-step reports
+`FINGERPRINT_MISMATCH` and `attest-it verify` fails **before** any gate is
+evaluated — naming `.attest-it/policy.yaml` as the untrusted change rather than
+emitting a generic failure. The only way to pass is a fresh root seal over the new
+policy from an **existing** root signer, whose private key is behind a
+human-presence backend.
+
+_Adversarial tests (run in CI):_
+`packages/core/test/root-gate.test.ts` ("adversarial AC 1", "adversarial AC 2",
+"AC 5") and
+`packages/cli/test/integration/root-gate.integration.test.ts` ("ADVERSARIAL 1",
+"ADVERSARIAL 2") exercise this end-to-end against tampered `policy.yaml`.
+
+### T2 — An agent edits the workflow file
+
+_Threat:_ a proposal branch edits the CI workflow (`.github/workflows/*.yml`) so
+that attest-it's Action runs with weakened inputs (e.g. an attacker-controlled
+`policy-ref`), or is skipped entirely.
+
+_Mitigation posture (PRD Q2 — recommended repository configuration):_
+
+1. **Branch protection with a required status check.** Mark the attest-it
+   verification job as a required check on the protected branch. A PR that removes
+   or renames the job cannot satisfy the required check, so it cannot merge.
+2. **`policy-ref` is loaded from the base branch, not the PR.** In a pull-request
+   context the Action fetches `policy.yaml` — and therefore the root signer set —
+   from the **base branch**, the trusted source. A branch that rewrites its own
+   `policy.yaml` (adding itself as a root signer and self-sealing) is rejected as
+   `UNKNOWN_SIGNER`, because the base branch does not list it. The repository's CI
+   workflow guard (`scripts/check-policy-ref-guard.mjs`) additionally rejects
+   unsafe `policy-ref` overrides in workflow definitions.
+3. **CODEOWNERS on trust-critical paths.** Require a human code owner's review for
+   changes to `.github/workflows/**` and `.attest-it/policy.yaml`, so workflow or
+   policy edits cannot merge without human approval.
+4. **Post-merge base-branch re-verification.** Run attest-it on `push` to the
+   protected branch (not only on PRs), so a merge that slipped through is caught
+   on the branch that matters.
+
+_Recommendation & scope:_ attest-it documents this posture and recommends
+enabling all four. It does **not** configure a specific repository's branch
+protection or CODEOWNERS (operational, repo-owner-owned). Whether attest-it's
+Action should additionally _self-check_ that it ran from base-branch workflow
+definitions is a deliberate **non-goal** of the root-gate work and is **not
+implemented** here; the recommended posture above (required check + base-branch
+policy load + CODEOWNERS + post-merge re-verify) covers the threat. If the PRD
+owner decides the Action should self-verify its own invocation, that is tracked
+as a follow-up.
+
+### T3 — An agent replays a seal against different content
+
+_Threat:_ a proposal branch reuses a previously-valid seal for content that has
+since changed (a stale or moved seal), hoping verification treats it as current.
+
+_Mitigation:_ every seal binds an authorized signer's signature to the content's
+**SHA-256 fingerprint** and a timestamp (`gateId:fingerprint:timestamp`). If the
+content changes, the current fingerprint no longer matches the sealed one and
+verification reports `FINGERPRINT_MISMATCH`. Seals also expire (`maxAge`), so a
+replayed old seal is additionally rejected as `STALE`. This applies to both
+ordinary gates and the root gate over `policy.yaml`.
+
+### T4 — An agent PATH-shadows the attest-it binary
+
+_Threat:_ an agent places a malicious `attest-it` earlier on `PATH` (or otherwise
+substitutes the binary) so that "verification" is a no-op that always succeeds.
+
+_Mitigation posture:_ **out of scope — the embedder's / consumer's duty.**
+attest-it cannot defend against an attacker who already controls the execution
+environment that invokes it. The embedder is responsible for invoking a trusted,
+pinned attest-it (e.g. a pinned Action `uses:` SHA, a locked dependency in CI, or
+an absolute path to a verified binary) from an environment the proposal branch
+cannot alter. This is the same trust boundary every CI tool relies on and is
+noted here so the boundary is explicit rather than assumed.
+
+## Residual risks and boundaries
+
+- **Local `attest-it verify` trusts the local policy.** On a developer's own
+  machine there is no trusted base branch to compare against, so a locally-edited
+  `policy.yaml` that is re-anchored locally will verify locally. The enforcement
+  boundary that matters is the **merge gate** (the Action, which loads policy from
+  the base branch) plus branch protection / CODEOWNERS. Local verification is a
+  fast pre-check, not the trust boundary.
+- **attest-it proves existence of a valid seal, never permission.** Usage grants,
+  session scoping, and human-presence enforcement are the key backend's / the
+  toolsmith's responsibility; attest-it verifies the resulting signatures.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,19 +3,36 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { stringify as stringifyYaml } from 'yaml'
-import { migrateUnifiedContent } from '@attest-it/core'
-import { log, success, error } from '../utils/output.js'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import {
+  migrateUnifiedContent,
+  loadLocalConfigSync,
+  getActiveIdentity,
+  computePolicyFingerprintSync,
+  createRootSeal,
+  findPolicyPath,
+  readSealsSync,
+  writeSealsSync,
+  ROOT_GATE_ID,
+  type Identity,
+} from '@attest-it/core'
+import { log, success, error, warn } from '../utils/output.js'
 import { confirmAction, isInteractiveTTY, handlePromptableError } from '../utils/prompts.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { offerCompletionInstall } from '../utils/completion-offer.js'
 import { getPackageVersion } from '../utils/version.js'
+import { loadIdentitySigningKey } from '../utils/identity-key.js'
 
 export const initCommand = new Command('init')
   .description('Initialize attest-it split configuration (policy.yaml + config.yaml)')
   .option('-d, --dir <dir>', 'Config directory', '.attest-it')
   .option('-f, --force', 'Overwrite existing config')
   .option('--migrate', 'Migrate an existing unified config.yaml into split policy + config')
+  .option(
+    '--root-signer <slug>',
+    'Bootstrap the trust anchor: establish this identity as the root signer and seal ' +
+      '.attest-it/policy.yaml. Must be your active local identity.',
+  )
   .action(async (options: InitOptions) => {
     await runInit(options)
   })
@@ -24,6 +41,7 @@ interface InitOptions {
   dir: string
   force?: boolean
   migrate?: boolean
+  rootSigner?: string
 }
 
 /**
@@ -293,18 +311,158 @@ async function runInit(options: InitOptions): Promise<void> {
     success(`Configuration created:`)
     log(`  - ${policyPath} (team, gates, security settings)`)
     log(`  - ${operationalPath} (suites, command settings)`)
+
+    // Bootstrap ceremony: establish the root gate's authorized signer over
+    // policy.yaml. This is the explicit, human-run trust anchor — never silently
+    // defaulted. It runs when --root-signer is passed, or interactively when a
+    // TTY and an active identity are available.
+    const bootstrapped = await maybeBootstrapRootGate(options, policyPath)
+
     log('')
     log('Next steps:')
     log(`  1. Run: ${packageManager} install`)
-    log("  2. Run: attest-it identity create  (if you haven't already)")
-    log('  3. Run: attest-it team join')
-    log(`  4. Edit ${policyPath} to define your gates, and ${operationalPath} to define suites`)
+    if (bootstrapped) {
+      log(`  2. Edit ${policyPath} to define your gates, and ${operationalPath} to define suites`)
+      log('  3. After editing trust-critical policy, re-seal the root gate: attest-it seal --root')
+    } else {
+      log("  2. Run: attest-it identity create  (if you haven't already)")
+      log('  3. Run: attest-it team join')
+      log('  4. Bootstrap the trust anchor: attest-it init --root-signer <your-identity-slug>')
+      log(`  5. Edit ${policyPath} to define your gates, and ${operationalPath} to define suites`)
+    }
 
     // Offer to install shell completions
     await offerCompletionInstall()
   } catch (err) {
     handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
+}
+
+/**
+ * Run the bootstrap ceremony that establishes the root gate over policy.yaml.
+ *
+ * Decides whether to bootstrap based on explicit signals only (never a silent
+ * default): the `--root-signer` flag, or an interactive confirmation when a TTY
+ * and an active identity are present. On confirmation it establishes the active
+ * identity as the sole root signer, records it in `rootGate`, and creates the
+ * anchoring seal over the policy file — all in this single command invocation.
+ *
+ * @returns True if the repository was bootstrapped to a trust-anchored state.
+ */
+async function maybeBootstrapRootGate(options: InitOptions, policyPath: string): Promise<boolean> {
+  const localConfig = loadLocalConfigSync()
+  const identity = localConfig ? getActiveIdentity(localConfig) : undefined
+  const identitySlug = localConfig?.activeIdentity
+
+  // Explicit flag path.
+  if (options.rootSigner !== undefined) {
+    if (!identity || !identitySlug) {
+      throw new Error(
+        'Cannot bootstrap the root gate: no active local identity found. ' +
+          'Run "attest-it identity create" first.',
+      )
+    }
+    if (options.rootSigner !== identitySlug) {
+      throw new Error(
+        `--root-signer '${options.rootSigner}' does not match your active identity ` +
+          `'${identitySlug}'. The bootstrapping signer must be an identity you hold the ` +
+          'private key for, so that it can create the anchoring seal.',
+      )
+    }
+    await bootstrapRootGate(identity, identitySlug, policyPath)
+    return true
+  }
+
+  // Interactive path: only prompt when we actually can bootstrap.
+  if (identity && identitySlug && isInteractiveTTY()) {
+    const confirmed = await confirmAction({
+      message:
+        `Establish '${identitySlug}' as this repository's root signer (the trust anchor ` +
+        'over policy.yaml)? This can only be changed later by an existing root signer.',
+      default: false,
+    })
+    if (confirmed) {
+      await bootstrapRootGate(identity, identitySlug, policyPath)
+      return true
+    }
+    return false
+  }
+
+  return false
+}
+
+/**
+ * Establish the root gate and create its anchoring seal over the policy file.
+ *
+ * Adds the identity to `team`, sets `rootGate.authorizedSigners`, then seals the
+ * resulting policy content with the identity's private key. After this returns,
+ * `attest-it verify` treats the policy as trust-anchored.
+ */
+async function bootstrapRootGate(
+  identity: Identity,
+  identitySlug: string,
+  policyPath: string,
+): Promise<void> {
+  // Read and mutate the scaffolded policy to add the root signer + rootGate.
+  const rawPolicy = await fs.promises.readFile(policyPath, 'utf8')
+  const parsed: unknown = parseYaml(rawPolicy)
+  const policy: Record<string, unknown> = isPlainRecord(parsed) ? { ...parsed } : {}
+
+  policy.version ??= 1
+
+  const team: Record<string, unknown> = isPlainRecord(policy.team) ? { ...policy.team } : {}
+  // eslint-disable-next-line security/detect-object-injection -- identitySlug is the operator's own local identity slug, not attacker-controlled
+  team[identitySlug] = {
+    name: identity.name,
+    publicKey: identity.publicKey,
+    publicKeyAlgorithm: 'ed25519',
+  }
+  policy.team = team
+
+  policy.rootGate = {
+    authorizedSigners: [identitySlug],
+    description: 'Trust anchor over .attest-it/policy.yaml',
+  }
+
+  // Resolve the seals path the verifier will read from, so the anchoring seal
+  // lands where `attest-it verify` looks (config.settings.sealsPath). Defaults
+  // to the policy schema default when unspecified.
+  const settings = isPlainRecord(policy.settings) ? policy.settings : {}
+  const sealsPath =
+    typeof settings.sealsPath === 'string' ? settings.sealsPath : '.attest-it/seals.json'
+
+  const policyHeader =
+    '# yaml-language-server: $schema=https://raw.githubusercontent.com/mike-north/attest-it/main/schemas/v1/policy.schema.json\n' +
+    '# attest-it policy configuration (trust-critical) — bootstrapped root gate\n\n'
+  await fs.promises.writeFile(policyPath, policyHeader + stringifyYaml(policy), 'utf8')
+
+  // Seal the policy file as the root gate, using the same primitives as any
+  // other gate seal.
+  const projectRoot = process.cwd()
+  const resolvedPolicyPath = findPolicyPath(projectRoot) ?? policyPath
+  const policyFingerprint = computePolicyFingerprintSync(projectRoot, resolvedPolicyPath)
+
+  const { privateKeyPem, passphrase } = await loadIdentitySigningKey(identity)
+  const seal = createRootSeal({
+    policyFingerprint,
+    sealedBy: identitySlug,
+    privateKey: privateKeyPem,
+    ...(passphrase !== undefined && { passphrase }),
+  })
+
+  const sealsFile = readSealsSync(projectRoot, sealsPath)
+  // eslint-disable-next-line security/detect-object-injection -- ROOT_GATE_ID is a fixed reserved constant
+  sealsFile.seals[ROOT_GATE_ID] = seal
+  writeSealsSync(projectRoot, sealsFile, sealsPath)
+
+  log('')
+  success(`Trust anchor established: '${identitySlug}' is the root signer`)
+  log(`  Root gate sealed over ${resolvedPolicyPath}`)
+  log(`  Fingerprint: ${seal.fingerprint}`)
+  warn(
+    '  Changing the root signers later requires a seal from an existing root signer — ' +
+      'a branch cannot bootstrap a new root of trust for itself.',
+  )
 }
 
 export { runInit }

--- a/packages/cli/src/commands/seal.ts
+++ b/packages/cli/src/commands/seal.ts
@@ -9,6 +9,9 @@ import {
   loadLocalConfigSync,
   getActiveIdentity,
   computeFingerprintSync,
+  computePolicyFingerprintSync,
+  createRootSeal,
+  findPolicyPath,
   isAuthorizedSigner,
   getGate,
   createSeal,
@@ -17,6 +20,7 @@ import {
   verifyGateSeal,
   isEncryptedPrivateKeyPem,
   KeyProviderRegistry,
+  ROOT_GATE_ID,
   API_SCHEMA_VERSION,
   type AttestItConfig,
   type FailureClass,
@@ -27,19 +31,26 @@ import {
 import { log, success, error, warn, verbose, outputJson } from '../utils/output.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { resolveKeyPassphrase } from '../utils/passphrase.js'
+import { loadIdentitySigningKey } from '../utils/identity-key.js'
 
 export const sealCommand = new Command('seal')
   .description('Create seals for gates')
   .argument('[gates...]', 'Gate IDs to seal (defaults to all gates without valid seals)')
   .option('--force', 'Force seal creation even if gate already has a valid seal')
+  .option('--root', 'Seal the reserved root gate over .attest-it/policy.yaml (root signers only)')
   .option('--dry-run', 'Show what would be sealed without creating seals')
   .option('--json', 'Output JSON for machine parsing (non-interactive)')
   .action(async (gates: string[], options: SealOptions) => {
+    if (options.root) {
+      await runSealRoot(options)
+      return
+    }
     await runSeal(gates, options)
   })
 
 interface SealOptions {
   force?: boolean
+  root?: boolean
   dryRun?: boolean
   json?: boolean
 }
@@ -198,6 +209,125 @@ async function runSeal(gates: string[], options: SealOptions): Promise<void> {
     } else {
       process.exit(ExitCode.SUCCESS)
     }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error occurred'
+    failFast(message, ExitCode.CONFIG_ERROR, json)
+  }
+}
+
+/**
+ * Seal the reserved root gate over `.attest-it/policy.yaml`.
+ *
+ * The root seal anchors the trust chain: it authorizes the CURRENT content of
+ * the policy file (team & gate authorization data). Only a team member listed in
+ * `rootGate.authorizedSigners` may create it — which is exactly what prevents a
+ * branch from bootstrapping a new root of trust for itself (changing the root
+ * signers requires a seal from an existing root signer).
+ *
+ * @param options - Command options (only `--json` and `--dry-run` apply here).
+ * @public
+ */
+async function runSealRoot(options: SealOptions): Promise<void> {
+  const json = options.json
+  try {
+    const config = await loadSplitConfig()
+
+    if (!config.rootGate) {
+      failFast(
+        'No rootGate defined in .attest-it/policy.yaml. Run the "attest-it init" bootstrap ' +
+          'ceremony to establish a root signer before sealing the root gate.',
+        ExitCode.CONFIG_ERROR,
+        json,
+      )
+    }
+
+    const localConfig = loadLocalConfigSync()
+    if (!localConfig) {
+      failFast(
+        'No local identity configuration found. Run "attest-it identity create" first.',
+        ExitCode.CONFIG_ERROR,
+        json,
+      )
+    }
+
+    const identity = getActiveIdentity(localConfig)
+    if (!identity) {
+      failFast(
+        `Active identity '${localConfig.activeIdentity}' not found in local config`,
+        ExitCode.CONFIG_ERROR,
+        json,
+      )
+    }
+
+    const identitySlug = localConfig.activeIdentity
+
+    // Only an authorized root signer may seal the root gate.
+    if (!config.rootGate.authorizedSigners.includes(identitySlug)) {
+      failFast(
+        `Active identity '${identitySlug}' is not an authorized root signer ` +
+          `(authorized: ${config.rootGate.authorizedSigners.join(', ')}). ` +
+          'A branch cannot bootstrap a new root of trust for itself.',
+        ExitCode.FAILURE,
+        json,
+      )
+    }
+
+    const projectRoot = process.cwd()
+    const policyPath = findPolicyPath(projectRoot)
+    if (!policyPath) {
+      failFast('Policy file not found under .attest-it/', ExitCode.CONFIG_ERROR, json)
+    }
+
+    const policyFingerprint = computePolicyFingerprintSync(projectRoot, policyPath)
+
+    if (options.dryRun) {
+      if (json) {
+        outputJson({
+          schemaVersion: API_SCHEMA_VERSION,
+          ok: true,
+          dryRun: true,
+          root: { fingerprint: policyFingerprint, sealedBy: identitySlug },
+        })
+      } else {
+        log(`Would seal root gate over ${policyPath}`)
+        log(`  Fingerprint: ${policyFingerprint}`)
+        log(`  Sealed by: ${identitySlug}`)
+      }
+      process.exit(ExitCode.SUCCESS)
+    }
+
+    const { privateKeyPem, passphrase } = await loadIdentitySigningKey(identity)
+
+    const seal = createRootSeal({
+      policyFingerprint,
+      sealedBy: identitySlug,
+      privateKey: privateKeyPem,
+      ...(passphrase !== undefined && { passphrase }),
+    })
+
+    const sealsFile = readSealsSync(projectRoot, config.settings.sealsPath)
+    // eslint-disable-next-line security/detect-object-injection -- ROOT_GATE_ID is a fixed reserved constant
+    sealsFile.seals[ROOT_GATE_ID] = seal
+    writeSealsSync(projectRoot, sealsFile, config.settings.sealsPath)
+
+    if (json) {
+      outputJson({
+        schemaVersion: API_SCHEMA_VERSION,
+        ok: true,
+        dryRun: false,
+        root: {
+          fingerprint: seal.fingerprint,
+          sealedBy: seal.sealedBy,
+          sealedAt: seal.timestamp,
+        },
+      })
+    } else {
+      success('Root gate sealed over .attest-it/policy.yaml')
+      log(`  Sealed by: ${identitySlug} (${identity.name})`)
+      log(`  Fingerprint: ${seal.fingerprint}`)
+      log(`  Timestamp: ${seal.timestamp}`)
+    }
+    process.exit(ExitCode.SUCCESS)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error occurred'
     failFast(message, ExitCode.CONFIG_ERROR, json)

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -2,12 +2,17 @@ import { Command } from 'commander'
 import {
   loadSplitConfig,
   computeFingerprintSync,
+  computePolicyFingerprintSync,
+  findPolicyPath,
   readSealsSync,
   verifyAllSeals,
   verifyGateSeal,
+  verifyRootGate,
+  isBlockingRootGateState,
   SplitConfigNotFoundError,
   type VerificationState,
   type SealVerificationResult,
+  type RootGateVerificationResult,
 } from '@attest-it/core'
 import {
   log,
@@ -63,6 +68,37 @@ async function runVerify(
       configPath ? { policySource: { type: 'filesystem', path: configPath } } : {},
     )
 
+    // Read seals (needed for both the root-gate pre-step and gate evaluation).
+    const projectRoot = process.cwd()
+    const sealsFile = readSealsSync(projectRoot, config.settings.sealsPath)
+
+    // MANDATORY PRE-STEP: verify the config's OWN seal chain against the root
+    // gate BEFORE evaluating any other gate. Gate evaluation must never proceed
+    // against a policy whose own root-gate seal did not verify. Repositories that
+    // have not run the bootstrap ceremony define no rootGate; there is no trust
+    // anchor to check, so evaluation proceeds unchanged (backward compatibility).
+    if (config.rootGate) {
+      const policyPath = configPath ?? findPolicyPath(projectRoot)
+      if (policyPath) {
+        const policyFingerprint = computePolicyFingerprintSync(projectRoot, policyPath)
+        const rootResult = verifyRootGate({ config, policyFingerprint, seals: sealsFile })
+
+        if (isBlockingRootGateState(rootResult.state)) {
+          if (options.json) {
+            outputJson([rootGateResultToJson(rootResult)])
+          } else {
+            log('')
+            error(rootResult.message)
+          }
+          process.exit(ExitCode.FAILURE)
+        }
+
+        if (rootResult.state === 'STALE' && !options.json) {
+          warn(rootResult.message)
+        }
+      }
+    }
+
     // Config loaded successfully but defines zero gates: there is nothing to verify.
     // This is distinct from a missing/unreadable config (CONFIG_ERROR) — the config
     // is valid, so treat it as NO_WORK rather than an error or a silent success.
@@ -74,10 +110,6 @@ async function runVerify(
       }
       process.exit(ExitCode.NO_WORK)
     }
-
-    // Read seals
-    const projectRoot = process.cwd()
-    const sealsFile = readSealsSync(projectRoot, config.settings.sealsPath)
 
     // Determine which gates to verify
     const gatesToVerify = gates.length > 0 ? gates : Object.keys(config.gates)
@@ -153,6 +185,19 @@ async function runVerify(
       error('Unknown error occurred')
     }
     process.exit(ExitCode.CONFIG_ERROR)
+  }
+}
+
+/**
+ * Shape a root-gate verification result into the same JSON envelope as ordinary
+ * gate results so `verify --json` consumers see a single, uniform array.
+ */
+function rootGateResultToJson(result: RootGateVerificationResult): SealVerificationResult {
+  return {
+    gateId: result.gateId,
+    state: result.state === 'NOT_ANCHORED' ? 'MISSING' : result.state,
+    ...(result.seal && { seal: result.seal }),
+    message: result.message,
   }
 }
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -27,7 +27,9 @@ import {
 import { ExitCode } from '../utils/exit-codes.js'
 
 export const verifyCommand = new Command('verify')
-  .description('Verify all gate seals (for CI)')
+  .description(
+    'Verify gate seals against the local policy (fast local pre-check, not a CI trust gate)',
+  )
   .argument('[gates...]', 'Verify specific gates only')
   .option('--json', 'Output JSON for machine parsing')
   .action(async (gates: string[], options: VerifyOptions, command: Command) => {
@@ -40,10 +42,27 @@ interface VerifyOptions {
 }
 
 /**
- * Run the verify command to validate gate seals.
+ * Run the verify command to validate gate seals against the local policy.
  *
- * Verifies signature validity and checks seal status for all gates
- * or specific gates. Intended for CI/CD pipelines.
+ * Verifies signature validity and checks seal status for all gates or specific
+ * gates, and (when the policy is trust-anchored) checks the root-gate seal over
+ * `policy.yaml` first.
+ *
+ * ## This is a local pre-check, NOT the CI trust boundary
+ *
+ * Local `verify` evaluates everything against the **working tree's** policy:
+ * `rootGate`, `team`, and `gates` are read from the local `policy.yaml`. That is
+ * correct for a developer checking their own tree, but it is **not** safe as a
+ * pull-request gate. A branch can rewrite its own `rootGate.authorizedSigners` to
+ * a key it controls and re-seal the policy; local `verify` trusts that local
+ * anchor and reports VALID by design (see the "Scenario B" regression test in
+ * `packages/cli/test/integration/root-gate.integration.test.ts`).
+ *
+ * The trust boundary is the **GitHub Action** (`@attest-it/github-action`), which
+ * sources `rootGate`/`team`/`gates` from the **base branch**, so a self-added root
+ * signer is rejected as `UNKNOWN_SIGNER`. For CI, use the Action. A CLI-native
+ * base-vs-worktree mode (`verify --base <ref>`) is planned in #115; until it
+ * lands, do not rely on plain local `verify` to gate untrusted proposal branches.
  *
  * Exits {@link ExitCode.CONFIG_ERROR} — never {@link ExitCode.SUCCESS} — when no
  * configuration can be found at all (no `.attest-it/policy.yaml` discoverable, or an

--- a/packages/cli/src/utils/identity-key.ts
+++ b/packages/cli/src/utils/identity-key.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared helpers for materializing an identity's private key for signing.
+ *
+ * The `seal`, `run`, and `init` (bootstrap ceremony) commands all need to load
+ * the PEM-encoded private key behind the active identity through its configured
+ * key-provider backend, and resolve a passphrase when the key is encrypted. This
+ * module centralizes that logic so there is a single, audited signing key path.
+ *
+ * @module
+ */
+
+import { readFile } from 'node:fs/promises'
+import { KeyProviderRegistry, isEncryptedPrivateKeyPem, type Identity } from '@attest-it/core'
+import { resolveKeyPassphrase } from './passphrase.js'
+
+/**
+ * Create a key provider for an identity's private key reference.
+ */
+function createKeyProviderFromIdentity(
+  identity: Identity,
+): ReturnType<typeof KeyProviderRegistry.create> {
+  const { privateKey } = identity
+
+  switch (privateKey.type) {
+    case 'file':
+      return KeyProviderRegistry.create({ type: 'filesystem', options: {} })
+    case 'keychain':
+      return KeyProviderRegistry.create({ type: 'macos-keychain', options: {} })
+    case '1password':
+      return KeyProviderRegistry.create({ type: '1password', options: {} })
+    case 'yubikey':
+      return KeyProviderRegistry.create({ type: 'yubikey', options: {} })
+    case 'filesystem':
+      return KeyProviderRegistry.create({ type: 'filesystem-legacy', options: {} })
+    default: {
+      const _exhaustiveCheck: never = privateKey
+      throw new Error(`Unsupported private key type: ${String(_exhaustiveCheck)}`)
+    }
+  }
+}
+
+/**
+ * Get the key reference string from an identity's private key reference.
+ *
+ * For v2 VaultKeeper-backed types the reference is the secret id; for the legacy
+ * filesystem type it is the file path.
+ */
+function getKeyRefFromIdentity(identity: Identity): string {
+  const { privateKey } = identity
+
+  switch (privateKey.type) {
+    case 'file':
+    case 'keychain':
+    case '1password':
+    case 'yubikey':
+      return privateKey.id
+    case 'filesystem':
+      return privateKey.path
+    default: {
+      const _exhaustiveCheck: never = privateKey
+      throw new Error(`Unsupported private key type: ${String(_exhaustiveCheck)}`)
+    }
+  }
+}
+
+/**
+ * The material needed to sign with an identity: the PEM private key and, when it
+ * is passphrase-encrypted, the resolved passphrase.
+ */
+export interface IdentitySigningKey {
+  /** PEM-encoded private key. */
+  privateKeyPem: string
+  /** Passphrase for the key, if it is encrypted. */
+  passphrase?: string
+}
+
+/**
+ * Load the PEM private key behind an identity through its key-provider backend
+ * and resolve a passphrase if the key is encrypted.
+ *
+ * @param identity - The active identity to sign with.
+ * @returns The signing key material.
+ */
+export async function loadIdentitySigningKey(identity: Identity): Promise<IdentitySigningKey> {
+  const keyProvider = createKeyProviderFromIdentity(identity)
+  const keyRef = getKeyRefFromIdentity(identity)
+
+  const keyResult = await keyProvider.getPrivateKey(keyRef)
+  let privateKeyPem: string
+  try {
+    privateKeyPem = await readFile(keyResult.keyPath, 'utf8')
+  } finally {
+    await keyResult.cleanup()
+  }
+
+  if (isEncryptedPrivateKeyPem(privateKeyPem)) {
+    const passphrase = await resolveKeyPassphrase()
+    return { privateKeyPem, passphrase }
+  }
+  return { privateKeyPem }
+}

--- a/packages/cli/test/integration/root-gate.integration.test.ts
+++ b/packages/cli/test/integration/root-gate.integration.test.ts
@@ -1,0 +1,345 @@
+/**
+ * End-to-end integration tests for the sealed root gate over policy.yaml (#72).
+ *
+ * These drive the real, built `attest-it` binary against fixture repositories
+ * with tampered and well-formed `.attest-it/policy.yaml`, proving the PRD R1
+ * acceptance criteria at the user-facing (CLI) layer:
+ *   - adversarial: an untrusted policy change fails `verify`, naming the change
+ *   - positive: a root-signer-sealed policy change verifies and gates evaluate
+ *   - bootstrap: a fresh repo reaches trusted state in one human-run ceremony
+ *
+ * @see Issue #72 acceptance criteria
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import {
+  createSeal,
+  createRootSeal,
+  computePolicyFingerprintSync,
+  generateEd25519KeyPair,
+  ROOT_GATE_ID,
+  type SealsFile,
+} from '@attest-it/core'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+const FIXTURE_PATH = path.resolve(__dirname, '../fixtures/sample-project')
+const CLI_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+function runCli(args: string[], cwd: string, env: NodeJS.ProcessEnv = {}): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (c: Buffer) => (stdout += c.toString()))
+    child.stderr.on('data', (c: Buffer) => (stderr += c.toString()))
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`CLI did not exit in ${String(CLI_TIMEOUT_MS)}ms: ${args.join(' ')}`))
+    }, CLI_TIMEOUT_MS)
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+async function runGit(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', args, { cwd, stdio: 'ignore' })
+    child.on('close', (code) =>
+      code === 0 ? resolve() : reject(new Error(`git ${args.join(' ')} -> ${String(code)}`)),
+    )
+    child.on('error', reject)
+  })
+}
+
+async function copyDir(src: string, dest: string): Promise<void> {
+  await fs.promises.mkdir(dest, { recursive: true })
+  for (const entry of await fs.promises.readdir(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name)
+    const d = path.join(dest, entry.name)
+    if (entry.isDirectory()) await copyDir(s, d)
+    else await fs.promises.copyFile(s, d)
+  }
+}
+
+/** Read, mutate, and write the policy.yaml at `<dir>/.attest-it/policy.yaml`. */
+function editPolicy(dir: string, mutate: (policy: Record<string, unknown>) => void): void {
+  const policyPath = path.join(dir, '.attest-it', 'policy.yaml')
+  const policy = parseYaml(fs.readFileSync(policyPath, 'utf8')) as Record<string, unknown>
+  mutate(policy)
+  fs.writeFileSync(policyPath, stringifyYaml(policy), 'utf8')
+}
+
+function writeSeals(dir: string, seals: SealsFile): void {
+  fs.writeFileSync(
+    path.join(dir, '.attest-it', 'seals.json'),
+    JSON.stringify(seals, null, 2),
+    'utf8',
+  )
+}
+
+describe('root gate — CLI verify against tampered/valid policy.yaml (#72)', () => {
+  let dir: string
+  let ownerPrivateKey: string
+  let ownerPublicKey: string
+
+  beforeEach(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-rootgate-'))
+    await copyDir(FIXTURE_PATH, dir)
+
+    const kp = generateEd25519KeyPair()
+    ownerPrivateKey = kp.privateKey
+    ownerPublicKey = kp.publicKey
+
+    // Anchor the fixture: give the owner a real key, add a rootGate, and seal the
+    // policy + the example gate. This is the bootstrapped, trusted starting state.
+    editPolicy(dir, (policy) => {
+      policy.rootGate = { authorizedSigners: ['test-user'] }
+      const team = policy.team as Record<string, { publicKey: string }>
+      team['test-user'].publicKey = ownerPublicKey
+    })
+
+    await runGit(['init'], dir)
+    await runGit(['config', 'user.email', 'test@example.com'], dir)
+    await runGit(['config', 'user.name', 'Test User'], dir)
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 'anchor policy'], dir)
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(dir, { recursive: true, force: true })
+  })
+
+  /** Anchor the current on-disk policy by writing a valid root seal over it. */
+  function sealRoot(): void {
+    const policyPath = path.join(dir, '.attest-it', 'policy.yaml')
+    const rootSeal = createRootSeal({
+      policyFingerprint: computePolicyFingerprintSync(dir, policyPath),
+      sealedBy: 'test-user',
+      privateKey: ownerPrivateKey,
+    })
+    writeSeals(dir, { version: 1, seals: { [ROOT_GATE_ID]: rootSeal } })
+  }
+
+  it('POSITIVE: a policy sealed by a genuine root signer verifies, and gates evaluate against it', async () => {
+    // Seal the current (well-formed) policy as the root gate.
+    const policyPath = path.join(dir, '.attest-it', 'policy.yaml')
+    const rootSeal = createRootSeal({
+      policyFingerprint: computePolicyFingerprintSync(dir, policyPath),
+      sealedBy: 'test-user',
+      privateKey: ownerPrivateKey,
+    })
+
+    // Also seal the example gate so it evaluates VALID once the root is trusted.
+    const statusJson = await runCli(['status', 'example-gate', '--json'], dir)
+    const status = JSON.parse(statusJson.stdout) as { currentFingerprint: string }[]
+    const gateFingerprint = status[0]!.currentFingerprint
+    const gateSeal = createSeal({
+      gateId: 'example-gate',
+      fingerprint: gateFingerprint,
+      sealedBy: 'test-user',
+      privateKey: ownerPrivateKey,
+    })
+    writeSeals(dir, { version: 1, seals: { [ROOT_GATE_ID]: rootSeal, 'example-gate': gateSeal } })
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 'seal root + gate'], dir)
+
+    const result = await runCli(['verify', 'example-gate'], dir)
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('VALID')
+    // The root pre-step did not report an untrusted policy.
+    expect(result.stdout).not.toContain('Untrusted')
+    expect(result.stderr).not.toContain('Untrusted')
+  })
+
+  it('ADVERSARIAL 1: adding a key to team and authorizing it, without a root re-seal, fails verify and names the untrusted change', async () => {
+    // Anchor the ORIGINAL policy.
+    sealRoot()
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 'anchor'], dir)
+
+    // Attacker adds a new team member + authorizes them on the example gate.
+    const attacker = generateEd25519KeyPair()
+    editPolicy(dir, (policy) => {
+      const team = policy.team as Record<string, unknown>
+      team.mallory = { name: 'Mallory', publicKey: attacker.publicKey }
+      const gates = policy.gates as Record<string, { authorizedSigners: string[] }>
+      gates['example-gate'].authorizedSigners.push('mallory')
+    })
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 'tamper: add mallory'], dir)
+
+    const result = await runCli(['verify', 'example-gate'], dir)
+    expect(result.exitCode).toBe(1)
+    const combined = result.stdout + result.stderr
+    // Not a generic failure: it names the untrusted policy change.
+    expect(combined).toContain('.attest-it/policy.yaml')
+    expect(combined.toLowerCase()).toContain('root signer')
+  })
+
+  it('ADVERSARIAL 2: modifying an existing gate authorizedSigners without a root re-seal fails verify', async () => {
+    sealRoot()
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 'anchor'], dir)
+
+    // Change an existing gate's authorized signer set to a different (valid)
+    // team member. The config still validates — only the root pre-step catches
+    // that the trust-critical policy changed without a root re-seal.
+    editPolicy(dir, (policy) => {
+      const team = policy.team as Record<string, unknown>
+      team.reviewer = { name: 'Reviewer', publicKey: generateEd25519KeyPair().publicKey }
+      const gates = policy.gates as Record<string, { authorizedSigners: string[] }>
+      gates['example-gate'].authorizedSigners = ['reviewer']
+    })
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 'tamper: swap signer'], dir)
+
+    const result = await runCli(['verify', 'example-gate'], dir)
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout + result.stderr).toContain('.attest-it/policy.yaml')
+  })
+
+  it('POSITIVE follow-up: after a root signer re-seals the changed policy, verify passes again', async () => {
+    // Legitimately add a member, then RE-SEAL the root over the new content.
+    const dev = generateEd25519KeyPair()
+    editPolicy(dir, (policy) => {
+      const team = policy.team as Record<string, unknown>
+      team.dev = { name: 'Dev', publicKey: dev.publicKey }
+    })
+    const policyPath = path.join(dir, '.attest-it', 'policy.yaml')
+    const rootSeal = createRootSeal({
+      policyFingerprint: computePolicyFingerprintSync(dir, policyPath),
+      sealedBy: 'test-user',
+      privateKey: ownerPrivateKey,
+    })
+    const statusJson = await runCli(['status', 'example-gate', '--json'], dir)
+    const gateFp = (JSON.parse(statusJson.stdout) as { currentFingerprint: string }[])[0]!
+      .currentFingerprint
+    const gateSeal = createSeal({
+      gateId: 'example-gate',
+      fingerprint: gateFp,
+      sealedBy: 'test-user',
+      privateKey: ownerPrivateKey,
+    })
+    writeSeals(dir, { version: 1, seals: { [ROOT_GATE_ID]: rootSeal, 'example-gate': gateSeal } })
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 're-seal after change'], dir)
+
+    const result = await runCli(['verify', 'example-gate'], dir)
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('VALID')
+  })
+})
+
+describe('root gate — bootstrap ceremony reaches trusted state in one human-run step (#72)', () => {
+  let projectDir: string
+  let homeDir: string
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-bootstrap-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-bootstrap-home-'))
+    await fs.promises.mkdir(path.join(projectDir, 'src'), { recursive: true })
+    await fs.promises.writeFile(path.join(projectDir, 'src', 'index.ts'), 'export const x = 1\n')
+    await runGit(['init'], projectDir)
+    await runGit(['config', 'user.email', 'test@example.com'], projectDir)
+    await runGit(['config', 'user.name', 'Test User'], projectDir)
+    await runGit(['add', '.'], projectDir)
+    await runGit(['commit', '-m', 'initial'], projectDir)
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  it('identity create -> init --root-signer establishes the trust anchor; tampering it then fails verify', async () => {
+    const env = { ATTEST_IT_HOME: homeDir }
+
+    const create = await runCli(
+      ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+      projectDir,
+      env,
+    )
+    expect(create.exitCode).toBe(0)
+
+    // THE single ceremony step: scaffold config, establish the root signer, and
+    // seal policy.yaml — all in one invocation.
+    const bootstrap = await runCli(['init', '--root-signer', 'test-user'], projectDir, env)
+    expect(bootstrap.exitCode).toBe(0)
+    expect(bootstrap.stdout).toContain('Trust anchor established')
+
+    // The repo is now trust-anchored: rootGate recorded + root seal present.
+    const policy = parseYaml(
+      fs.readFileSync(path.join(projectDir, '.attest-it', 'policy.yaml'), 'utf8'),
+    ) as { rootGate?: { authorizedSigners: string[] } }
+    expect(policy.rootGate?.authorizedSigners).toEqual(['test-user'])
+
+    const seals = JSON.parse(
+      fs.readFileSync(path.join(projectDir, '.attest-it', 'seals.json'), 'utf8'),
+    ) as SealsFile
+    expect(seals.seals[ROOT_GATE_ID]).toBeDefined()
+
+    // Add a gate + suite so there is real work to verify, then re-anchor the
+    // (now-changed) policy with `attest-it seal --root` and seal the gate.
+    editPolicy(projectDir, (p) => {
+      const gates = (p.gates ?? {}) as Record<string, unknown>
+      gates['src-gate'] = {
+        name: 'Source Gate',
+        description: 'Source files',
+        authorizedSigners: ['test-user'],
+        fingerprint: { paths: ['src'] },
+        maxAge: '30d',
+      }
+      p.gates = gates
+    })
+    const configPath = path.join(projectDir, '.attest-it', 'config.yaml')
+    const opConfig = parseYaml(fs.readFileSync(configPath, 'utf8')) as Record<string, unknown>
+    opConfig.suites = { src: { gate: 'src-gate', command: 'echo ok' } }
+    fs.writeFileSync(configPath, stringifyYaml(opConfig), 'utf8')
+
+    const reSealRoot = await runCli(['seal', '--root'], projectDir, env)
+    expect(reSealRoot.exitCode).toBe(0)
+    expect(reSealRoot.stdout).toContain('Root gate sealed')
+
+    const sealGate = await runCli(['seal', 'src-gate'], projectDir, env)
+    expect(sealGate.exitCode).toBe(0)
+
+    // The anchor is live and the gate evaluates against the trusted policy.
+    const verifyOk = await runCli(['verify', 'src-gate'], projectDir, env)
+    expect(verifyOk.exitCode).toBe(0)
+    expect(verifyOk.stdout).toContain('VALID')
+    expect(verifyOk.stdout + verifyOk.stderr).not.toContain('Untrusted')
+
+    // Tampering the anchored policy makes verify fail closed, naming the change.
+    editPolicy(projectDir, (p) => {
+      const team = (p.team ?? {}) as Record<string, unknown>
+      team.intruder = { name: 'Intruder', publicKey: generateEd25519KeyPair().publicKey }
+      p.team = team
+    })
+    const verifyTampered = await runCli(['verify', 'src-gate'], projectDir, env)
+    expect(verifyTampered.exitCode).toBe(1)
+    expect(verifyTampered.stdout + verifyTampered.stderr).toContain('.attest-it/policy.yaml')
+  })
+})

--- a/packages/cli/test/integration/root-gate.integration.test.ts
+++ b/packages/cli/test/integration/root-gate.integration.test.ts
@@ -353,7 +353,10 @@ describe('root gate — bootstrap ceremony reaches trusted state in one human-ru
   })
 
   it('identity create -> init --root-signer establishes the trust anchor; tampering it then fails verify', async () => {
-    const env = { ATTEST_IT_HOME: homeDir }
+    // VAULTKEEPER_CONFIG_DIR is redirected to the isolated per-test home so the
+    // `identity create --storage file` step below never writes to the real
+    // VaultKeeper config dir (issue #114 test-isolation guard).
+    const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
     const create = await runCli(
       ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],

--- a/packages/cli/test/integration/root-gate.integration.test.ts
+++ b/packages/cli/test/integration/root-gate.integration.test.ts
@@ -11,7 +11,7 @@
  * @see Issue #72 acceptance criteria
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { spawn } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
@@ -33,6 +33,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
 const FIXTURE_PATH = path.resolve(__dirname, '../fixtures/sample-project')
 const CLI_TIMEOUT_MS = 15000
+// Each test spawns several real CLI subprocesses in sequence (identity create,
+// init/bootstrap, seal, verify, …). vitest's 5s default is far too tight for
+// that on a cold CI runner, so give the whole suite a generous per-test budget.
+const TEST_TIMEOUT_MS = 90000
+vi.setConfig({ testTimeout: TEST_TIMEOUT_MS, hookTimeout: TEST_TIMEOUT_MS })
 
 interface RunResult {
   exitCode: number

--- a/packages/cli/test/integration/root-gate.integration.test.ts
+++ b/packages/cli/test/integration/root-gate.integration.test.ts
@@ -23,7 +23,9 @@ import {
   createRootSeal,
   computePolicyFingerprintSync,
   generateEd25519KeyPair,
+  verifyRootGate,
   ROOT_GATE_ID,
+  type AttestItConfig,
   type SealsFile,
 } from '@attest-it/core'
 
@@ -250,6 +252,82 @@ describe('root gate — CLI verify against tampered/valid policy.yaml (#72)', ()
     const result = await runCli(['verify', 'example-gate'], dir)
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('VALID')
+  })
+
+  it('SCENARIO B — BY DESIGN: a self-rewritten + self-resealed rootGate PASSES plain local verify, while the base-branch trust model (the Action) rejects it', async () => {
+    // This test documents a DELIBERATE design boundary, not a vulnerability.
+    //
+    // Local `attest-it verify` evaluates against the WORKING TREE's policy. If a
+    // branch rewrites `rootGate.authorizedSigners` to a key it controls and
+    // re-seals the policy with that key, local verify trusts that local anchor and
+    // reports VALID — by design. Local verify is a fast pre-check, not the trust
+    // boundary (see the command docblock and docs/threat-model.md).
+    //
+    // The trust boundary is the merge gate: the GitHub Action sources
+    // `rootGate`/`team`/`gates` from the BASE branch, so the same self-rewritten
+    // anchor is rejected as UNKNOWN_SIGNER. We assert BOTH halves so the
+    // intended/observed split is explicit and regression-guarded.
+    const mallory = generateEd25519KeyPair()
+
+    // Attacker rewrites the local policy: root signer -> mallory, and authorizes
+    // mallory on the example gate too.
+    editPolicy(dir, (policy) => {
+      policy.rootGate = { authorizedSigners: ['mallory'] }
+      const team = policy.team as Record<string, unknown>
+      team.mallory = { name: 'Mallory', publicKey: mallory.publicKey }
+      const gates = policy.gates as Record<string, { authorizedSigners: string[] }>
+      gates['example-gate'].authorizedSigners = ['mallory']
+    })
+
+    // Re-seal BOTH the root gate and the example gate with mallory's own key over
+    // the new local policy content.
+    const policyPath = path.join(dir, '.attest-it', 'policy.yaml')
+    const policyFingerprint = computePolicyFingerprintSync(dir, policyPath)
+    const rootSeal = createRootSeal({
+      policyFingerprint,
+      sealedBy: 'mallory',
+      privateKey: mallory.privateKey,
+    })
+    const statusJson = await runCli(['status', 'example-gate', '--json'], dir)
+    const gateFp = (JSON.parse(statusJson.stdout) as { currentFingerprint: string }[])[0]!
+      .currentFingerprint
+    const gateSeal = createSeal({
+      gateId: 'example-gate',
+      fingerprint: gateFp,
+      sealedBy: 'mallory',
+      privateKey: mallory.privateKey,
+    })
+    writeSeals(dir, { version: 1, seals: { [ROOT_GATE_ID]: rootSeal, 'example-gate': gateSeal } })
+    await runGit(['add', '.'], dir)
+    await runGit(['commit', '-m', 'self-rewrite + self-reseal root of trust'], dir)
+
+    // OBSERVED, BY DESIGN: local verify trusts the local anchor -> PASSES.
+    const local = await runCli(['verify', 'example-gate'], dir)
+    expect(local.exitCode).toBe(0)
+    expect(local.stdout).toContain('VALID')
+
+    // INTENDED BOUNDARY: the merge gate (the Action) verifies the SAME working-tree
+    // root seal against the TRUSTED base-branch config, whose rootGate/team still
+    // list only the original owner ('test-user'). Mallory is not a base-branch root
+    // signer, so it is rejected as UNKNOWN_SIGNER.
+    const baseConfig: AttestItConfig = {
+      version: 1,
+      settings: {
+        maxAgeDays: 30,
+        publicKeyPath: '.attest-it/pubkey.pem',
+        attestationsPath: '.attest-it/attestations.json',
+        sealsPath: '.attest-it/seals.json',
+      },
+      rootGate: { authorizedSigners: ['test-user'], maxAge: '365d' },
+      team: { 'test-user': { name: 'Test User', publicKey: ownerPublicKey } },
+      suites: {},
+    }
+    const baseResult = verifyRootGate({
+      config: baseConfig,
+      policyFingerprint,
+      seals: { version: 1, seals: { [ROOT_GATE_ID]: rootSeal } },
+    })
+    expect(baseResult.state).toBe('UNKNOWN_SIGNER')
   })
 })
 

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -44,6 +44,7 @@ export interface AttestItConfig {
     gates?: Record<string, GateConfig>;
     groups?: Record<string, string[]>;
     minVersion?: string;
+    rootGate?: RootGateConfig;
     settings: AttestItSettings;
     suites: Record<string, SuiteConfig>;
     team?: Record<string, TeamMember>;
@@ -76,6 +77,20 @@ export function computeFingerprint(options: FingerprintOptions): Promise<Fingerp
 
 // @public
 export function computeFingerprintSync(options: FingerprintOptions): FingerprintResult;
+
+// @public
+export function computePolicyFingerprint(baseDir: string, policyPath: string): Promise<string>;
+
+// @public
+export function computePolicyFingerprintSync(baseDir: string, policyPath: string): string;
+
+// @public
+export function createRootSeal(params: {
+    passphrase?: string;
+    policyFingerprint: string;
+    privateKey: string;
+    sealedBy: string;
+}): Seal;
 
 // @public
 export function createSeal(options: CreateSealOptions): Seal;
@@ -250,6 +265,9 @@ export interface InaccessibleAccount {
 
 // @public
 export function isAuthorizedSigner(config: AttestItConfig, gateId: string, publicKey: string): boolean;
+
+// @public
+export function isBlockingRootGateState(state: RootGateState): boolean;
 
 // @public
 export function isEncryptedPrivateKeyPem(privateKeyPem: string): boolean;
@@ -619,7 +637,7 @@ export function parsePolicyContent(content: string, format: 'json' | 'yaml'): Po
 export type PolicyConfig = z.infer<typeof policySchema>;
 
 // @public
-export const policySchema: z.ZodObject<{
+export const policySchema: z.ZodEffects<z.ZodObject<{
     gates: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
         authorizedSigners: z.ZodArray<z.ZodString, "many">;
         description: z.ZodString;
@@ -655,6 +673,19 @@ export const policySchema: z.ZodObject<{
         name: string;
     }>>>;
     minVersion: z.ZodOptional<z.ZodString>;
+    rootGate: z.ZodOptional<z.ZodObject<{
+        authorizedSigners: z.ZodArray<z.ZodString, "many">;
+        description: z.ZodOptional<z.ZodString>;
+        maxAge: z.ZodDefault<z.ZodEffects<z.ZodString, string, string>>;
+    }, "strict", z.ZodTypeAny, {
+        authorizedSigners: string[];
+        description?: string | undefined;
+        maxAge: string;
+    }, {
+        authorizedSigners: string[];
+        description?: string | undefined;
+        maxAge?: string | undefined;
+    }>>;
     settings: z.ZodDefault<z.ZodObject<{
         attestationsPath: z.ZodDefault<z.ZodString>;
         maxAgeDays: z.ZodDefault<z.ZodNumber>;
@@ -703,6 +734,11 @@ export const policySchema: z.ZodObject<{
         name: string;
     }> | undefined;
     minVersion?: string | undefined;
+    rootGate?: {
+        authorizedSigners: string[];
+        description?: string | undefined;
+        maxAge: string;
+    } | undefined;
     settings: {
         attestationsPath: string;
         maxAgeDays: number;
@@ -729,6 +765,73 @@ export const policySchema: z.ZodObject<{
         name: string;
     }> | undefined;
     minVersion?: string | undefined;
+    rootGate?: {
+        authorizedSigners: string[];
+        description?: string | undefined;
+        maxAge?: string | undefined;
+    } | undefined;
+    settings?: {
+        attestationsPath?: string | undefined;
+        maxAgeDays?: number | undefined;
+        publicKeyPath?: string | undefined;
+        sealsPath?: string | undefined;
+    } | undefined;
+    team?: Record<string, {
+        email?: string | undefined;
+        github?: string | undefined;
+        name: string;
+        publicKey: string;
+        publicKeyAlgorithm?: "ed25519" | undefined;
+    }> | undefined;
+    version: 1 | string;
+}>, {
+    gates?: Record<string, {
+        authorizedSigners: string[];
+        description: string;
+        fingerprint: {
+            exclude?: string[] | undefined;
+            paths: string[];
+        };
+        maxAge: string;
+        name: string;
+    }> | undefined;
+    minVersion?: string | undefined;
+    rootGate?: {
+        authorizedSigners: string[];
+        description?: string | undefined;
+        maxAge: string;
+    } | undefined;
+    settings: {
+        attestationsPath: string;
+        maxAgeDays: number;
+        publicKeyPath: string;
+        sealsPath: string;
+    };
+    team?: Record<string, {
+        email?: string | undefined;
+        github?: string | undefined;
+        name: string;
+        publicKey: string;
+        publicKeyAlgorithm?: "ed25519" | undefined;
+    }> | undefined;
+    version: 1;
+}, {
+    gates?: Record<string, {
+        authorizedSigners: string[];
+        description: string;
+        fingerprint: {
+            exclude?: string[] | undefined;
+            paths: string[];
+        };
+        maxAge: string;
+        name: string;
+    }> | undefined;
+    minVersion?: string | undefined;
+    rootGate?: {
+        authorizedSigners: string[];
+        description?: string | undefined;
+        maxAge?: string | undefined;
+    } | undefined;
     settings?: {
         attestationsPath?: string | undefined;
         maxAgeDays?: number | undefined;
@@ -787,6 +890,34 @@ export function readSeals(dir: string, sealsPathOverride?: string): Promise<Seal
 
 // @public
 export function readSealsSync(dir: string, sealsPathOverride?: string): SealsFile;
+
+// @public
+export const ROOT_GATE_ID = "__root__";
+
+// @public
+export interface RootGateConfig {
+    authorizedSigners: string[];
+    description?: string;
+    maxAge: string;
+}
+
+// @public
+export type RootGateState = 'NOT_ANCHORED' | SealVerificationResult['state'];
+
+// @public
+export class RootGateVerificationError extends Error {
+    constructor(result: RootGateVerificationResult);
+    // (undocumented)
+    readonly result: RootGateVerificationResult;
+}
+
+// @public
+export interface RootGateVerificationResult {
+    gateId: string;
+    message: string;
+    seal?: Seal;
+    state: RootGateState;
+}
 
 // @public
 export function saveLocalConfig(config: LocalConfig, configPath?: string): Promise<void>;
@@ -921,6 +1052,11 @@ export interface SuiteConfig {
     timeout?: string;
 }
 
+// Warning: (ae-internal-missing-underscore) The name "synthesizeRootGate" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function synthesizeRootGate(rootGate: RootGateConfig, policyRelPath: string): GateConfig;
+
 // @public
 export interface TeamMember {
     email?: string | undefined;
@@ -1025,6 +1161,14 @@ export function verifyGateSeal(config: AttestItConfig, gateId: string, seals: Se
 
 // @public
 export function verifyOne(artifactPath: string, options?: ApiOptions): Promise<ArtifactVerification>;
+
+// @public
+export function verifyRootGate(params: {
+    config: AttestItConfig;
+    policyFingerprint: string;
+    seals: SealsFile;
+    trustedSourceLabel?: string;
+}): RootGateVerificationResult;
 
 // @public
 export function verifySeal(seal: Seal, config: AttestItConfig): SignatureVerificationResult;

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -637,8 +637,8 @@ export function parsePolicyContent(content: string, format: 'json' | 'yaml'): Po
 export type PolicyConfig = z.infer<typeof policySchema>;
 
 // @public
-export const policySchema: z.ZodEffects<z.ZodObject<{
-    gates: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
+export const policySchema: z.ZodObject<{
+    gates: z.ZodOptional<z.ZodRecord<z.ZodEffects<z.ZodString, string, string>, z.ZodObject<{
         authorizedSigners: z.ZodArray<z.ZodString, "many">;
         description: z.ZodString;
         fingerprint: z.ZodObject<{
@@ -723,68 +723,6 @@ export const policySchema: z.ZodEffects<z.ZodObject<{
     }>>>;
     version: z.ZodEffects<z.ZodUnion<[z.ZodLiteral<1>, z.ZodLiteral<string>]>, 1, 1 | string>;
 }, "strict", z.ZodTypeAny, {
-    gates?: Record<string, {
-        authorizedSigners: string[];
-        description: string;
-        fingerprint: {
-            exclude?: string[] | undefined;
-            paths: string[];
-        };
-        maxAge: string;
-        name: string;
-    }> | undefined;
-    minVersion?: string | undefined;
-    rootGate?: {
-        authorizedSigners: string[];
-        description?: string | undefined;
-        maxAge: string;
-    } | undefined;
-    settings: {
-        attestationsPath: string;
-        maxAgeDays: number;
-        publicKeyPath: string;
-        sealsPath: string;
-    };
-    team?: Record<string, {
-        email?: string | undefined;
-        github?: string | undefined;
-        name: string;
-        publicKey: string;
-        publicKeyAlgorithm?: "ed25519" | undefined;
-    }> | undefined;
-    version: 1;
-}, {
-    gates?: Record<string, {
-        authorizedSigners: string[];
-        description: string;
-        fingerprint: {
-            exclude?: string[] | undefined;
-            paths: string[];
-        };
-        maxAge: string;
-        name: string;
-    }> | undefined;
-    minVersion?: string | undefined;
-    rootGate?: {
-        authorizedSigners: string[];
-        description?: string | undefined;
-        maxAge?: string | undefined;
-    } | undefined;
-    settings?: {
-        attestationsPath?: string | undefined;
-        maxAgeDays?: number | undefined;
-        publicKeyPath?: string | undefined;
-        sealsPath?: string | undefined;
-    } | undefined;
-    team?: Record<string, {
-        email?: string | undefined;
-        github?: string | undefined;
-        name: string;
-        publicKey: string;
-        publicKeyAlgorithm?: "ed25519" | undefined;
-    }> | undefined;
-    version: 1 | string;
-}>, {
     gates?: Record<string, {
         authorizedSigners: string[];
         description: string;

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -58,3 +58,17 @@ export {
   UnifiedMigrationError,
   type SplitConfigResult,
 } from './migrations/index.js'
+
+// Root-gate trust anchoring over policy.yaml
+export {
+  ROOT_GATE_ID,
+  RootGateVerificationError,
+  verifyRootGate,
+  createRootSeal,
+  synthesizeRootGate,
+  computePolicyFingerprint,
+  computePolicyFingerprintSync,
+  isBlockingRootGateState,
+  type RootGateState,
+  type RootGateVerificationResult,
+} from './root-gate.js'

--- a/packages/core/src/config/merge.ts
+++ b/packages/core/src/config/merge.ts
@@ -13,6 +13,7 @@ import type {
   AttestItConfig,
   GateConfig,
   KeyProviderSettings,
+  RootGateConfig,
   SuiteConfig,
   TeamMember,
 } from '../types.js'
@@ -172,6 +173,19 @@ export function mergeConfigs(policy: PolicyConfig, operational: OperationalConfi
     version: 1,
     settings,
     suites,
+  }
+
+  // Carry the reserved root gate through from policy (trust-critical). Like
+  // team/gates, it comes exclusively from the policy config.
+  if (policy.rootGate !== undefined) {
+    const rootGate: RootGateConfig = {
+      authorizedSigners: policy.rootGate.authorizedSigners,
+      maxAge: policy.rootGate.maxAge,
+    }
+    if (policy.rootGate.description !== undefined) {
+      rootGate.description = policy.rootGate.description
+    }
+    config.rootGate = rootGate
   }
 
   // Add team from policy if defined

--- a/packages/core/src/config/migrations/policy-graph.ts
+++ b/packages/core/src/config/migrations/policy-graph.ts
@@ -10,7 +10,19 @@
 import { createMigrationGraph, integerStrategy } from '@migrex/core'
 import { fromZod } from '@migrex/zod'
 import { z } from 'zod'
-import { gateSchema, semverSchema, teamMemberSchema } from '../shared-schemas.js'
+import { durationSchema, gateSchema, semverSchema, teamMemberSchema } from '../shared-schemas.js'
+
+/**
+ * Reserved gate identifier for the root gate over `.attest-it/policy.yaml`.
+ *
+ * This slug is intentionally not usable as a normal gate id (the policy schema
+ * rejects it in `gates`), so a pull request cannot define an ordinary gate
+ * named `__root__` and have it treated as the trust anchor. The root gate's
+ * identity comes solely from the top-level `rootGate` section.
+ *
+ * @public
+ */
+export const ROOT_GATE_ID = '__root__'
 
 /**
  * Helper to create a version schema that accepts both number and string versions.
@@ -39,24 +51,65 @@ const policySettingsSchemaV1 = z
   .strict()
 
 /**
- * Zod schema for the policy configuration file (v1).
+ * Zod schema for the reserved root gate (v1).
+ *
+ * Unlike an ordinary gate, the root gate has no user-configurable `fingerprint`:
+ * the artifact it covers is always the policy file itself. Omitting the
+ * fingerprint from the schema is a security property — a branch cannot repoint
+ * the root gate at empty or unrelated content.
  * @internal
  */
-const policySchemaV1 = z
+const rootGateSchemaV1 = z
+  .object({
+    authorizedSigners: z
+      .array(z.string().min(1, 'Root-gate signer slug cannot be empty'))
+      .min(1, 'The root gate requires at least one authorized signer'),
+    maxAge: durationSchema.default('365d'),
+    description: z.string().min(1, 'Root gate description cannot be empty').optional(),
+  })
+  .strict()
+
+/**
+ * Base object schema for the policy configuration file (v1).
+ *
+ * Kept as a bare `ZodObject` (no wrapping effects) so the migrex `fromZod`
+ * adapter, which expects an object schema, can consume it. The reserved-slug
+ * cross-field check is layered on top in {@link policySchemaV1}.
+ * @internal
+ */
+const policyObjectSchemaV1 = z
   .object({
     version: versionSchema(1),
     minVersion: semverSchema.optional(),
     settings: policySettingsSchemaV1.default({}),
+    rootGate: rootGateSchemaV1.optional(),
     team: z.record(z.string(), teamMemberSchema).optional(),
     gates: z.record(z.string(), gateSchema).optional(),
   })
   .strict()
 
 /**
+ * Zod schema for the policy configuration file (v1).
+ * @internal
+ */
+const policySchemaV1 = policyObjectSchemaV1.superRefine((policy, ctx) => {
+  // The reserved root-gate slug may never appear as an ordinary gate: that is
+  // what prevents a PR from redefining "which gate is root" via the
+  // user-editable `gates` map.
+  if (policy.gates && Object.prototype.hasOwnProperty.call(policy.gates, ROOT_GATE_ID)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['gates', ROOT_GATE_ID],
+      message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`,
+    })
+  }
+})
+
+/**
  * Migrex versioned schema for policy config v1.
  * @internal
  */
-const schemaV1 = fromZod('1', policySchemaV1)
+const schemaV1 = fromZod('1', policyObjectSchemaV1)
 
 /**
  * Migration graph for policy configuration.

--- a/packages/core/src/config/migrations/policy-graph.ts
+++ b/packages/core/src/config/migrations/policy-graph.ts
@@ -70,11 +70,29 @@ const rootGateSchemaV1 = z
   .strict()
 
 /**
+ * Key schema for the `gates` record: an ordinary gate slug may never be the
+ * reserved root-gate id.
+ *
+ * The reservation is enforced here — on the record KEY within the object schema
+ * itself — rather than only via a wrapping `superRefine`. This is what keeps the
+ * guard from silently dropping on any validation path: both the refined
+ * {@link policySchemaV1} used by the live loader AND the bare object schema
+ * registered in the migrex migration graph share this exact key constraint, so a
+ * future validation through the graph cannot bypass it. A branch therefore cannot
+ * define an ordinary gate named `__root__` and have it treated as the trust anchor.
+ * @internal
+ */
+const ordinaryGateSlugSchemaV1 = z.string().refine((slug) => slug !== ROOT_GATE_ID, {
+  message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`,
+})
+
+/**
  * Base object schema for the policy configuration file (v1).
  *
  * Kept as a bare `ZodObject` (no wrapping effects) so the migrex `fromZod`
  * adapter, which expects an object schema, can consume it. The reserved-slug
- * cross-field check is layered on top in {@link policySchemaV1}.
+ * guard lives on the `gates` record key ({@link ordinaryGateSlugSchemaV1}), so it
+ * holds identically here and in {@link policySchemaV1}.
  * @internal
  */
 const policyObjectSchemaV1 = z
@@ -84,29 +102,25 @@ const policyObjectSchemaV1 = z
     settings: policySettingsSchemaV1.default({}),
     rootGate: rootGateSchemaV1.optional(),
     team: z.record(z.string(), teamMemberSchema).optional(),
-    gates: z.record(z.string(), gateSchema).optional(),
+    gates: z.record(ordinaryGateSlugSchemaV1, gateSchema).optional(),
   })
   .strict()
 
 /**
  * Zod schema for the policy configuration file (v1).
+ *
+ * Identical validation to {@link policyObjectSchemaV1} — the reserved-slug guard
+ * is enforced on the record key in the object schema itself, so no additional
+ * refinement is required. Exported separately to preserve the historical name.
  * @internal
  */
-const policySchemaV1 = policyObjectSchemaV1.superRefine((policy, ctx) => {
-  // The reserved root-gate slug may never appear as an ordinary gate: that is
-  // what prevents a PR from redefining "which gate is root" via the
-  // user-editable `gates` map.
-  if (policy.gates && Object.prototype.hasOwnProperty.call(policy.gates, ROOT_GATE_ID)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['gates', ROOT_GATE_ID],
-      message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`,
-    })
-  }
-})
+const policySchemaV1 = policyObjectSchemaV1
 
 /**
  * Migrex versioned schema for policy config v1.
+ *
+ * Uses the same object schema the live loader validates against, so the
+ * reserved-slug reservation cannot diverge between the two paths.
  * @internal
  */
 const schemaV1 = fromZod('1', policyObjectSchemaV1)

--- a/packages/core/src/config/root-gate.ts
+++ b/packages/core/src/config/root-gate.ts
@@ -1,0 +1,292 @@
+/**
+ * Root-gate trust anchoring over `.attest-it/policy.yaml`.
+ *
+ * The root gate makes the policy file itself a gated, sealed artifact. Its
+ * authorized signers are established at `attest-it init` time and can only be
+ * changed by a seal from an existing root signer. Verification loads the config,
+ * verifies the config's own seal chain against the root gate FIRST, and only then
+ * evaluates every other gate against the now-trusted config.
+ *
+ * Design notes:
+ * - The root gate's identity lives in a dedicated top-level `rootGate` section,
+ *   never in the user-editable `gates` map, so a PR cannot redefine which gate is
+ *   root (see {@link ROOT_GATE_ID}).
+ * - The root seal goes through the SAME primitives as any other gate seal
+ *   ({@link createSeal} / {@link verifyGateSeal}). This module materializes the
+ *   root gate into a reserved, non-persisted gate slot at verify time and defers
+ *   entirely to {@link verifyGateSeal}, so there is one trust system to audit.
+ * - The artifact the root gate covers is fixed to the policy file; it is never
+ *   user-configurable, so a branch cannot repoint the root gate at empty content.
+ *
+ * @packageDocumentation
+ */
+
+import { relative, resolve } from 'node:path'
+import { computeFingerprint, computeFingerprintSync } from '../fingerprint.js'
+import type { AttestItConfig, GateConfig, RootGateConfig } from '../types.js'
+import { createSeal } from '../seal/operations.js'
+import { verifyGateSeal, type SealVerificationResult } from '../seal/verification.js'
+import type { Seal, SealsFile } from '../seal/types.js'
+import { ROOT_GATE_ID } from './migrations/policy-graph.js'
+
+export { ROOT_GATE_ID }
+
+/**
+ * Repo-relative path of the policy file the root gate covers.
+ *
+ * The fingerprint algorithm hashes the file's normalized relative path together
+ * with its content, so seal creation and verification must agree on this exact
+ * path. It is derived from the resolved policy path relative to the base
+ * directory via {@link computePolicyFingerprintSync}.
+ * @internal
+ */
+const DEFAULT_POLICY_REL_PATH = '.attest-it/policy.yaml'
+
+/**
+ * Verification state of the root gate.
+ *
+ * Extends the ordinary gate {@link SealVerificationResult} states with
+ * `NOT_ANCHORED`, which reports that the policy defines no `rootGate` at all
+ * (a repository that has not yet run the bootstrap ceremony).
+ * @public
+ */
+export type RootGateState = SealVerificationResult['state'] | 'NOT_ANCHORED'
+
+/**
+ * Result of verifying the root gate over the policy file.
+ * @public
+ */
+export interface RootGateVerificationResult {
+  /** Always {@link ROOT_GATE_ID}. */
+  gateId: string
+  /** Root-gate verification state. */
+  state: RootGateState
+  /** The root seal, if one exists. */
+  seal?: Seal
+  /** Human-readable, non-generic explanation of the state. */
+  message: string
+}
+
+/**
+ * Error thrown when the mandatory root-gate pre-step fails, before any other
+ * gate is evaluated. Carries the underlying {@link RootGateVerificationResult}
+ * so callers can render a precise, non-generic message.
+ * @public
+ */
+export class RootGateVerificationError extends Error {
+  constructor(public readonly result: RootGateVerificationResult) {
+    super(result.message)
+    this.name = 'RootGateVerificationError'
+  }
+}
+
+/**
+ * Materialize the root gate as an ordinary {@link GateConfig} so that the exact
+ * same verification pipeline used for every other gate applies to it.
+ *
+ * @param rootGate - The root-gate section from the (trusted) config.
+ * @param policyRelPath - Repo-relative path of the policy file.
+ * @returns A synthetic gate covering the policy file.
+ * @internal
+ */
+export function synthesizeRootGate(rootGate: RootGateConfig, policyRelPath: string): GateConfig {
+  return {
+    name: 'Root Gate',
+    description: rootGate.description ?? 'Trust anchor over .attest-it/policy.yaml',
+    authorizedSigners: rootGate.authorizedSigners,
+    fingerprint: { paths: [policyRelPath] },
+    maxAge: rootGate.maxAge,
+  }
+}
+
+/**
+ * Compute the repo-relative policy path used for root-gate fingerprinting.
+ * @internal
+ */
+function toPolicyRelPath(baseDir: string, policyPath: string): string {
+  const rel = relative(resolve(baseDir), resolve(policyPath))
+  // Guard against a policy path outside baseDir (shouldn't happen in practice):
+  // fall back to the canonical location so the fingerprint stays deterministic.
+  if (rel.length === 0 || rel.startsWith('..')) {
+    return DEFAULT_POLICY_REL_PATH
+  }
+  return rel.split('\\').join('/')
+}
+
+/**
+ * Compute the fingerprint of the policy file that the root gate covers (sync).
+ *
+ * @param baseDir - Base directory (repository root).
+ * @param policyPath - Absolute or relative path to the policy file.
+ * @returns The `sha256:...` fingerprint of the policy file.
+ * @public
+ */
+export function computePolicyFingerprintSync(baseDir: string, policyPath: string): string {
+  const relPath = toPolicyRelPath(baseDir, policyPath)
+  return computeFingerprintSync({ paths: [relPath], baseDir }).fingerprint
+}
+
+/**
+ * Compute the fingerprint of the policy file that the root gate covers (async).
+ *
+ * @param baseDir - Base directory (repository root).
+ * @param policyPath - Absolute or relative path to the policy file.
+ * @returns The `sha256:...` fingerprint of the policy file.
+ * @public
+ */
+export async function computePolicyFingerprint(
+  baseDir: string,
+  policyPath: string,
+): Promise<string> {
+  const relPath = toPolicyRelPath(baseDir, policyPath)
+  const result = await computeFingerprint({ paths: [relPath], baseDir })
+  return result.fingerprint
+}
+
+/**
+ * Create a seal over the policy file for the root gate.
+ *
+ * Delegates to {@link createSeal} with the reserved {@link ROOT_GATE_ID}, so the
+ * root seal is byte-for-byte the same shape as any other gate seal and is
+ * verified by the same code path.
+ *
+ * @public
+ */
+export function createRootSeal(params: {
+  /** Fingerprint of the policy file (from {@link computePolicyFingerprintSync}). */
+  policyFingerprint: string
+  /** Team member slug creating the root seal. */
+  sealedBy: string
+  /** PEM-encoded Ed25519 private key of the root signer. */
+  privateKey: string
+  /** Passphrase for the private key, if it is encrypted. */
+  passphrase?: string
+}): Seal {
+  return createSeal({
+    gateId: ROOT_GATE_ID,
+    fingerprint: params.policyFingerprint,
+    sealedBy: params.sealedBy,
+    privateKey: params.privateKey,
+    ...(params.passphrase !== undefined && { passphrase: params.passphrase }),
+  })
+}
+
+/**
+ * Produce a precise, non-generic message for a root-gate verification state.
+ *
+ * The adversarial acceptance criteria require that a failure NAME the untrusted
+ * config change rather than emit a generic "signature failed". These messages
+ * always identify the policy file and the trust-critical nature of the change.
+ * @internal
+ */
+function describeRootState(state: RootGateState, base: string | undefined): string {
+  switch (state) {
+    case 'VALID':
+      return 'Root gate is valid: .attest-it/policy.yaml is sealed by an authorized root signer.'
+    case 'MISSING':
+      return (
+        'Untrusted policy: .attest-it/policy.yaml is not sealed by a root signer. ' +
+        'The trust-critical policy (team & gate authorization) has no root seal. ' +
+        'Have a root signer run `attest-it seal --root` to anchor it.'
+      )
+    case 'FINGERPRINT_MISMATCH':
+      return (
+        'Untrusted change to .attest-it/policy.yaml: the trust-critical policy ' +
+        '(team &/or gate authorization) was modified, but the modification is not ' +
+        'sealed by a root signer. The existing root seal covers a different policy ' +
+        'fingerprint. Have a root signer re-run `attest-it seal --root` to authorize ' +
+        'this change.'
+      )
+    case 'UNKNOWN_SIGNER':
+      return (
+        'Untrusted policy change: the root seal over .attest-it/policy.yaml was ' +
+        'created by a signer that is not an authorized root signer. A branch cannot ' +
+        'bootstrap a new root of trust for itself — changing the root signers requires ' +
+        'a seal from an existing root signer.' +
+        (base ? ` (${base})` : '')
+      )
+    case 'INVALID_SIGNATURE':
+      return (
+        'Untrusted policy: the root seal over .attest-it/policy.yaml has an invalid ' +
+        'signature and does not authorize the current policy.' +
+        (base ? ` (${base})` : '')
+      )
+    case 'STALE':
+      return (
+        'The root seal over .attest-it/policy.yaml is stale (exceeds the root gate maxAge). ' +
+        'Have a root signer re-run `attest-it seal --root`.'
+      )
+    case 'NOT_ANCHORED':
+      return (
+        'Policy is not trust-anchored: .attest-it/policy.yaml defines no rootGate. ' +
+        'Run the `attest-it init` bootstrap ceremony to establish a root signer.'
+      )
+    default: {
+      // Exhaustiveness guard: every RootGateState is handled above.
+      const _exhaustive: never = state
+      return `Root gate verification failed${base ? ` (${base})` : ''}: ${String(_exhaustive)}`
+    }
+  }
+}
+
+/**
+ * Verify the root gate's seal over the policy file — the mandatory pre-step.
+ *
+ * This reuses {@link verifyGateSeal} verbatim by injecting a synthesized root
+ * gate under the reserved {@link ROOT_GATE_ID} into a shallow copy of the config.
+ * The authorized signer set and team come from `config` (which callers source
+ * from the *trusted* policy — the base branch for the Action, the local policy
+ * for the CLI), so a self-added signer whose key is not in the trusted set is
+ * rejected as `UNKNOWN_SIGNER`.
+ *
+ * @param params.config - Trusted config carrying `rootGate` and `team`.
+ * @param params.policyFingerprint - Fingerprint of the policy file being verified.
+ * @param params.seals - The seals file (root seal stored under {@link ROOT_GATE_ID}).
+ * @returns The root-gate verification result. Never throws.
+ * @public
+ */
+export function verifyRootGate(params: {
+  config: AttestItConfig
+  policyFingerprint: string
+  seals: SealsFile
+  /** Optional label describing the trusted policy source (e.g. "base branch"). */
+  trustedSourceLabel?: string
+}): RootGateVerificationResult {
+  const { config, policyFingerprint, seals, trustedSourceLabel } = params
+
+  if (!config.rootGate) {
+    return {
+      gateId: ROOT_GATE_ID,
+      state: 'NOT_ANCHORED',
+      message: describeRootState('NOT_ANCHORED', trustedSourceLabel),
+    }
+  }
+
+  const syntheticGate = synthesizeRootGate(config.rootGate, DEFAULT_POLICY_REL_PATH)
+  const configWithRoot: AttestItConfig = {
+    ...config,
+    gates: { ...config.gates, [ROOT_GATE_ID]: syntheticGate },
+  }
+
+  const result = verifyGateSeal(configWithRoot, ROOT_GATE_ID, seals, policyFingerprint)
+
+  return {
+    gateId: ROOT_GATE_ID,
+    state: result.state,
+    ...(result.seal && { seal: result.seal }),
+    message: describeRootState(result.state, trustedSourceLabel),
+  }
+}
+
+/**
+ * Whether a root-gate state should block gate evaluation.
+ *
+ * Any state other than `VALID`, `STALE` (a warning, matching ordinary gate
+ * semantics), and `NOT_ANCHORED` (a repository that predates the bootstrap
+ * ceremony) is a hard failure: gate evaluation must not proceed against a policy
+ * whose own root-gate seal did not verify.
+ * @public
+ */
+export function isBlockingRootGateState(state: RootGateState): boolean {
+  return state !== 'VALID' && state !== 'STALE' && state !== 'NOT_ANCHORED'
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   TeamMember,
   FingerprintConfig,
   GateConfig,
+  RootGateConfig,
   SuiteConfig,
   AttestItConfig,
 } from './types.js'
@@ -67,6 +68,17 @@ export {
   migrateUnifiedContent,
   UnifiedMigrationError,
   type SplitConfigResult,
+  // Root-gate trust anchoring over policy.yaml
+  ROOT_GATE_ID,
+  RootGateVerificationError,
+  verifyRootGate,
+  createRootSeal,
+  synthesizeRootGate,
+  computePolicyFingerprint,
+  computePolicyFingerprintSync,
+  isBlockingRootGateState,
+  type RootGateState,
+  type RootGateVerificationResult,
 } from './config/index.js'
 
 // Fingerprinting

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,6 +90,26 @@ export interface GateConfig {
 }
 
 /**
+ * Root-gate definition — the reserved trust anchor over `.attest-it/policy.yaml`.
+ *
+ * The root gate is deliberately NOT an entry in {@link AttestItConfig.gates}: it
+ * lives in its own top-level `rootGate` section so that a pull request cannot
+ * redefine *which* gate is root by editing an ordinary, user-definable gate.
+ * The file it covers (`.attest-it/policy.yaml`) is fixed and not user-configurable,
+ * so a branch cannot repoint the root gate at empty or unrelated content.
+ *
+ * @public
+ */
+export interface RootGateConfig {
+  /** Team member slugs authorized to seal changes to the policy file itself. */
+  authorizedSigners: string[]
+  /** Maximum age before the root seal is considered stale (duration string). */
+  maxAge: string
+  /** Optional human-readable description of the root gate. */
+  description?: string
+}
+
+/**
  * Suite definition from the configuration file.
  * Suites are CLI-layer extensions of gates with command execution capabilities.
  * @public
@@ -122,6 +142,12 @@ export interface AttestItConfig {
   minVersion?: string
   /** Global settings for attestation behavior */
   settings: AttestItSettings
+  /**
+   * Reserved trust anchor over `.attest-it/policy.yaml`. When present, its seal
+   * chain is verified before any other gate is evaluated. Absent on
+   * repositories that have not yet run the `attest-it init` bootstrap ceremony.
+   */
+  rootGate?: RootGateConfig
   /** Team members mapped by slug */
   team?: Record<string, TeamMember>
   /** Gates defining authorization and fingerprinting */

--- a/packages/core/test/root-gate.test.ts
+++ b/packages/core/test/root-gate.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for the sealed root gate over `.attest-it/policy.yaml` (issue #72).
+ *
+ * These cover the PRD R1 acceptance criteria at the core (library) layer, using
+ * real Ed25519 keys and the same seal primitives production uses. Expected
+ * behaviors are written by hand from the acceptance criteria, not derived from
+ * program output.
+ *
+ * @see PRD R1 — "the config file is itself a gated, sealed artifact"
+ * @see Issue #72 acceptance criteria
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { generateKeyPair } from '../src/crypto/ed25519.js'
+import { createSeal, verifyGateSeal } from '../src/seal/index.js'
+import type { Seal, SealsFile } from '../src/seal/types.js'
+import type { AttestItConfig, TeamMember } from '../src/types.js'
+import {
+  ROOT_GATE_ID,
+  createRootSeal,
+  computePolicyFingerprintSync,
+  verifyRootGate,
+  isBlockingRootGateState,
+} from '../src/config/root-gate.js'
+import { parsePolicyContent, PolicyValidationError } from '../src/config/policy-schema.js'
+
+interface Signer {
+  slug: string
+  member: TeamMember
+  privateKey: string
+}
+
+/** Create a named signer with a fresh Ed25519 keypair. */
+function makeSigner(slug: string, name: string): Signer {
+  const { publicKey, privateKey } = generateKeyPair()
+  return { slug, member: { name, publicKey }, privateKey }
+}
+
+/**
+ * Build a merged {@link AttestItConfig} with the given root signers, team, and
+ * gates. This mirrors what `loadSplitConfig` produces after merge.
+ */
+function makeConfig(params: {
+  rootSigners: string[]
+  team: Record<string, TeamMember>
+  gates?: AttestItConfig['gates']
+}): AttestItConfig {
+  return {
+    version: 1,
+    settings: {
+      maxAgeDays: 30,
+      publicKeyPath: '.attest-it/pubkey.pem',
+      attestationsPath: '.attest-it/attestations.json',
+      sealsPath: '.attest-it/seals.json',
+    },
+    rootGate: {
+      authorizedSigners: params.rootSigners,
+      maxAge: '365d',
+    },
+    team: params.team,
+    ...(params.gates && { gates: params.gates }),
+    suites: {},
+  }
+}
+
+/** Write a policy.yaml with the given content to `<dir>/.attest-it/policy.yaml`. */
+function writePolicy(dir: string, content: string): string {
+  const attestDir = path.join(dir, '.attest-it')
+  fs.mkdirSync(attestDir, { recursive: true })
+  const policyPath = path.join(attestDir, 'policy.yaml')
+  fs.writeFileSync(policyPath, content, 'utf8')
+  return policyPath
+}
+
+function sealsWith(root: Seal, extra: Record<string, Seal> = {}): SealsFile {
+  return { version: 1, seals: { [ROOT_GATE_ID]: root, ...extra } }
+}
+
+const ORIGINAL_POLICY = `version: 1
+rootGate:
+  authorizedSigners:
+    - owner
+team:
+  owner:
+    name: Repo Owner
+    publicKey: AAAA
+gates:
+  unit:
+    name: Unit
+    description: Unit tests
+    authorizedSigners:
+      - owner
+    fingerprint:
+      paths:
+        - src
+    maxAge: 30d
+`
+
+describe('root gate — happy path (positive AC)', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-root-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('verifies VALID when the policy is sealed by an authorized root signer', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+    const policyPath = writePolicy(dir, ORIGINAL_POLICY)
+    const fingerprint = computePolicyFingerprintSync(dir, policyPath)
+
+    const rootSeal = createRootSeal({
+      policyFingerprint: fingerprint,
+      sealedBy: 'owner',
+      privateKey: owner.privateKey,
+    })
+
+    const config = makeConfig({ rootSigners: ['owner'], team: { owner: owner.member } })
+    const result = verifyRootGate({
+      config,
+      policyFingerprint: fingerprint,
+      seals: sealsWith(rootSeal),
+    })
+
+    // AC positive: a config sealed by a genuine root signer verifies.
+    expect(result.state).toBe('VALID')
+    expect(isBlockingRootGateState(result.state)).toBe(false)
+    expect(result.gateId).toBe(ROOT_GATE_ID)
+  })
+
+  it('after a root signer re-seals a changed policy, VALID again and gates evaluate against the NEW config', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+    const newDev = makeSigner('dev', 'New Dev')
+
+    // Owner legitimately adds a new team member and authorizes them on a gate,
+    // then RE-SEALS the root gate over the new policy content.
+    const newPolicy = `${ORIGINAL_POLICY}    dev:
+      name: New Dev
+      publicKey: BBBB
+`
+    const policyPath = writePolicy(dir, newPolicy)
+    const newFingerprint = computePolicyFingerprintSync(dir, policyPath)
+
+    const rootSeal = createRootSeal({
+      policyFingerprint: newFingerprint,
+      sealedBy: 'owner',
+      privateKey: owner.privateKey,
+    })
+
+    // The new (now-trusted) config includes the new team member + a gate they sign.
+    const config = makeConfig({
+      rootSigners: ['owner'],
+      team: { owner: owner.member, dev: newDev.member },
+      gates: {
+        unit: {
+          name: 'Unit',
+          description: 'Unit tests',
+          authorizedSigners: ['dev'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      },
+    })
+
+    const rootResult = verifyRootGate({
+      config,
+      policyFingerprint: newFingerprint,
+      seals: sealsWith(rootSeal),
+    })
+    expect(rootResult.state).toBe('VALID')
+
+    // Subsequent gate evaluation uses the NEW config: the new dev can now seal
+    // the 'unit' gate and it verifies.
+    const gateSeal = createSeal({
+      gateId: 'unit',
+      fingerprint: 'sha256:abc',
+      sealedBy: 'dev',
+      privateKey: newDev.privateKey,
+    })
+    const gateResult = verifyGateSeal(
+      config,
+      'unit',
+      { version: 1, seals: { unit: gateSeal } },
+      'sha256:abc',
+    )
+    expect(gateResult.state).toBe('VALID')
+  })
+})
+
+describe('root gate — adversarial AC 1: untrusted team/gate addition', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-root-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('FAILS and names the untrusted policy change when a branch adds a key to team and authorizes it, without a root re-seal', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+    const mallory = makeSigner('mallory', 'Mallory')
+
+    // 1. Owner seals the ORIGINAL policy.
+    const originalPath = writePolicy(dir, ORIGINAL_POLICY)
+    const originalFingerprint = computePolicyFingerprintSync(dir, originalPath)
+    const rootSeal = createRootSeal({
+      policyFingerprint: originalFingerprint,
+      sealedBy: 'owner',
+      privateKey: owner.privateKey,
+    })
+
+    // 2. Attacker branch adds mallory to team + authorizes her on the gate, and
+    // seals the gate ARTIFACT with mallory's key. It does NOT (cannot) re-seal
+    // the root gate — mallory does not hold the owner's key.
+    const tamperedPolicy = `${ORIGINAL_POLICY}    mallory:
+      name: Mallory
+      publicKey: ${mallory.member.publicKey}
+`
+    const tamperedPath = writePolicy(dir, tamperedPolicy)
+    const tamperedFingerprint = computePolicyFingerprintSync(dir, tamperedPath)
+
+    // The tampered, working-tree config (as the CLI would load it locally).
+    const tamperedConfig = makeConfig({
+      rootSigners: ['owner'],
+      team: { owner: owner.member, mallory: mallory.member },
+      gates: {
+        unit: {
+          name: 'Unit',
+          description: 'Unit tests',
+          authorizedSigners: ['owner', 'mallory'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      },
+    })
+    const gateSeal = createSeal({
+      gateId: 'unit',
+      fingerprint: 'sha256:abc',
+      sealedBy: 'mallory',
+      privateKey: mallory.privateKey,
+    })
+
+    // 3. verify: the mandatory root pre-step fails because the policy content
+    // changed but the root seal covers the original fingerprint.
+    const result = verifyRootGate({
+      config: tamperedConfig,
+      policyFingerprint: tamperedFingerprint,
+      seals: sealsWith(rootSeal, { unit: gateSeal }),
+    })
+
+    expect(result.state).toBe('FINGERPRINT_MISMATCH')
+    expect(isBlockingRootGateState(result.state)).toBe(true)
+    // The message NAMES the untrusted config change (not a generic failure).
+    expect(result.message).toContain('.attest-it/policy.yaml')
+    expect(result.message.toLowerCase()).toContain('not')
+    expect(result.message.toLowerCase()).toContain('root signer')
+  })
+})
+
+describe('root gate — adversarial AC 2: modifying an existing gate authorizedSigners', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-root-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('FAILS absent a valid root-signer seal over the config change', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+
+    const originalPath = writePolicy(dir, ORIGINAL_POLICY)
+    const originalFingerprint = computePolicyFingerprintSync(dir, originalPath)
+    const rootSeal = createRootSeal({
+      policyFingerprint: originalFingerprint,
+      sealedBy: 'owner',
+      privateKey: owner.privateKey,
+    })
+
+    // Branch changes an existing gate's authorizedSigners (owner -> attacker),
+    // without a root re-seal.
+    const tampered = ORIGINAL_POLICY.replace(
+      '      - owner\n    fingerprint',
+      '      - attacker\n    fingerprint',
+    )
+    const tamperedPath = writePolicy(dir, tampered)
+    const tamperedFingerprint = computePolicyFingerprintSync(dir, tamperedPath)
+    expect(tamperedFingerprint).not.toBe(originalFingerprint)
+
+    const config = makeConfig({ rootSigners: ['owner'], team: { owner: owner.member } })
+    const result = verifyRootGate({
+      config,
+      policyFingerprint: tamperedFingerprint,
+      seals: sealsWith(rootSeal),
+    })
+
+    expect(result.state).toBe('FINGERPRINT_MISMATCH')
+    expect(isBlockingRootGateState(result.state)).toBe(true)
+    expect(result.message).toContain('.attest-it/policy.yaml')
+  })
+})
+
+describe('root gate — AC 5: a branch cannot bootstrap a new root of trust for itself', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-root-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('rejects a self-added root signer whose key is not in the trusted signer set (UNKNOWN_SIGNER)', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+    const mallory = makeSigner('mallory', 'Mallory')
+
+    // Attacker rewrites the policy to add herself as a root signer AND self-seals
+    // the new policy with her own key — a fingerprint-matching self-seal.
+    const selfBootstrapPolicy = `version: 1
+rootGate:
+  authorizedSigners:
+    - owner
+    - mallory
+team:
+  owner:
+    name: Repo Owner
+    publicKey: AAAA
+  mallory:
+    name: Mallory
+    publicKey: ${mallory.member.publicKey}
+`
+    const policyPath = writePolicy(dir, selfBootstrapPolicy)
+    const fingerprint = computePolicyFingerprintSync(dir, policyPath)
+    const malloryRootSeal = createRootSeal({
+      policyFingerprint: fingerprint,
+      sealedBy: 'mallory',
+      privateKey: mallory.privateKey,
+    })
+
+    // Verification uses the TRUSTED (base branch) config: root signers = [owner],
+    // team = { owner } only. Mallory is not a member of the trusted team.
+    const trustedConfig = makeConfig({ rootSigners: ['owner'], team: { owner: owner.member } })
+    const result = verifyRootGate({
+      config: trustedConfig,
+      policyFingerprint: fingerprint,
+      seals: sealsWith(malloryRootSeal),
+    })
+
+    expect(result.state).toBe('UNKNOWN_SIGNER')
+    expect(isBlockingRootGateState(result.state)).toBe(true)
+  })
+
+  it('rejects a self-added root signer who is a regular team member but not a trusted root signer', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+    const mallory = makeSigner('mallory', 'Mallory')
+
+    const policyPath = writePolicy(dir, ORIGINAL_POLICY)
+    const fingerprint = computePolicyFingerprintSync(dir, policyPath)
+    const malloryRootSeal = createRootSeal({
+      policyFingerprint: fingerprint,
+      sealedBy: 'mallory',
+      privateKey: mallory.privateKey,
+    })
+
+    // Trusted config: mallory IS in the team (regular member) but the root gate's
+    // authorized signers are only [owner]. A non-root signer cannot anchor the policy.
+    const trustedConfig = makeConfig({
+      rootSigners: ['owner'],
+      team: { owner: owner.member, mallory: mallory.member },
+    })
+    const result = verifyRootGate({
+      config: trustedConfig,
+      policyFingerprint: fingerprint,
+      seals: sealsWith(malloryRootSeal),
+    })
+
+    expect(result.state).toBe('UNKNOWN_SIGNER')
+    expect(isBlockingRootGateState(result.state)).toBe(true)
+  })
+})
+
+describe('root gate — MISSING / NOT_ANCHORED states', () => {
+  it('reports NOT_ANCHORED (non-blocking) when the policy defines no rootGate', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+    const config: AttestItConfig = {
+      version: 1,
+      settings: {
+        maxAgeDays: 30,
+        publicKeyPath: '.attest-it/pubkey.pem',
+        attestationsPath: '.attest-it/attestations.json',
+        sealsPath: '.attest-it/seals.json',
+      },
+      team: { owner: owner.member },
+      suites: {},
+    }
+    const result = verifyRootGate({
+      config,
+      policyFingerprint: 'sha256:whatever',
+      seals: { version: 1, seals: {} },
+    })
+    expect(result.state).toBe('NOT_ANCHORED')
+    // Backward compatibility: an un-bootstrapped repo does not hard-fail.
+    expect(isBlockingRootGateState(result.state)).toBe(false)
+  })
+
+  it('reports MISSING (blocking) when a rootGate exists but no root seal is present', () => {
+    const owner = makeSigner('owner', 'Repo Owner')
+    const config = makeConfig({ rootSigners: ['owner'], team: { owner: owner.member } })
+    const result = verifyRootGate({
+      config,
+      policyFingerprint: 'sha256:whatever',
+      seals: { version: 1, seals: {} },
+    })
+    expect(result.state).toBe('MISSING')
+    expect(isBlockingRootGateState(result.state)).toBe(true)
+  })
+})
+
+describe('policy schema — reserved root-gate slug and rootGate parsing', () => {
+  it('parses a policy with a rootGate section', () => {
+    const policy = parsePolicyContent(ORIGINAL_POLICY, 'yaml')
+    expect(policy.rootGate?.authorizedSigners).toEqual(['owner'])
+    // maxAge defaults to 365d when unspecified (schema default).
+    expect(policy.rootGate?.maxAge).toBe('365d')
+  })
+
+  it('rejects a rootGate with an empty authorizedSigners array', () => {
+    const bad = `version: 1
+rootGate:
+  authorizedSigners: []
+team: {}
+`
+    expect(() => parsePolicyContent(bad, 'yaml')).toThrow(PolicyValidationError)
+  })
+
+  it('rejects an ordinary gate that reuses the reserved __root__ slug', () => {
+    const bad = `version: 1
+team:
+  owner:
+    name: Owner
+    publicKey: AAAA
+gates:
+  __root__:
+    name: Fake Root
+    description: Attempt to redefine the root gate
+    authorizedSigners:
+      - owner
+    fingerprint:
+      paths:
+        - src
+    maxAge: 30d
+`
+    expect(() => parsePolicyContent(bad, 'yaml')).toThrow(/reserved gate id/)
+  })
+})

--- a/packages/core/test/root-gate.test.ts
+++ b/packages/core/test/root-gate.test.ts
@@ -26,6 +26,7 @@ import {
   isBlockingRootGateState,
 } from '../src/config/root-gate.js'
 import { parsePolicyContent, PolicyValidationError } from '../src/config/policy-schema.js'
+import { policyMigrationGraph } from '../src/config/migrations/policy-graph.js'
 
 interface Signer {
   slug: string
@@ -436,7 +437,7 @@ team: {}
     expect(() => parsePolicyContent(bad, 'yaml')).toThrow(PolicyValidationError)
   })
 
-  it('rejects an ordinary gate that reuses the reserved __root__ slug', () => {
+  it('rejects an ordinary gate that reuses the reserved __root__ slug (refined-schema load path)', () => {
     const bad = `version: 1
 team:
   owner:
@@ -454,5 +455,50 @@ gates:
     maxAge: 30d
 `
     expect(() => parsePolicyContent(bad, 'yaml')).toThrow(/reserved gate id/)
+  })
+
+  it('rejects the reserved __root__ slug via the migration-graph validation path too (defense-in-depth)', () => {
+    // The reserved-slug guard lives on the gates record KEY in the object schema
+    // that is registered in the migrex migration graph — not only on the refined
+    // load-path schema — so a future validation routed through the graph cannot
+    // silently drop the reservation.
+    const raw = {
+      version: 1,
+      team: { owner: { name: 'Owner', publicKey: 'AAAA' } },
+      gates: {
+        __root__: {
+          name: 'Fake Root',
+          description: 'Attempt to redefine the root gate',
+          authorizedSigners: ['owner'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      },
+    }
+
+    const versions = policyMigrationGraph.getVersions()
+    const latest = versions[versions.length - 1]
+    if (latest === undefined) throw new Error('policy migration graph has no versions')
+    const versioned = policyMigrationGraph.getSchema(latest)
+    if (!versioned) throw new Error(`no schema registered for version ${latest}`)
+
+    const result = versioned.schema(raw)
+    expect(result.success).toBe(false)
+
+    // A well-formed policy with an ordinary gate slug still validates through the graph.
+    const ok = versioned.schema({
+      version: 1,
+      team: { owner: { name: 'Owner', publicKey: 'AAAA' } },
+      gates: {
+        unit: {
+          name: 'Unit',
+          description: 'Unit tests',
+          authorizedSigners: ['owner'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      },
+    })
+    expect(ok.success).toBe(true)
   })
 })

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -198,7 +198,7 @@ var require_file_command = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.prepareKeyValueMessage = exports2.issueFileCommand = void 0;
     var crypto = __importStar(require("crypto"));
-    var fs4 = __importStar(require("fs"));
+    var fs2 = __importStar(require("fs"));
     var os3 = __importStar(require("os"));
     var utils_1 = require_utils();
     function issueFileCommand(command, message) {
@@ -206,10 +206,10 @@ var require_file_command = __commonJS({
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
       }
-      if (!fs4.existsSync(filePath)) {
+      if (!fs2.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
       }
-      fs4.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os3.EOL}`, {
+      fs2.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os3.EOL}`, {
         encoding: "utf8"
       });
     }
@@ -1021,14 +1021,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`;
-        let path4 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path3 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin.endsWith("/")) {
           origin = origin.substring(0, origin.length - 1);
         }
-        if (path4 && !path4.startsWith("/")) {
-          path4 = `/${path4}`;
+        if (path3 && !path3.startsWith("/")) {
+          path3 = `/${path3}`;
         }
-        url = new URL(origin + path4);
+        url = new URL(origin + path3);
       }
       return url;
     }
@@ -2651,20 +2651,20 @@ var require_basename = __commonJS({
   "../../node_modules/.pnpm/@fastify+busboy@2.1.1/node_modules/@fastify/busboy/lib/utils/basename.js"(exports2, module2) {
     "use strict";
     init_cjs_shims();
-    module2.exports = function basename2(path4) {
-      if (typeof path4 !== "string") {
+    module2.exports = function basename2(path3) {
+      if (typeof path3 !== "string") {
         return "";
       }
-      for (var i = path4.length - 1; i >= 0; --i) {
-        switch (path4.charCodeAt(i)) {
+      for (var i = path3.length - 1; i >= 0; --i) {
+        switch (path3.charCodeAt(i)) {
           case 47:
           // '/'
           case 92:
-            path4 = path4.slice(i + 1);
-            return path4 === ".." || path4 === "." ? "" : path4;
+            path3 = path3.slice(i + 1);
+            return path3 === ".." || path3 === "." ? "" : path3;
         }
       }
-      return path4 === ".." || path4 === "." ? "" : path4;
+      return path3 === ".." || path3 === "." ? "" : path3;
     };
   }
 });
@@ -4064,8 +4064,8 @@ var require_util2 = __commonJS({
     function createDeferredPromise() {
       let res;
       let rej;
-      const promise2 = new Promise((resolve6, reject) => {
-        res = resolve6;
+      const promise2 = new Promise((resolve7, reject) => {
+        res = resolve7;
         rej = reject;
       });
       return { promise: promise2, resolve: res, reject: rej };
@@ -5576,8 +5576,8 @@ Content-Type: ${value.type || "application/octet-stream"}\r
                 });
               }
             });
-            const busboyResolve = new Promise((resolve6, reject) => {
-              busboy.on("finish", resolve6);
+            const busboyResolve = new Promise((resolve7, reject) => {
+              busboy.on("finish", resolve7);
               busboy.on("error", (err) => reject(new TypeError(err)));
             });
             if (this.body !== null) for await (const chunk of consumeBody(this[kState].body)) busboy.write(chunk);
@@ -5709,7 +5709,7 @@ var require_request = __commonJS({
     }
     var Request2 = class _Request {
       constructor(origin, {
-        path: path4,
+        path: path3,
         method,
         body,
         headers,
@@ -5723,11 +5723,11 @@ var require_request = __commonJS({
         throwOnError,
         expectContinue
       }, handler2) {
-        if (typeof path4 !== "string") {
+        if (typeof path3 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path4[0] !== "/" && !(path4.startsWith("http://") || path4.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path3[0] !== "/" && !(path3.startsWith("http://") || path3.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.exec(path4) !== null) {
+        } else if (invalidPathRegex.exec(path3) !== null) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -5790,7 +5790,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? util2.buildURL(path4, query) : path4;
+        this.path = query ? util2.buildURL(path3, query) : path3;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6114,9 +6114,9 @@ var require_dispatcher_base = __commonJS({
       }
       close(callback2) {
         if (callback2 === void 0) {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             this.close((err, data) => {
-              return err ? reject(err) : resolve6(data);
+              return err ? reject(err) : resolve7(data);
             });
           });
         }
@@ -6154,12 +6154,12 @@ var require_dispatcher_base = __commonJS({
           err = null;
         }
         if (callback2 === void 0) {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             this.destroy(err, (err2, data) => {
               return err2 ? (
                 /* istanbul ignore next: should never error */
                 reject(err2)
-              ) : resolve6(data);
+              ) : resolve7(data);
             });
           });
         }
@@ -6804,9 +6804,9 @@ var require_RedirectHandler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util2.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path4 = search ? `${pathname}${search}` : pathname;
+        const path3 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path4;
+        this.opts.path = path3;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -7229,16 +7229,16 @@ var require_client = __commonJS({
         return this[kNeedDrain] < 2;
       }
       async [kClose]() {
-        return new Promise((resolve6) => {
+        return new Promise((resolve7) => {
           if (!this[kSize]) {
-            resolve6(null);
+            resolve7(null);
           } else {
-            this[kClosedResolve] = resolve6;
+            this[kClosedResolve] = resolve7;
           }
         });
       }
       async [kDestroy](err) {
-        return new Promise((resolve6) => {
+        return new Promise((resolve7) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
           for (let i = 0; i < requests.length; i++) {
             const request2 = requests[i];
@@ -7249,7 +7249,7 @@ var require_client = __commonJS({
               this[kClosedResolve]();
               this[kClosedResolve] = null;
             }
-            resolve6();
+            resolve7();
           };
           if (this[kHTTP2Session] != null) {
             util2.destroy(this[kHTTP2Session], err);
@@ -7829,7 +7829,7 @@ var require_client = __commonJS({
         });
       }
       try {
-        const socket = await new Promise((resolve6, reject) => {
+        const socket = await new Promise((resolve7, reject) => {
           client[kConnector]({
             host,
             hostname,
@@ -7841,7 +7841,7 @@ var require_client = __commonJS({
             if (err) {
               reject(err);
             } else {
-              resolve6(socket2);
+              resolve7(socket2);
             }
           });
         });
@@ -8052,7 +8052,7 @@ var require_client = __commonJS({
         writeH2(client, client[kHTTP2Session], request2);
         return;
       }
-      const { body, method, path: path4, host, upgrade, headers, blocking, reset } = request2;
+      const { body, method, path: path3, host, upgrade, headers, blocking, reset } = request2;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
         body.read(0);
@@ -8102,7 +8102,7 @@ var require_client = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path4} HTTP/1.1\r
+      let header = `${method} ${path3} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -8165,7 +8165,7 @@ upgrade: ${upgrade}\r
       return true;
     }
     function writeH2(client, session, request2) {
-      const { body, method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
+      const { body, method, path: path3, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
       let headers;
       if (typeof reqHeaders === "string") headers = Request2[kHTTP2CopyHeaders](reqHeaders.trim());
       else headers = reqHeaders;
@@ -8208,7 +8208,7 @@ upgrade: ${upgrade}\r
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path4;
+      headers[HTTP2_HEADER_PATH] = path3;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -8465,12 +8465,12 @@ upgrade: ${upgrade}\r
           cb();
         }
       }
-      const waitForDrain = () => new Promise((resolve6, reject) => {
+      const waitForDrain = () => new Promise((resolve7, reject) => {
         assert(callback2 === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback2 = resolve6;
+          callback2 = resolve7;
         }
       });
       if (client[kHTTPConnVersion] === "h2") {
@@ -8819,8 +8819,8 @@ var require_pool_base = __commonJS({
         if (this[kQueue].isEmpty()) {
           return Promise.all(this[kClients].map((c) => c.close()));
         } else {
-          return new Promise((resolve6) => {
-            this[kClosedResolve] = resolve6;
+          return new Promise((resolve7) => {
+            this[kClosedResolve] = resolve7;
           });
         }
       }
@@ -9403,7 +9403,7 @@ var require_readable = __commonJS({
         if (this.closed) {
           return Promise.resolve(null);
         }
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           const signalListenerCleanup = signal ? util2.addAbortListener(signal, () => {
             this.destroy();
           }) : noop2;
@@ -9412,7 +9412,7 @@ var require_readable = __commonJS({
             if (signal && signal.aborted) {
               reject(signal.reason || Object.assign(new Error("The operation was aborted"), { name: "AbortError" }));
             } else {
-              resolve6(null);
+              resolve7(null);
             }
           }).on("error", noop2).on("data", function(chunk) {
             limit -= chunk.length;
@@ -9434,11 +9434,11 @@ var require_readable = __commonJS({
         throw new TypeError("unusable");
       }
       assert(!stream[kConsume]);
-      return new Promise((resolve6, reject) => {
+      return new Promise((resolve7, reject) => {
         stream[kConsume] = {
           type,
           stream,
-          resolve: resolve6,
+          resolve: resolve7,
           reject,
           length: 0,
           body: []
@@ -9473,12 +9473,12 @@ var require_readable = __commonJS({
       }
     }
     function consumeEnd(consume2) {
-      const { type, body, resolve: resolve6, stream, length } = consume2;
+      const { type, body, resolve: resolve7, stream, length } = consume2;
       try {
         if (type === "text") {
-          resolve6(toUSVString(Buffer.concat(body)));
+          resolve7(toUSVString(Buffer.concat(body)));
         } else if (type === "json") {
-          resolve6(JSON.parse(Buffer.concat(body)));
+          resolve7(JSON.parse(Buffer.concat(body)));
         } else if (type === "arrayBuffer") {
           const dst = new Uint8Array(length);
           let pos = 0;
@@ -9486,12 +9486,12 @@ var require_readable = __commonJS({
             dst.set(buf, pos);
             pos += buf.byteLength;
           }
-          resolve6(dst.buffer);
+          resolve7(dst.buffer);
         } else if (type === "blob") {
           if (!Blob2) {
             Blob2 = require("buffer").Blob;
           }
-          resolve6(new Blob2(body, { type: stream[kContentType] }));
+          resolve7(new Blob2(body, { type: stream[kContentType] }));
         }
         consumeFinish(consume2);
       } catch (err) {
@@ -9751,9 +9751,9 @@ var require_api_request = __commonJS({
     };
     function request2(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           request2.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -9927,9 +9927,9 @@ var require_api_stream = __commonJS({
     };
     function stream(opts, factory, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           stream.call(this, opts, factory, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -10212,9 +10212,9 @@ var require_api_upgrade = __commonJS({
     };
     function upgrade(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           upgrade.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -10304,9 +10304,9 @@ var require_api_connect = __commonJS({
     };
     function connect(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           connect.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -10470,20 +10470,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path4) {
-      if (typeof path4 !== "string") {
-        return path4;
+    function safeUrl(path3) {
+      if (typeof path3 !== "string") {
+        return path3;
       }
-      const pathSegments = path4.split("?");
+      const pathSegments = path3.split("?");
       if (pathSegments.length !== 2) {
-        return path4;
+        return path3;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path4, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path4);
+    function matchKey(mockDispatch2, { path: path3, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path3);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10501,7 +10501,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path4 }) => matchValue(safeUrl(path4), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path3 }) => matchValue(safeUrl(path3), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10538,9 +10538,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path4, method, body, headers, query } = opts;
+      const { path: path3, method, body, headers, query } = opts;
       return {
-        path: path4,
+        path: path3,
         method,
         body,
         headers,
@@ -10994,10 +10994,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path4, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path3, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path4,
+            Path: path3,
             "Status code": statusCode,
             Persistent: persist ? "\u2705" : "\u274C",
             Invocations: timesInvoked,
@@ -13947,7 +13947,7 @@ var require_fetch = __commonJS({
       async function dispatch({ body }) {
         const url = requestCurrentURL(request2);
         const agent = fetchParams.controller.dispatcher;
-        return new Promise((resolve6, reject) => agent.dispatch(
+        return new Promise((resolve7, reject) => agent.dispatch(
           {
             path: url.pathname + url.search,
             origin: url.origin,
@@ -14023,7 +14023,7 @@ var require_fetch = __commonJS({
                   }
                 }
               }
-              resolve6({
+              resolve7({
                 status,
                 statusText,
                 headersList: headers[kHeadersList],
@@ -14066,7 +14066,7 @@ var require_fetch = __commonJS({
                 const val = headersList[n + 1].toString("latin1");
                 headers[kHeadersList].append(key, val);
               }
-              resolve6({
+              resolve7({
                 status,
                 statusText: STATUS_CODES[status],
                 headersList: headers[kHeadersList],
@@ -15638,8 +15638,8 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path4) {
-      for (const char of path4) {
+    function validateCookiePath(path3) {
+      for (const char of path3) {
         const code = char.charCodeAt(0);
         if (code < 33 || char === ";") {
           throw new Error("Invalid cookie path");
@@ -17330,11 +17330,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path4 = opts.path;
+          let path3 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path4 = `/${path4}`;
+            path3 = `/${path3}`;
           }
-          url = new URL(util2.parseOrigin(url).origin + path4);
+          url = new URL(util2.parseOrigin(url).origin + path3);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -17443,11 +17443,11 @@ var require_lib = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -17463,7 +17463,7 @@ var require_lib = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -17549,26 +17549,26 @@ var require_lib = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve6(output.toString());
+              resolve7(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve6(Buffer.concat(chunks));
+              resolve7(Buffer.concat(chunks));
             });
           }));
         });
@@ -17777,14 +17777,14 @@ var require_lib = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve6(res);
+                resolve7(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -17966,12 +17966,12 @@ var require_lib = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
+          return new Promise((resolve7) => setTimeout(() => resolve7(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -17979,7 +17979,7 @@ var require_lib = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve6(response);
+              resolve7(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -18018,7 +18018,7 @@ var require_lib = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve6(response);
+              resolve7(response);
             }
           }));
         });
@@ -18036,11 +18036,11 @@ var require_auth = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18056,7 +18056,7 @@ var require_auth = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18141,11 +18141,11 @@ var require_oidc_utils = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18161,7 +18161,7 @@ var require_oidc_utils = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18240,11 +18240,11 @@ var require_summary = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18260,7 +18260,7 @@ var require_summary = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18562,7 +18562,7 @@ var require_path_utils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.toPlatformPath = exports2.toWin32Path = exports2.toPosixPath = void 0;
-    var path4 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -18572,7 +18572,7 @@ var require_path_utils = __commonJS({
     }
     exports2.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path4.sep);
+      return pth.replace(/[/\\]/g, path3.sep);
     }
     exports2.toPlatformPath = toPlatformPath;
   }
@@ -18608,11 +18608,11 @@ var require_io_util = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18628,7 +18628,7 @@ var require_io_util = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18636,12 +18636,12 @@ var require_io_util = __commonJS({
     var _a;
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.READONLY = exports2.UV_FS_O_EXLOCK = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rm = exports2.rename = exports2.readlink = exports2.readdir = exports2.open = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
-    var fs4 = __importStar(require("fs"));
-    var path4 = __importStar(require("path"));
-    _a = fs4.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.open = _a.open, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rm = _a.rm, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
+    var fs2 = __importStar(require("fs"));
+    var path3 = __importStar(require("path"));
+    _a = fs2.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.open = _a.open, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rm = _a.rm, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
     exports2.IS_WINDOWS = process.platform === "win32";
     exports2.UV_FS_O_EXLOCK = 268435456;
-    exports2.READONLY = fs4.constants.O_RDONLY;
+    exports2.READONLY = fs2.constants.O_RDONLY;
     function exists(fsPath) {
       return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -18686,7 +18686,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path4.extname(filePath).toUpperCase();
+            const upperExt = path3.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -18710,11 +18710,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports2.IS_WINDOWS) {
               try {
-                const directory = path4.dirname(filePath);
-                const upperName = path4.basename(filePath).toUpperCase();
+                const directory = path3.dirname(filePath);
+                const upperName = path3.basename(filePath).toUpperCase();
                 for (const actualName of yield exports2.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path4.join(directory, actualName);
+                    filePath = path3.join(directory, actualName);
                     break;
                   }
                 }
@@ -18782,11 +18782,11 @@ var require_io = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18802,7 +18802,7 @@ var require_io = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18810,7 +18810,7 @@ var require_io = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
     var assert_1 = require("assert");
-    var path4 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     var ioUtil = __importStar(require_io_util());
     function cp(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
@@ -18819,7 +18819,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path4.join(dest, path4.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path3.join(dest, path3.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -18831,7 +18831,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path4.relative(source, newDest) === "") {
+          if (path3.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile(source, newDest, force);
@@ -18844,7 +18844,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path4.join(dest, path4.basename(source));
+            dest = path3.join(dest, path3.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -18855,7 +18855,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path4.dirname(dest));
+        yield mkdirP(path3.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -18918,7 +18918,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path4.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path3.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -18931,12 +18931,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path4.sep)) {
+        if (tool.includes(path3.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path4.delimiter)) {
+          for (const p of process.env.PATH.split(path3.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -18944,7 +18944,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path4.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path3.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -19031,11 +19031,11 @@ var require_toolrunner = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19051,7 +19051,7 @@ var require_toolrunner = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19061,7 +19061,7 @@ var require_toolrunner = __commonJS({
     var os3 = __importStar(require("os"));
     var events = __importStar(require("events"));
     var child = __importStar(require("child_process"));
-    var path4 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     var io = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = require("timers");
@@ -19276,10 +19276,10 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path4.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io.which(this.toolPath, true);
-          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
             this._debug(`exec tool: ${this.toolPath}`);
             this._debug("arguments:");
             for (const arg of this.args) {
@@ -19362,7 +19362,7 @@ var require_toolrunner = __commonJS({
               if (error2) {
                 reject(error2);
               } else {
-                resolve6(exitCode);
+                resolve7(exitCode);
               }
             });
             if (this.options.input) {
@@ -19516,11 +19516,11 @@ var require_exec = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19536,7 +19536,7 @@ var require_exec = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19628,11 +19628,11 @@ var require_platform = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19648,7 +19648,7 @@ var require_platform = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19748,11 +19748,11 @@ var require_core = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19768,7 +19768,7 @@ var require_core = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19779,7 +19779,7 @@ var require_core = __commonJS({
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os3 = __importStar(require("os"));
-    var path4 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -19807,7 +19807,7 @@ var require_core = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path4.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path3.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath;
     function getInput2(name, options) {
@@ -21998,17 +21998,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path4) {
-      const ctrl = callVisitor(key, node, visitor, path4);
+    function visit_(key, node, visitor, path3) {
+      const ctrl = callVisitor(key, node, visitor, path3);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path4, ctrl);
-        return visit_(key, ctrl, visitor, path4);
+        replaceNode(key, path3, ctrl);
+        return visit_(key, ctrl, visitor, path3);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path4 = Object.freeze(path4.concat(node));
+          path3 = Object.freeze(path3.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path4);
+            const ci = visit_(i, node.items[i], visitor, path3);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22019,13 +22019,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path4 = Object.freeze(path4.concat(node));
-          const ck = visit_("key", node.key, visitor, path4);
+          path3 = Object.freeze(path3.concat(node));
+          const ck = visit_("key", node.key, visitor, path3);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path4);
+          const cv = visit_("value", node.value, visitor, path3);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22046,17 +22046,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path4) {
-      const ctrl = await callVisitor(key, node, visitor, path4);
+    async function visitAsync_(key, node, visitor, path3) {
+      const ctrl = await callVisitor(key, node, visitor, path3);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path4, ctrl);
-        return visitAsync_(key, ctrl, visitor, path4);
+        replaceNode(key, path3, ctrl);
+        return visitAsync_(key, ctrl, visitor, path3);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path4 = Object.freeze(path4.concat(node));
+          path3 = Object.freeze(path3.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path4);
+            const ci = await visitAsync_(i, node.items[i], visitor, path3);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22067,13 +22067,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path4 = Object.freeze(path4.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path4);
+          path3 = Object.freeze(path3.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path3);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path4);
+          const cv = await visitAsync_("value", node.value, visitor, path3);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22100,23 +22100,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path4) {
+    function callVisitor(key, node, visitor, path3) {
       if (typeof visitor === "function")
-        return visitor(key, node, path4);
+        return visitor(key, node, path3);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path4);
+        return visitor.Map?.(key, node, path3);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path4);
+        return visitor.Seq?.(key, node, path3);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path4);
+        return visitor.Pair?.(key, node, path3);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path4);
+        return visitor.Scalar?.(key, node, path3);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path4);
+        return visitor.Alias?.(key, node, path3);
       return void 0;
     }
-    function replaceNode(key, path4, node) {
-      const parent = path4[path4.length - 1];
+    function replaceNode(key, path3, node) {
+      const parent = path3[path3.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -22733,10 +22733,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path4, value) {
+    function collectionFromPath(schema, path3, value) {
       let v = value;
-      for (let i = path4.length - 1; i >= 0; --i) {
-        const k = path4[i];
+      for (let i = path3.length - 1; i >= 0; --i) {
+        const k = path3[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -22755,7 +22755,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path4) => path4 == null || typeof path4 === "object" && !!path4[Symbol.iterator]().next().done;
+    var isEmptyPath = (path3) => path3 == null || typeof path3 === "object" && !!path3[Symbol.iterator]().next().done;
     var Collection2 = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -22785,11 +22785,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path4, value) {
-        if (isEmptyPath(path4))
+      addIn(path3, value) {
+        if (isEmptyPath(path3))
           this.add(value);
         else {
-          const [key, ...rest] = path4;
+          const [key, ...rest] = path3;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -22803,8 +22803,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path4) {
-        const [key, ...rest] = path4;
+      deleteIn(path3) {
+        const [key, ...rest] = path3;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -22818,8 +22818,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path4, keepScalar) {
-        const [key, ...rest] = path4;
+      getIn(path3, keepScalar) {
+        const [key, ...rest] = path3;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -22837,8 +22837,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path4) {
-        const [key, ...rest] = path4;
+      hasIn(path3) {
+        const [key, ...rest] = path3;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -22848,8 +22848,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path4, value) {
-        const [key, ...rest] = path4;
+      setIn(path3, value) {
+        const [key, ...rest] = path3;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -25388,9 +25388,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path4, value) {
+      addIn(path3, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path4, value);
+          this.contents.addIn(path3, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -25465,14 +25465,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path4) {
-        if (Collection2.isEmptyPath(path4)) {
+      deleteIn(path3) {
+        if (Collection2.isEmptyPath(path3)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path4) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path3) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -25487,10 +25487,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path4, keepScalar) {
-        if (Collection2.isEmptyPath(path4))
+      getIn(path3, keepScalar) {
+        if (Collection2.isEmptyPath(path3))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path4, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path3, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -25501,10 +25501,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path4) {
-        if (Collection2.isEmptyPath(path4))
+      hasIn(path3) {
+        if (Collection2.isEmptyPath(path3))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path4) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path3) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -25521,13 +25521,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path4, value) {
-        if (Collection2.isEmptyPath(path4)) {
+      setIn(path3, value) {
+        if (Collection2.isEmptyPath(path3)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path4), value);
+          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path3), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path4, value);
+          this.contents.setIn(path3, value);
         }
       }
       /**
@@ -27499,9 +27499,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path4) => {
+    visit.itemAtPath = (cst, path3) => {
       let item = cst;
-      for (const [field, index] of path4) {
+      for (const [field, index] of path3) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -27510,23 +27510,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path4) => {
-      const parent = visit.itemAtPath(cst, path4.slice(0, -1));
-      const field = path4[path4.length - 1][0];
+    visit.parentCollection = (cst, path3) => {
+      const parent = visit.itemAtPath(cst, path3.slice(0, -1));
+      const field = path3[path3.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path4, item, visitor) {
-      let ctrl = visitor(item, path4);
+    function _visit(path3, item, visitor) {
+      let ctrl = visitor(item, path3);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path4.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path3.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -27537,10 +27537,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path4);
+            ctrl = ctrl(item, path3);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path4) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path3) : ctrl;
     }
     exports2.visit = visit;
   }
@@ -28829,14 +28829,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs4 = this.flowScalar(this.type);
+              const fs2 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs4, sep: [] });
+                map.items.push({ start, key: fs2, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs4);
+                this.stack.push(fs2);
               } else {
-                Object.assign(it, { key: fs4, sep: [] });
+                Object.assign(it, { key: fs2, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -28964,13 +28964,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs4 = this.flowScalar(this.type);
+              const fs2 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs4, sep: [] });
+                fc.items.push({ start: [], key: fs2, sep: [] });
               else if (it.sep)
-                this.stack.push(fs4);
+                this.stack.push(fs2);
               else
-                Object.assign(it, { key: fs4, sep: [] });
+                Object.assign(it, { key: fs2, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -29688,8 +29688,8 @@ var require_utils3 = __commonJS({
       }
       return output;
     };
-    exports2.basename = (path4, { windows } = {}) => {
-      const segs = path4.split(windows ? /[\\/]/ : "/");
+    exports2.basename = (path3, { windows } = {}) => {
+      const segs = path3.split(windows ? /[\\/]/ : "/");
       const last = segs[segs.length - 1];
       if (last === "") {
         return segs[segs.length - 2];
@@ -31626,8 +31626,8 @@ ${val.stack}`;
     module2.exports.__wbindgen_throw = function(arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     };
-    var path4 = require("path").join(__dirname, "core_bg.wasm");
-    var bytes = require("fs").readFileSync(path4);
+    var path3 = require("path").join(__dirname, "core_bg.wasm");
+    var bytes = require("fs").readFileSync(path3);
     var wasmModule = new WebAssembly.Module(bytes);
     var wasmInstance = new WebAssembly.Instance(wasmModule, imports);
     wasm = wasmInstance.exports;
@@ -31847,11 +31847,11 @@ var require_core3 = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -31867,7 +31867,7 @@ var require_core3 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32041,11 +32041,11 @@ var require_secrets = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32061,7 +32061,7 @@ var require_secrets = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32172,11 +32172,11 @@ var require_items_shares = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32192,7 +32192,7 @@ var require_items_shares = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32291,11 +32291,11 @@ var require_items_files = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32311,7 +32311,7 @@ var require_items_files = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32431,11 +32431,11 @@ var require_items = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32451,7 +32451,7 @@ var require_items = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32671,11 +32671,11 @@ var require_vaults = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32691,7 +32691,7 @@ var require_vaults = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32904,11 +32904,11 @@ var require_groups = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32924,7 +32924,7 @@ var require_groups = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33042,11 +33042,11 @@ var require_shared_lib_core = __commonJS({
     })();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33062,26 +33062,26 @@ var require_shared_lib_core = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.SharedLibCore = void 0;
-    var fs4 = __importStar(require("fs"));
+    var fs2 = __importStar(require("fs"));
     var os3 = __importStar(require("os"));
-    var path4 = __importStar(require("path"));
+    var path3 = __importStar(require("path"));
     var errors_1 = require_errors3();
     var find1PasswordLibPath = () => {
       const platform = os3.platform();
-      const appRoot = path4.dirname(process.execPath);
+      const appRoot = path3.dirname(process.execPath);
       let searchPaths = [];
       switch (platform) {
         case "darwin":
           searchPaths = [
             "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib",
-            path4.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
+            path3.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
           ];
           break;
         case "linux":
@@ -33093,17 +33093,17 @@ var require_shared_lib_core = __commonJS({
           break;
         case "win32":
           searchPaths = [
-            path4.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
+            path3.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
             "C:/Program Files/1Password/app/8/op_sdk_ipc_client.dll",
             "C:/Program Files (x86)/1Password/app/8/op_sdk_ipc_client.dll",
-            path4.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
+            path3.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
           ];
           break;
         default:
           throw new Error(`Unsupported platform: ${platform}`);
       }
       for (const addonPath of searchPaths) {
-        if (fs4.existsSync(addonPath)) {
+        if (fs2.existsSync(addonPath)) {
           return addonPath;
         }
       }
@@ -33188,11 +33188,11 @@ var require_client_builder = __commonJS({
     init_cjs_shims();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33208,7 +33208,7 @@ var require_client_builder = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33260,11 +33260,11 @@ var require_sdk = __commonJS({
     };
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33280,7 +33280,7 @@ var require_sdk = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33329,8 +33329,8 @@ var require_context = __commonJS({
           if ((0, fs_1.existsSync)(process.env.GITHUB_EVENT_PATH)) {
             this.payload = JSON.parse((0, fs_1.readFileSync)(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
           } else {
-            const path4 = process.env.GITHUB_EVENT_PATH;
-            process.stdout.write(`GITHUB_EVENT_PATH ${path4} does not exist${os_1.EOL}`);
+            const path3 = process.env.GITHUB_EVENT_PATH;
+            process.stdout.write(`GITHUB_EVENT_PATH ${path3} does not exist${os_1.EOL}`);
           }
         }
         this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -33495,11 +33495,11 @@ var require_lib2 = __commonJS({
     })();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33515,7 +33515,7 @@ var require_lib2 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33602,26 +33602,26 @@ var require_lib2 = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve6(output.toString());
+              resolve7(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve6(Buffer.concat(chunks));
+              resolve7(Buffer.concat(chunks));
             });
           }));
         });
@@ -33829,14 +33829,14 @@ var require_lib2 = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve6(res);
+                resolve7(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -34080,12 +34080,12 @@ var require_lib2 = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
+          return new Promise((resolve7) => setTimeout(() => resolve7(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -34093,7 +34093,7 @@ var require_lib2 = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve6(response);
+              resolve7(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -34132,7 +34132,7 @@ var require_lib2 = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve6(response);
+              resolve7(response);
             }
           }));
         });
@@ -34187,11 +34187,11 @@ var require_utils4 = __commonJS({
     })();
     var __awaiter = exports2 && exports2.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -34207,7 +34207,7 @@ var require_utils4 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -38281,7 +38281,7 @@ var import_node_path = require("path");
 init_cjs_shims();
 var fs = __toESM(require("fs"), 1);
 var import_fs3 = require("fs");
-var path3 = __toESM(require("path"), 1);
+var path4 = __toESM(require("path"), 1);
 var import_path4 = require("path");
 var import_semver = __toESM(require_semver2(), 1);
 var import_yaml = __toESM(require_dist(), 1);
@@ -38779,8 +38779,8 @@ function getErrorMap() {
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js
 init_cjs_shims();
 var makeIssue = (params) => {
-  const { data, path: path4, errorMaps, issueData } = params;
-  const fullPath = [...path4, ...issueData.path || []];
+  const { data, path: path3, errorMaps, issueData } = params;
+  const fullPath = [...path3, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -38900,11 +38900,11 @@ var errorUtil;
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path4, key) {
+  constructor(parent, value, path3, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path4;
+    this._path = path3;
     this._key = key;
   }
   get path() {
@@ -42845,7 +42845,7 @@ var MigrationGraphImpl = class {
         hasIrreversibleStep: false
       };
     }
-    const path4 = findPath(
+    const path3 = findPath(
       normalizedFrom,
       normalizedTo,
       this.adjacencyList,
@@ -42853,10 +42853,10 @@ var MigrationGraphImpl = class {
       this.versionStrategy,
       (from, to) => this.getMigrationKey(from, to)
     );
-    if (!path4) {
+    if (!path3) {
       throw new NoPathError(fromVersion, toVersion);
     }
-    return path4;
+    return path3;
   }
   migrate(data, fromVersion, toVersion, options = {}) {
     const startTime = performance.now();
@@ -42885,12 +42885,12 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path4;
+    let path3;
     try {
       const pathStartTime = performance.now();
-      path4 = this.getPath(normalizedFrom, normalizedTo);
+      path3 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path4, pathDuration);
+      this.telemetry?.onPathComputed?.(path3, pathDuration);
     } catch (err) {
       return {
         success: false,
@@ -42900,27 +42900,27 @@ var MigrationGraphImpl = class {
         error: err
       };
     }
-    if (path4.steps.length === 0) {
+    if (path3.steps.length === 0) {
       return {
         success: true,
         data,
-        path: path4,
+        path: path3,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
     }
-    const context = createMigrationContext(path4.steps.length, options.initialStash);
+    const context = createMigrationContext(path3.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path4.steps.length; i++) {
-      const step = path4.steps[i];
+    for (let i = 0; i < path3.steps.length; i++) {
+      const step = path3.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path4.steps.length
+        totalSteps: path3.steps.length
       });
-      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
       const stepStartTime = performance.now();
       try {
         if (step.direction === "up") {
@@ -42945,20 +42945,20 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, step, context);
         return {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: error2
         };
       }
-      if (options.validateIntermediate && i < path4.steps.length - 1) {
+      if (options.validateIntermediate && i < path3.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             return {
               success: false,
-              path: path4,
+              path: path3,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -42982,7 +42982,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, null, context);
         const result2 = {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43002,7 +43002,7 @@ var MigrationGraphImpl = class {
           this.telemetry?.onError?.(error2, null, context);
           const result2 = {
             success: false,
-            path: path4,
+            path: path3,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43018,7 +43018,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path4,
+      path: path3,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43050,11 +43050,11 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path4;
+    let path3;
     try {
       const pathStartTime = performance.now();
-      path4 = this.getPath(normalizedFrom, normalizedTo);
-      this.telemetry?.onPathComputed?.(path4, performance.now() - pathStartTime);
+      path3 = this.getPath(normalizedFrom, normalizedTo);
+      this.telemetry?.onPathComputed?.(path3, performance.now() - pathStartTime);
     } catch (err) {
       const result2 = {
         success: false,
@@ -43066,30 +43066,30 @@ var MigrationGraphImpl = class {
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    if (path4.steps.length === 0) {
+    if (path3.steps.length === 0) {
       const result2 = {
         success: true,
         data,
-        path: path4,
+        path: path3,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    const context = createMigrationContext(path4.steps.length, options.initialStash);
+    const context = createMigrationContext(path3.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path4.steps.length; i++) {
-      const step = path4.steps[i];
+    for (let i = 0; i < path3.steps.length; i++) {
+      const step = path3.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path4.steps.length
+        totalSteps: path3.steps.length
       });
       const stepStartTime = performance.now();
-      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
       try {
         if (step.direction === "up") {
           const result2 = step.migration.up(currentData, context);
@@ -43104,7 +43104,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(err, step, context);
         const result2 = {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: new MigrationError(
@@ -43120,14 +43120,14 @@ var MigrationGraphImpl = class {
         this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
         return result2;
       }
-      if (options.validateIntermediate && i < path4.steps.length - 1) {
+      if (options.validateIntermediate && i < path3.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             const result2 = {
               success: false,
-              path: path4,
+              path: path3,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -43148,7 +43148,7 @@ var MigrationGraphImpl = class {
       if (!validation.success) {
         const result2 = {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43165,7 +43165,7 @@ var MigrationGraphImpl = class {
         if (!validation.success) {
           const result2 = {
             success: false,
-            path: path4,
+            path: path3,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43183,7 +43183,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path4,
+      path: path3,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43195,12 +43195,12 @@ var MigrationGraphImpl = class {
   migrateMany(data, fromVersion, toVersion, options = {}) {
     const normalizedFrom = this.normalizeVersion(fromVersion);
     const normalizedTo = this.normalizeVersion(toVersion);
-    let path4;
+    let path3;
     try {
       const pathStartTime = performance.now();
-      path4 = this.getPath(normalizedFrom, normalizedTo);
+      path3 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path4, pathDuration);
+      this.telemetry?.onPathComputed?.(path3, pathDuration);
     } catch {
       return {
         total: 0,
@@ -43226,7 +43226,7 @@ var MigrationGraphImpl = class {
           for (let j = i + 1; j < items.length; j++) {
             results.push({
               success: false,
-              path: path4,
+              path: path3,
               stash: { consumed: [], unconsumed: [], lossless: true },
               preservedFields: [],
               error: new MigrationError(
@@ -43247,7 +43247,7 @@ var MigrationGraphImpl = class {
       succeeded,
       failed,
       results,
-      path: path4
+      path: path3
     };
   }
   getVersions() {
@@ -43327,8 +43327,8 @@ function createMigrationGraph(options) {
 
 // ../../node_modules/.pnpm/@migrex+zod@1.0.0-alpha.1_@migrex+core@0.2.0-alpha.1_zod@3.25.76/node_modules/@migrex/zod/dist/index.js
 init_cjs_shims();
-function pathToStringArray(path4) {
-  return path4.map((p) => String(p));
+function pathToStringArray(path3) {
+  return path3.map((p) => String(p));
 }
 function zodErrorToValidationErrors(error2) {
   return error2.issues.map((issue) => ({
@@ -43360,7 +43360,7 @@ function fromZod(version2, zodSchema, options) {
 }
 
 // ../core/dist/index.js
-var fs2 = __toESM(require("fs/promises"), 1);
+var fs32 = __toESM(require("fs/promises"), 1);
 var import_promises = require("fs/promises");
 var crypto22 = __toESM(require("crypto"), 1);
 
@@ -43376,27 +43376,27 @@ var import_module = require("module");
 var import_path = require("path");
 var nativeFs = __toESM(require("fs"), 1);
 var __require = /* @__PURE__ */ (0, import_module.createRequire)(importMetaUrl);
-function cleanPath(path4) {
-  let normalized = (0, import_path.normalize)(path4);
+function cleanPath(path3) {
+  let normalized = (0, import_path.normalize)(path3);
   if (normalized.length > 1 && normalized[normalized.length - 1] === import_path.sep) normalized = normalized.substring(0, normalized.length - 1);
   return normalized;
 }
 var SLASHES_REGEX = /[\\/]/g;
-function convertSlashes(path4, separator) {
-  return path4.replace(SLASHES_REGEX, separator);
+function convertSlashes(path3, separator) {
+  return path3.replace(SLASHES_REGEX, separator);
 }
 var WINDOWS_ROOT_DIR_REGEX = /^[a-z]:[\\/]$/i;
-function isRootDirectory(path4) {
-  return path4 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path4);
+function isRootDirectory(path3) {
+  return path3 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path3);
 }
-function normalizePath(path4, options) {
+function normalizePath(path3, options) {
   const { resolvePaths, normalizePath: normalizePath$1, pathSeparator } = options;
-  const pathNeedsCleaning = process.platform === "win32" && path4.includes("/") || path4.startsWith(".");
-  if (resolvePaths) path4 = (0, import_path.resolve)(path4);
-  if (normalizePath$1 || pathNeedsCleaning) path4 = cleanPath(path4);
-  if (path4 === ".") return "";
-  const needsSeperator = path4[path4.length - 1] !== pathSeparator;
-  return convertSlashes(needsSeperator ? path4 + pathSeparator : path4, pathSeparator);
+  const pathNeedsCleaning = process.platform === "win32" && path3.includes("/") || path3.startsWith(".");
+  if (resolvePaths) path3 = (0, import_path.resolve)(path3);
+  if (normalizePath$1 || pathNeedsCleaning) path3 = cleanPath(path3);
+  if (path3 === ".") return "";
+  const needsSeperator = path3[path3.length - 1] !== pathSeparator;
+  return convertSlashes(needsSeperator ? path3 + pathSeparator : path3, pathSeparator);
 }
 function joinPathWithBasePath(filename, directoryPath) {
   return directoryPath + filename;
@@ -43433,8 +43433,8 @@ var pushDirectory = (directoryPath, paths) => {
   paths.push(directoryPath || ".");
 };
 var pushDirectoryFilter = (directoryPath, paths, filters) => {
-  const path4 = directoryPath || ".";
-  if (filters.every((filter) => filter(path4, true))) paths.push(path4);
+  const path3 = directoryPath || ".";
+  if (filters.every((filter) => filter(path3, true))) paths.push(path3);
 };
 var empty$2 = () => {
 };
@@ -43486,26 +43486,26 @@ var empty = () => {
 function build$3(options) {
   return options.group ? groupFiles : empty;
 }
-var resolveSymlinksAsync = function(path4, state, callback$1) {
-  const { queue, fs: fs4, options: { suppressErrors } } = state;
+var resolveSymlinksAsync = function(path3, state, callback$1) {
+  const { queue, fs: fs2, options: { suppressErrors } } = state;
   queue.enqueue();
-  fs4.realpath(path4, (error2, resolvedPath) => {
+  fs2.realpath(path3, (error2, resolvedPath) => {
     if (error2) return queue.dequeue(suppressErrors ? null : error2, state);
-    fs4.stat(resolvedPath, (error$1, stat3) => {
+    fs2.stat(resolvedPath, (error$1, stat3) => {
       if (error$1) return queue.dequeue(suppressErrors ? null : error$1, state);
-      if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return queue.dequeue(null, state);
+      if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return queue.dequeue(null, state);
       callback$1(stat3, resolvedPath);
       queue.dequeue(null, state);
     });
   });
 };
-var resolveSymlinks = function(path4, state, callback$1) {
-  const { queue, fs: fs4, options: { suppressErrors } } = state;
+var resolveSymlinks = function(path3, state, callback$1) {
+  const { queue, fs: fs2, options: { suppressErrors } } = state;
   queue.enqueue();
   try {
-    const resolvedPath = fs4.realpathSync(path4);
-    const stat3 = fs4.statSync(resolvedPath);
-    if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return;
+    const resolvedPath = fs2.realpathSync(path3);
+    const stat3 = fs2.statSync(resolvedPath);
+    if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return;
     callback$1(stat3, resolvedPath);
   } catch (e) {
     if (!suppressErrors) throw e;
@@ -43515,9 +43515,9 @@ function build$2(options, isSynchronous) {
   if (!options.resolveSymlinks || options.excludeSymlinks) return null;
   return isSynchronous ? resolveSymlinks : resolveSymlinksAsync;
 }
-function isRecursive(path4, resolved, state) {
+function isRecursive(path3, resolved, state) {
   if (state.options.useRealPaths) return isRecursiveUsingRealPaths(resolved, state);
-  let parent = (0, import_path.dirname)(path4);
+  let parent = (0, import_path.dirname)(path3);
   let depth = 1;
   while (parent !== state.root && depth < 2) {
     const resolvedPath = state.symlinks.get(parent);
@@ -43525,7 +43525,7 @@ function isRecursive(path4, resolved, state) {
     if (isSameRoot) depth++;
     else parent = (0, import_path.dirname)(parent);
   }
-  state.symlinks.set(path4, resolved);
+  state.symlinks.set(path3, resolved);
   return depth > 1;
 }
 function isRecursiveUsingRealPaths(resolved, state) {
@@ -43574,22 +43574,22 @@ var readdirOpts = { withFileTypes: true };
 var walkAsync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
   state.queue.enqueue();
   if (currentDepth < 0) return state.queue.dequeue(null, state);
-  const { fs: fs4 } = state;
+  const { fs: fs2 } = state;
   state.visited.push(crawlPath);
   state.counts.directories++;
-  fs4.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
+  fs2.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
     callback$1(entries, directoryPath, currentDepth);
     state.queue.dequeue(state.options.suppressErrors ? null : error2, state);
   });
 };
 var walkSync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
-  const { fs: fs4 } = state;
+  const { fs: fs2 } = state;
   if (currentDepth < 0) return;
   state.visited.push(crawlPath);
   state.counts.directories++;
   let entries = [];
   try {
-    entries = fs4.readdirSync(crawlPath || ".", readdirOpts);
+    entries = fs2.readdirSync(crawlPath || ".", readdirOpts);
   } catch (e) {
     if (!state.options.suppressErrors) throw e;
   }
@@ -43697,19 +43697,19 @@ var Walker = class {
         const filename = this.joinPath(entry.name, directoryPath);
         this.pushFile(filename, files, this.state.counts, filters);
       } else if (entry.isDirectory()) {
-        let path4 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
-        if (exclude && exclude(entry.name, path4)) continue;
-        this.pushDirectory(path4, paths, filters);
-        this.walkDirectory(this.state, path4, path4, depth - 1, this.walk);
+        let path3 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
+        if (exclude && exclude(entry.name, path3)) continue;
+        this.pushDirectory(path3, paths, filters);
+        this.walkDirectory(this.state, path3, path3, depth - 1, this.walk);
       } else if (this.resolveSymlink && entry.isSymbolicLink()) {
-        let path4 = joinPathWithBasePath(entry.name, directoryPath);
-        this.resolveSymlink(path4, this.state, (stat3, resolvedPath) => {
+        let path3 = joinPathWithBasePath(entry.name, directoryPath);
+        this.resolveSymlink(path3, this.state, (stat3, resolvedPath) => {
           if (stat3.isDirectory()) {
             resolvedPath = normalizePath(resolvedPath, this.state.options);
-            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path4 + pathSeparator)) return;
-            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path4 + pathSeparator, depth - 1, this.walk);
+            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path3 + pathSeparator)) return;
+            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path3 + pathSeparator, depth - 1, this.walk);
           } else {
-            resolvedPath = useRealPaths ? resolvedPath : path4;
+            resolvedPath = useRealPaths ? resolvedPath : path3;
             const filename = (0, import_path.basename)(resolvedPath);
             const directoryPath$1 = normalizePath((0, import_path.dirname)(resolvedPath), this.state.options);
             resolvedPath = this.joinPath(filename, directoryPath$1);
@@ -43875,7 +43875,7 @@ var Builder = class {
       isMatch = globFn(patterns, ...options);
       this.globCache[patterns.join("\0")] = isMatch;
     }
-    this.options.filters.push((path4) => isMatch(path4));
+    this.options.filters.push((path3) => isMatch(path3));
     return this;
   }
 };
@@ -44034,10 +44034,10 @@ function processPatterns({ patterns = ["**/*"], ignore = [], expandDirectories =
     ignore: ignorePatterns
   };
 }
-function formatPaths(paths, relative3) {
+function formatPaths(paths, relative4) {
   for (let i = paths.length - 1; i >= 0; i--) {
     const path$1 = paths[i];
-    paths[i] = relative3(path$1);
+    paths[i] = relative4(path$1);
   }
   return paths;
 }
@@ -44134,17 +44134,17 @@ function getCrawler(patterns, inputOptions = {}) {
   props.root = props.root.replace(BACKSLASHES, "");
   const root = props.root;
   if (options.debug) log("internal properties:", props);
-  const relative3 = cwd !== root && !options.absolute && buildRelative(cwd, props.root);
-  return [new Builder(fdirOptions).crawl(root), relative3];
+  const relative4 = cwd !== root && !options.absolute && buildRelative(cwd, props.root);
+  return [new Builder(fdirOptions).crawl(root), relative4];
 }
 async function glob(patternsOrOptions, options) {
   if (patternsOrOptions && (options === null || options === void 0 ? void 0 : options.patterns)) throw new Error("Cannot pass patterns as both an argument and an option");
   const isModern = isReadonlyArray(patternsOrOptions) || typeof patternsOrOptions === "string";
   const opts = isModern ? options : patternsOrOptions;
   const patterns = isModern ? patternsOrOptions : patternsOrOptions.patterns;
-  const [crawler, relative3] = getCrawler(patterns, opts);
-  if (!relative3) return crawler.withPromise();
-  return formatPaths(await crawler.withPromise(), relative3);
+  const [crawler, relative4] = getCrawler(patterns, opts);
+  if (!relative4) return crawler.withPromise();
+  return formatPaths(await crawler.withPromise(), relative4);
 }
 
 // ../core/dist/index.js
@@ -46343,6 +46343,7 @@ createMigrationGraph({
   schemas: [schemaV12],
   migrations: []
 });
+var ROOT_GATE_ID = "__root__";
 function versionSchema2(version2) {
   return external_exports.union([external_exports.literal(version2), external_exports.literal(String(version2))]).transform(() => version2);
 }
@@ -46352,14 +46353,29 @@ var policySettingsSchemaV1 = external_exports.object({
   attestationsPath: external_exports.string().default(".attest-it/attestations.json"),
   sealsPath: external_exports.string().default(".attest-it/seals.json")
 }).strict();
-var policySchemaV1 = external_exports.object({
+var rootGateSchemaV1 = external_exports.object({
+  authorizedSigners: external_exports.array(external_exports.string().min(1, "Root-gate signer slug cannot be empty")).min(1, "The root gate requires at least one authorized signer"),
+  maxAge: durationSchema.default("365d"),
+  description: external_exports.string().min(1, "Root gate description cannot be empty").optional()
+}).strict();
+var policyObjectSchemaV1 = external_exports.object({
   version: versionSchema2(1),
   minVersion: semverSchema.optional(),
   settings: policySettingsSchemaV1.default({}),
+  rootGate: rootGateSchemaV1.optional(),
   team: external_exports.record(external_exports.string(), teamMemberSchema).optional(),
   gates: external_exports.record(external_exports.string(), gateSchema).optional()
 }).strict();
-var schemaV13 = fromZod("1", policySchemaV1);
+var policySchemaV1 = policyObjectSchemaV1.superRefine((policy, ctx) => {
+  if (policy.gates && Object.prototype.hasOwnProperty.call(policy.gates, ROOT_GATE_ID)) {
+    ctx.addIssue({
+      code: external_exports.ZodIssueCode.custom,
+      path: ["gates", ROOT_GATE_ID],
+      message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`
+    });
+  }
+});
+var schemaV13 = fromZod("1", policyObjectSchemaV1);
 createMigrationGraph({
   id: "attest-it-policy",
   versionStrategy: integerStrategy,
@@ -46585,6 +46601,16 @@ function mergeConfigs(policy, operational) {
     settings,
     suites
   };
+  if (policy.rootGate !== void 0) {
+    const rootGate = {
+      authorizedSigners: policy.rootGate.authorizedSigners,
+      maxAge: policy.rootGate.maxAge
+    };
+    if (policy.rootGate.description !== void 0) {
+      rootGate.description = policy.rootGate.description;
+    }
+    config.rootGate = rootGate;
+  }
   if (policy.team !== void 0) {
     const team = {};
     for (const [slug, member] of Object.entries(policy.team)) {
@@ -46805,7 +46831,7 @@ function sortFiles(files) {
   });
 }
 function normalizePath2(filePath) {
-  return filePath.split(path3.sep).join("/");
+  return filePath.split(path4.sep).join("/");
 }
 function computeFinalFingerprint(fileHashes) {
   const sorted = [...fileHashes].sort((a, b) => {
@@ -46820,7 +46846,7 @@ function computeFinalFingerprint(fileHashes) {
 }
 async function hashFileAsync(realPath, normalizedPath, stats) {
   if (stats.size > LARGE_FILE_THRESHOLD) {
-    return new Promise((resolve52, reject) => {
+    return new Promise((resolve62, reject) => {
       const hash2 = crypto22.createHash("sha256");
       hash2.update(normalizedPath);
       hash2.update(":");
@@ -46829,7 +46855,7 @@ async function hashFileAsync(realPath, normalizedPath, stats) {
         hash2.update(chunk);
       });
       stream.on("end", () => {
-        resolve52(hash2.digest());
+        resolve62(hash2.digest());
       });
       stream.on("error", reject);
     });
@@ -46851,7 +46877,7 @@ function validateOptions(options) {
   const baseDir = options.baseDir ?? process.cwd();
   for (const p of options.paths) {
     if (!isGlobPattern(p)) {
-      const resolvedPath = path3.resolve(baseDir, p);
+      const resolvedPath = path4.resolve(baseDir, p);
       if (!fs.existsSync(resolvedPath)) {
         throw new Error(`Path does not exist: ${resolvedPath}`);
       }
@@ -46866,7 +46892,7 @@ async function computeFingerprint(options) {
   const fileHashCache = /* @__PURE__ */ new Map();
   const fileHashInputs = [];
   for (const file of sortedFiles) {
-    const filePath = path3.resolve(baseDir, file);
+    const filePath = path4.resolve(baseDir, file);
     let realPath = filePath;
     let stats = await fs.promises.lstat(filePath);
     if (stats.isSymbolicLink()) {
@@ -46906,7 +46932,7 @@ function resolvePackagePattern(pkg, baseDir) {
   if (isGlobPattern(pkg)) {
     return pkg;
   }
-  const fullPath = path3.resolve(baseDir, pkg);
+  const fullPath = path4.resolve(baseDir, pkg);
   try {
     const stats = fs.statSync(fullPath);
     return stats.isFile() ? pkg : `${pkg}/**/*`;
@@ -46937,17 +46963,10 @@ async function listPackageFiles(packages, ignore = [], baseDir = process.cwd()) 
   }
   return allFiles;
 }
-async function setKeyPermissions(keyPath) {
-  if (process.platform === "win32") {
-    await fs2.chmod(keyPath, 384);
-  } else {
-    await fs2.chmod(keyPath, 384);
-  }
-}
 function isBuffer(value) {
   return Buffer.isBuffer(value);
 }
-function generateKeyPair2(options = {}) {
+function generateKeyPair(options = {}) {
   try {
     const { passphrase } = options;
     const keyPair = passphrase !== void 0 && passphrase.length > 0 ? crypto22.generateKeyPairSync("ed25519", {
@@ -46995,7 +47014,7 @@ function generateKeyPair2(options = {}) {
     );
   }
 }
-function verify3(data, signature, publicKeyBase64) {
+function verify2(data, signature, publicKeyBase64) {
   try {
     const dataBuffer = typeof data === "string" ? Buffer.from(data, "utf8") : data;
     const signatureBuffer = Buffer.from(signature, "base64");
@@ -47039,241 +47058,120 @@ function verify3(data, signature, publicKeyBase64) {
     );
   }
 }
-var VaultKeyProvider = class {
-  type;
-  displayName;
-  backend;
-  /**
-   * Create a new VaultKeyProvider.
-   * @param options - Provider options including the VaultKeeper backend
-   */
-  constructor(options) {
-    this.backend = options.backend;
-    this.type = options.backend.type;
-    this.displayName = options.displayName;
+function isFileNotFoundError(error2) {
+  if (error2 && typeof error2 === "object" && "code" in error2) {
+    const errorWithCode = error2;
+    return errorWithCode.code === "ENOENT" || errorWithCode.code === "ENOTDIR";
   }
-  /**
-   * Check if the underlying VaultKeeper backend is available.
-   */
-  async isAvailable() {
-    return this.backend.isAvailable();
-  }
-  /**
-   * Check if a key exists in the VaultKeeper backend.
-   * @param keyRef - Secret identifier in the backend
-   */
-  async keyExists(keyRef) {
-    return this.backend.exists(keyRef);
-  }
-  /**
-   * Retrieve the private key from VaultKeeper for signing.
-   *
-   * @remarks
-   * Downloads the PEM to a secure temporary file (mode 0o600) and returns
-   * a cleanup function that overwrites the file with random bytes before deletion.
-   *
-   * @param keyRef - Secret identifier in the backend
-   * @throws Error if the key does not exist in the backend
-   */
-  async getPrivateKey(keyRef) {
-    const pemContent = await this.backend.retrieve(keyRef);
-    const tempDir = await fs2.mkdtemp(path3.join(os2.tmpdir(), "attest-it-vk-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      await fs2.writeFile(tempKeyPath, pemContent, "utf-8");
-      await setKeyPermissions(tempKeyPath);
-      return {
-        keyPath: tempKeyPath,
-        cleanup: async () => {
-          try {
-            const stat3 = await fs2.stat(tempKeyPath);
-            await fs2.writeFile(tempKeyPath, crypto22.randomBytes(stat3.size));
-            await fs2.unlink(tempKeyPath);
-            await fs2.rmdir(tempDir);
-          } catch (cleanupError) {
-            console.warn(
-              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-            );
-          }
-        }
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new Ed25519 keypair and store the private key in VaultKeeper.
-   *
-   * @remarks
-   * The public key is written to the filesystem for repository commit.
-   * The private key is stored in the VaultKeeper backend and the local
-   * copy is securely deleted.
-   *
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    if (!force) {
-      try {
-        await fs2.access(publicKeyPath);
-        throw new Error(
-          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
-        );
-      } catch (err) {
-        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
-          throw err;
-        }
-      }
-    }
-    const keyPair = generateKeyPair2();
-    await fs2.mkdir(path3.dirname(publicKeyPath), { recursive: true });
-    await fs2.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
-    const secretId = `attest-it-${crypto22.randomUUID()}`;
-    await this.backend.store(secretId, keyPair.privateKey);
-    return {
-      privateKeyRef: secretId,
-      publicKeyPath,
-      storageDescription: `VaultKeeper (${this.backend.displayName}): ${secretId}`
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: { backendType: this.backend.type }
-    };
-  }
-};
-function resolveLegacyPath(p) {
-  if (p === "~" || p.startsWith("~/")) {
-    return path3.join((0, import_os.homedir)(), p.slice(1));
-  }
-  return p;
+  return false;
 }
-var LegacyFilesystemKeyProvider = class {
-  type = "filesystem-legacy";
-  displayName = "Filesystem (Legacy)";
-  /**
-   * Check if this provider is available.
-   * The legacy filesystem provider is always available.
-   */
-  async isAvailable() {
-    return Promise.resolve(true);
-  }
-  /**
-   * Check if a key exists at the given filesystem path.
-   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
-   */
-  async keyExists(keyRef) {
-    try {
-      await fs2.access(resolveLegacyPath(keyRef));
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key path for signing.
-   * Returns the resolved (tilde-expanded) path with a no-op cleanup function.
-   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
-   */
-  async getPrivateKey(keyRef) {
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(`Private key not found: ${keyRef}`);
-    }
+function verifySeal(seal2, config) {
+  const { gateId, fingerprint: fingerprint2, timestamp, sealedBy, signature } = seal2;
+  if (!config.team) {
     return {
-      keyPath: resolveLegacyPath(keyRef),
-      // No-op cleanup — key stays on filesystem
-      cleanup: async () => {
-      }
+      valid: false,
+      error: `No team configuration found`
     };
   }
-  /**
-   * Not supported — legacy provider does not create new keys.
-   * @param _options - Unused key generation options
-   * @throws Always throws an informative error directing the user to `identity create`
-   */
-  // Must stay async so the throw below becomes a rejected Promise, matching the KeyProvider interface contract
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async generateKeyPair(_options) {
-    throw new Error(
-      'Legacy filesystem provider does not support key generation. Use "attest-it identity create" with a VaultKeeper-backed provider.'
-    );
+  const teamMember = config.team[sealedBy];
+  if (!teamMember) {
+    return {
+      valid: false,
+      error: `Team member '${sealedBy}' not found in configuration`
+    };
   }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return { type: this.type, options: {} };
+  const canonicalString = `${gateId}:${fingerprint2}:${timestamp}`;
+  try {
+    const isValid2 = verify2(canonicalString, signature, teamMember.publicKey);
+    if (!isValid2) {
+      return {
+        valid: false,
+        error: "Signature verification failed"
+      };
+    }
+    return { valid: true };
+  } catch (error2) {
+    return {
+      valid: false,
+      error: `Signature verification error: ${error2 instanceof Error ? error2.message : String(error2)}`
+    };
   }
-};
-var KeyProviderRegistry = class {
-  static providers = /* @__PURE__ */ new Map();
-  /**
-   * Register a key provider factory.
-   * @param type - Provider type identifier
-   * @param factory - Factory function to create provider instances
-   */
-  static register(type, factory) {
-    this.providers.set(type, factory);
+}
+function createEmptySealsFile() {
+  return {
+    version: 1,
+    seals: {}
+  };
+}
+function detectFormat2(filepath) {
+  const ext = filepath.split(".").pop()?.toLowerCase();
+  if (ext === "json") return "json";
+  return "yaml";
+}
+function parseSealsContent(content, format) {
+  let data;
+  try {
+    data = format === "yaml" ? (0, import_yaml.parse)(content) : JSON.parse(content);
+  } catch (error2) {
+    if (error2 instanceof SyntaxError || error2 instanceof Error && error2.name === "YAMLParseError") {
+      throw new Error(`Failed to read seals file: Invalid ${format.toUpperCase()}`);
+    }
+    throw error2;
   }
-  /**
-   * Create a key provider from configuration.
-   * @param config - Provider configuration
-   * @returns A key provider instance
-   * @throws Error if the provider type is not registered
-   */
-  static create(config) {
-    const factory = this.providers.get(config.type);
-    if (!factory) {
+  if (typeof data === "object" && data !== null && "version" in data) {
+    const dataObj = data;
+    const version2 = dataObj.version;
+    if (version2 !== 1 && version2 !== "1") {
+      throw new Error(`Unsupported seals file version: ${String(version2)}`);
+    }
+  }
+  const result = sealsFileSchemaV1.safeParse(data);
+  if (!result.success) {
+    const errors = result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ");
+    throw new Error(`Failed to read seals file: Validation failed: ${errors}`);
+  }
+  return result.data;
+}
+async function readSeals(dir, sealsPathOverride) {
+  if (sealsPathOverride) {
+    const sealsPath = path4.resolve(dir, sealsPathOverride);
+    let content;
+    try {
+      content = await fs.promises.readFile(sealsPath, "utf8");
+    } catch (error2) {
+      if (isFileNotFoundError(error2)) {
+        return createEmptySealsFile();
+      }
       throw new Error(
-        `Unknown key provider type: ${config.type}. Available types: ${Array.from(this.providers.keys()).join(", ")}`
+        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
       );
     }
-    return factory(config);
+    return parseSealsContent(content, detectFormat2(sealsPath));
   }
-  /**
-   * Get all registered provider types.
-   * @returns Array of provider type identifiers
-   */
-  static getProviderTypes() {
-    return Array.from(this.providers.keys());
+  const yamlPath = path4.join(dir, ".attest-it", "seals.yaml");
+  const jsonPath = path4.join(dir, ".attest-it", "seals.json");
+  try {
+    const content = await fs.promises.readFile(yamlPath, "utf8");
+    return parseSealsContent(content, "yaml");
+  } catch (error2) {
+    if (!isFileNotFoundError(error2)) {
+      throw new Error(
+        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
+      );
+    }
   }
-};
-KeyProviderRegistry.register("filesystem", (_config) => {
-  const backend = BackendRegistry.create("file");
-  return new VaultKeyProvider({ backend, displayName: "Filesystem" });
-});
-KeyProviderRegistry.register("1password", (_config) => {
-  const backend = BackendRegistry.create("1password");
-  return new VaultKeyProvider({ backend, displayName: "1Password" });
-});
-KeyProviderRegistry.register("macos-keychain", (_config) => {
-  const backend = BackendRegistry.create("keychain");
-  return new VaultKeyProvider({ backend, displayName: "macOS Keychain" });
-});
-KeyProviderRegistry.register("yubikey", (_config) => {
-  const backend = BackendRegistry.create("yubikey");
-  return new VaultKeyProvider({ backend, displayName: "YubiKey" });
-});
-KeyProviderRegistry.register("filesystem-legacy", (_config) => {
-  return new LegacyFilesystemKeyProvider();
-});
-var cliExperienceSchema = external_exports.object({
-  declinedCompletionInstall: external_exports.boolean().optional()
-}).strict();
-var userPreferencesSchema = external_exports.object({
-  cliExperience: cliExperienceSchema.optional()
-}).strict();
+  try {
+    const content = await fs.promises.readFile(jsonPath, "utf8");
+    return parseSealsContent(content, "json");
+  } catch (error2) {
+    if (isFileNotFoundError(error2)) {
+      return createEmptySealsFile();
+    }
+    throw new Error(
+      `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
+    );
+  }
+}
 function isAuthorizedSigner(config, gateId, publicKey) {
   const gate = config.gates?.[gateId];
   if (!gate) {
@@ -47327,120 +47225,6 @@ function parseDuration(duration) {
     throw new Error(`Invalid duration string: ${duration}`);
   }
   return result;
-}
-function isFileNotFoundError(error2) {
-  if (error2 && typeof error2 === "object" && "code" in error2) {
-    const errorWithCode = error2;
-    return errorWithCode.code === "ENOENT" || errorWithCode.code === "ENOTDIR";
-  }
-  return false;
-}
-function verifySeal(seal2, config) {
-  const { gateId, fingerprint: fingerprint2, timestamp, sealedBy, signature } = seal2;
-  if (!config.team) {
-    return {
-      valid: false,
-      error: `No team configuration found`
-    };
-  }
-  const teamMember = config.team[sealedBy];
-  if (!teamMember) {
-    return {
-      valid: false,
-      error: `Team member '${sealedBy}' not found in configuration`
-    };
-  }
-  const canonicalString = `${gateId}:${fingerprint2}:${timestamp}`;
-  try {
-    const isValid2 = verify3(canonicalString, signature, teamMember.publicKey);
-    if (!isValid2) {
-      return {
-        valid: false,
-        error: "Signature verification failed"
-      };
-    }
-    return { valid: true };
-  } catch (error2) {
-    return {
-      valid: false,
-      error: `Signature verification error: ${error2 instanceof Error ? error2.message : String(error2)}`
-    };
-  }
-}
-function createEmptySealsFile() {
-  return {
-    version: 1,
-    seals: {}
-  };
-}
-function detectFormat2(filepath) {
-  const ext = filepath.split(".").pop()?.toLowerCase();
-  if (ext === "json") return "json";
-  return "yaml";
-}
-function parseSealsContent(content, format) {
-  let data;
-  try {
-    data = format === "yaml" ? (0, import_yaml.parse)(content) : JSON.parse(content);
-  } catch (error2) {
-    if (error2 instanceof SyntaxError || error2 instanceof Error && error2.name === "YAMLParseError") {
-      throw new Error(`Failed to read seals file: Invalid ${format.toUpperCase()}`);
-    }
-    throw error2;
-  }
-  if (typeof data === "object" && data !== null && "version" in data) {
-    const dataObj = data;
-    const version2 = dataObj.version;
-    if (version2 !== 1 && version2 !== "1") {
-      throw new Error(`Unsupported seals file version: ${String(version2)}`);
-    }
-  }
-  const result = sealsFileSchemaV1.safeParse(data);
-  if (!result.success) {
-    const errors = result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ");
-    throw new Error(`Failed to read seals file: Validation failed: ${errors}`);
-  }
-  return result.data;
-}
-async function readSeals(dir, sealsPathOverride) {
-  if (sealsPathOverride) {
-    const sealsPath = path3.resolve(dir, sealsPathOverride);
-    let content;
-    try {
-      content = await fs.promises.readFile(sealsPath, "utf8");
-    } catch (error2) {
-      if (isFileNotFoundError(error2)) {
-        return createEmptySealsFile();
-      }
-      throw new Error(
-        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
-      );
-    }
-    return parseSealsContent(content, detectFormat2(sealsPath));
-  }
-  const yamlPath = path3.join(dir, ".attest-it", "seals.yaml");
-  const jsonPath = path3.join(dir, ".attest-it", "seals.json");
-  try {
-    const content = await fs.promises.readFile(yamlPath, "utf8");
-    return parseSealsContent(content, "yaml");
-  } catch (error2) {
-    if (!isFileNotFoundError(error2)) {
-      throw new Error(
-        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
-      );
-    }
-  }
-  try {
-    const content = await fs.promises.readFile(jsonPath, "utf8");
-    return parseSealsContent(content, "json");
-  } catch (error2) {
-    if (isFileNotFoundError(error2)) {
-      return createEmptySealsFile();
-    }
-    throw new Error(
-      `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
-    );
-  }
 }
 function verifyGateSeal(config, gateId, seals, currentFingerprint) {
   const gate = getGate(config, gateId);
@@ -47551,6 +47335,317 @@ function verifyAllSeals(config, seals, fingerprints) {
   }
   return results;
 }
+var DEFAULT_POLICY_REL_PATH = ".attest-it/policy.yaml";
+function synthesizeRootGate(rootGate, policyRelPath) {
+  return {
+    name: "Root Gate",
+    description: rootGate.description ?? "Trust anchor over .attest-it/policy.yaml",
+    authorizedSigners: rootGate.authorizedSigners,
+    fingerprint: { paths: [policyRelPath] },
+    maxAge: rootGate.maxAge
+  };
+}
+function toPolicyRelPath(baseDir, policyPath) {
+  const rel = (0, import_path4.relative)((0, import_path4.resolve)(baseDir), (0, import_path4.resolve)(policyPath));
+  if (rel.length === 0 || rel.startsWith("..")) {
+    return DEFAULT_POLICY_REL_PATH;
+  }
+  return rel.split("\\").join("/");
+}
+async function computePolicyFingerprint(baseDir, policyPath) {
+  const relPath = toPolicyRelPath(baseDir, policyPath);
+  const result = await computeFingerprint({ paths: [relPath], baseDir });
+  return result.fingerprint;
+}
+function describeRootState(state, base) {
+  switch (state) {
+    case "VALID":
+      return "Root gate is valid: .attest-it/policy.yaml is sealed by an authorized root signer.";
+    case "MISSING":
+      return "Untrusted policy: .attest-it/policy.yaml is not sealed by a root signer. The trust-critical policy (team & gate authorization) has no root seal. Have a root signer run `attest-it seal --root` to anchor it.";
+    case "FINGERPRINT_MISMATCH":
+      return "Untrusted change to .attest-it/policy.yaml: the trust-critical policy (team &/or gate authorization) was modified, but the modification is not sealed by a root signer. The existing root seal covers a different policy fingerprint. Have a root signer re-run `attest-it seal --root` to authorize this change.";
+    case "UNKNOWN_SIGNER":
+      return "Untrusted policy change: the root seal over .attest-it/policy.yaml was created by a signer that is not an authorized root signer. A branch cannot bootstrap a new root of trust for itself \u2014 changing the root signers requires a seal from an existing root signer." + (base ? ` (${base})` : "");
+    case "INVALID_SIGNATURE":
+      return "Untrusted policy: the root seal over .attest-it/policy.yaml has an invalid signature and does not authorize the current policy." + (base ? ` (${base})` : "");
+    case "STALE":
+      return "The root seal over .attest-it/policy.yaml is stale (exceeds the root gate maxAge). Have a root signer re-run `attest-it seal --root`.";
+    case "NOT_ANCHORED":
+      return "Policy is not trust-anchored: .attest-it/policy.yaml defines no rootGate. Run the `attest-it init` bootstrap ceremony to establish a root signer.";
+    default: {
+      const _exhaustive = state;
+      return `Root gate verification failed${base ? ` (${base})` : ""}: ${String(_exhaustive)}`;
+    }
+  }
+}
+function verifyRootGate(params) {
+  const { config, policyFingerprint, seals, trustedSourceLabel } = params;
+  if (!config.rootGate) {
+    return {
+      gateId: ROOT_GATE_ID,
+      state: "NOT_ANCHORED",
+      message: describeRootState("NOT_ANCHORED", trustedSourceLabel)
+    };
+  }
+  const syntheticGate = synthesizeRootGate(config.rootGate, DEFAULT_POLICY_REL_PATH);
+  const configWithRoot = {
+    ...config,
+    gates: { ...config.gates, [ROOT_GATE_ID]: syntheticGate }
+  };
+  const result = verifyGateSeal(configWithRoot, ROOT_GATE_ID, seals, policyFingerprint);
+  return {
+    gateId: ROOT_GATE_ID,
+    state: result.state,
+    ...result.seal && { seal: result.seal },
+    message: describeRootState(result.state, trustedSourceLabel)
+  };
+}
+function isBlockingRootGateState(state) {
+  return state !== "VALID" && state !== "STALE" && state !== "NOT_ANCHORED";
+}
+async function setKeyPermissions(keyPath) {
+  if (process.platform === "win32") {
+    await fs32.chmod(keyPath, 384);
+  } else {
+    await fs32.chmod(keyPath, 384);
+  }
+}
+var VaultKeyProvider = class {
+  type;
+  displayName;
+  backend;
+  /**
+   * Create a new VaultKeyProvider.
+   * @param options - Provider options including the VaultKeeper backend
+   */
+  constructor(options) {
+    this.backend = options.backend;
+    this.type = options.backend.type;
+    this.displayName = options.displayName;
+  }
+  /**
+   * Check if the underlying VaultKeeper backend is available.
+   */
+  async isAvailable() {
+    return this.backend.isAvailable();
+  }
+  /**
+   * Check if a key exists in the VaultKeeper backend.
+   * @param keyRef - Secret identifier in the backend
+   */
+  async keyExists(keyRef) {
+    return this.backend.exists(keyRef);
+  }
+  /**
+   * Retrieve the private key from VaultKeeper for signing.
+   *
+   * @remarks
+   * Downloads the PEM to a secure temporary file (mode 0o600) and returns
+   * a cleanup function that overwrites the file with random bytes before deletion.
+   *
+   * @param keyRef - Secret identifier in the backend
+   * @throws Error if the key does not exist in the backend
+   */
+  async getPrivateKey(keyRef) {
+    const pemContent = await this.backend.retrieve(keyRef);
+    const tempDir = await fs32.mkdtemp(path4.join(os2.tmpdir(), "attest-it-vk-"));
+    const tempKeyPath = path4.join(tempDir, "private.pem");
+    try {
+      await fs32.writeFile(tempKeyPath, pemContent, "utf-8");
+      await setKeyPermissions(tempKeyPath);
+      return {
+        keyPath: tempKeyPath,
+        cleanup: async () => {
+          try {
+            const stat3 = await fs32.stat(tempKeyPath);
+            await fs32.writeFile(tempKeyPath, crypto22.randomBytes(stat3.size));
+            await fs32.unlink(tempKeyPath);
+            await fs32.rmdir(tempDir);
+          } catch (cleanupError) {
+            console.warn(
+              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+            );
+          }
+        }
+      };
+    } catch (error2) {
+      try {
+        await fs32.rm(tempDir, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.warn(
+          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+        );
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Generate a new Ed25519 keypair and store the private key in VaultKeeper.
+   *
+   * @remarks
+   * The public key is written to the filesystem for repository commit.
+   * The private key is stored in the VaultKeeper backend and the local
+   * copy is securely deleted.
+   *
+   * @param options - Key generation options
+   */
+  async generateKeyPair(options) {
+    const { publicKeyPath, force = false } = options;
+    if (!force) {
+      try {
+        await fs32.access(publicKeyPath);
+        throw new Error(
+          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
+        );
+      } catch (err) {
+        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+          throw err;
+        }
+      }
+    }
+    const keyPair = generateKeyPair();
+    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
+    await fs32.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
+    const secretId = `attest-it-${crypto22.randomUUID()}`;
+    await this.backend.store(secretId, keyPair.privateKey);
+    return {
+      privateKeyRef: secretId,
+      publicKeyPath,
+      storageDescription: `VaultKeeper (${this.backend.displayName}): ${secretId}`
+    };
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return {
+      type: this.type,
+      options: { backendType: this.backend.type }
+    };
+  }
+};
+function resolveLegacyPath(p) {
+  if (p === "~" || p.startsWith("~/")) {
+    return path4.join((0, import_os.homedir)(), p.slice(1));
+  }
+  return p;
+}
+var LegacyFilesystemKeyProvider = class {
+  type = "filesystem-legacy";
+  displayName = "Filesystem (Legacy)";
+  /**
+   * Check if this provider is available.
+   * The legacy filesystem provider is always available.
+   */
+  async isAvailable() {
+    return Promise.resolve(true);
+  }
+  /**
+   * Check if a key exists at the given filesystem path.
+   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
+   */
+  async keyExists(keyRef) {
+    try {
+      await fs32.access(resolveLegacyPath(keyRef));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  /**
+   * Get the private key path for signing.
+   * Returns the resolved (tilde-expanded) path with a no-op cleanup function.
+   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
+   */
+  async getPrivateKey(keyRef) {
+    if (!await this.keyExists(keyRef)) {
+      throw new Error(`Private key not found: ${keyRef}`);
+    }
+    return {
+      keyPath: resolveLegacyPath(keyRef),
+      // No-op cleanup — key stays on filesystem
+      cleanup: async () => {
+      }
+    };
+  }
+  /**
+   * Not supported — legacy provider does not create new keys.
+   * @param _options - Unused key generation options
+   * @throws Always throws an informative error directing the user to `identity create`
+   */
+  // Must stay async so the throw below becomes a rejected Promise, matching the KeyProvider interface contract
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async generateKeyPair(_options) {
+    throw new Error(
+      'Legacy filesystem provider does not support key generation. Use "attest-it identity create" with a VaultKeeper-backed provider.'
+    );
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return { type: this.type, options: {} };
+  }
+};
+var KeyProviderRegistry = class {
+  static providers = /* @__PURE__ */ new Map();
+  /**
+   * Register a key provider factory.
+   * @param type - Provider type identifier
+   * @param factory - Factory function to create provider instances
+   */
+  static register(type, factory) {
+    this.providers.set(type, factory);
+  }
+  /**
+   * Create a key provider from configuration.
+   * @param config - Provider configuration
+   * @returns A key provider instance
+   * @throws Error if the provider type is not registered
+   */
+  static create(config) {
+    const factory = this.providers.get(config.type);
+    if (!factory) {
+      throw new Error(
+        `Unknown key provider type: ${config.type}. Available types: ${Array.from(this.providers.keys()).join(", ")}`
+      );
+    }
+    return factory(config);
+  }
+  /**
+   * Get all registered provider types.
+   * @returns Array of provider type identifiers
+   */
+  static getProviderTypes() {
+    return Array.from(this.providers.keys());
+  }
+};
+KeyProviderRegistry.register("filesystem", (_config) => {
+  const backend = BackendRegistry.create("file");
+  return new VaultKeyProvider({ backend, displayName: "Filesystem" });
+});
+KeyProviderRegistry.register("1password", (_config) => {
+  const backend = BackendRegistry.create("1password");
+  return new VaultKeyProvider({ backend, displayName: "1Password" });
+});
+KeyProviderRegistry.register("macos-keychain", (_config) => {
+  const backend = BackendRegistry.create("keychain");
+  return new VaultKeyProvider({ backend, displayName: "macOS Keychain" });
+});
+KeyProviderRegistry.register("yubikey", (_config) => {
+  const backend = BackendRegistry.create("yubikey");
+  return new VaultKeyProvider({ backend, displayName: "YubiKey" });
+});
+KeyProviderRegistry.register("filesystem-legacy", (_config) => {
+  return new LegacyFilesystemKeyProvider();
+});
+var cliExperienceSchema = external_exports.object({
+  declinedCompletionInstall: external_exports.boolean().optional()
+}).strict();
+var userPreferencesSchema = external_exports.object({
+  cliExperience: cliExperienceSchema.optional()
+}).strict();
 var version = getPackageVersion();
 
 // src/fetch-policy.ts
@@ -47708,6 +47803,24 @@ async function run() {
       } else {
         throw err;
       }
+    }
+    if (config.rootGate) {
+      const workingTreePolicyPath = (0, import_node_path.resolve)(process.cwd(), policyPath);
+      const policyFingerprint = await computePolicyFingerprint(process.cwd(), workingTreePolicyPath);
+      const rootResult = verifyRootGate({
+        config,
+        policyFingerprint,
+        seals,
+        trustedSourceLabel: effectivePolicyRef ? `root signers from ${effectivePolicyRef}` : void 0
+      });
+      if (isBlockingRootGateState(rootResult.state)) {
+        core.setFailed(rootResult.message);
+        return;
+      }
+      if (rootResult.state === "STALE") {
+        core.warning(rootResult.message);
+      }
+      core.info("\u2713 Root gate verified: policy.yaml is sealed by an authorized root signer");
     }
     const fingerprints = {};
     if (config.gates) {

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -29160,7 +29160,7 @@ var require_public_api = __commonJS({
         return docs;
       return Object.assign([], { empty: true }, composer$1.streamInfo());
     }
-    function parseDocument(source, options = {}) {
+    function parseDocument2(source, options = {}) {
       const { lineCounter: lineCounter2, prettyErrors } = parseOptions(options);
       const parser$1 = new parser.Parser(lineCounter2?.addNewLine);
       const composer$1 = new composer.Composer(options);
@@ -29186,7 +29186,7 @@ var require_public_api = __commonJS({
       } else if (options === void 0 && reviver && typeof reviver === "object") {
         options = reviver;
       }
-      const doc = parseDocument(src, options);
+      const doc = parseDocument2(src, options);
       if (!doc)
         return null;
       doc.warnings.forEach((warning2) => log2.warn(doc.options.logLevel, warning2));
@@ -29222,7 +29222,7 @@ var require_public_api = __commonJS({
     }
     exports2.parse = parse3;
     exports2.parseAllDocuments = parseAllDocuments;
-    exports2.parseDocument = parseDocument;
+    exports2.parseDocument = parseDocument2;
     exports2.stringify = stringify2;
   }
 });

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -46358,23 +46358,18 @@ var rootGateSchemaV1 = external_exports.object({
   maxAge: durationSchema.default("365d"),
   description: external_exports.string().min(1, "Root gate description cannot be empty").optional()
 }).strict();
+var ordinaryGateSlugSchemaV1 = external_exports.string().refine((slug) => slug !== ROOT_GATE_ID, {
+  message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`
+});
 var policyObjectSchemaV1 = external_exports.object({
   version: versionSchema2(1),
   minVersion: semverSchema.optional(),
   settings: policySettingsSchemaV1.default({}),
   rootGate: rootGateSchemaV1.optional(),
   team: external_exports.record(external_exports.string(), teamMemberSchema).optional(),
-  gates: external_exports.record(external_exports.string(), gateSchema).optional()
+  gates: external_exports.record(ordinaryGateSlugSchemaV1, gateSchema).optional()
 }).strict();
-var policySchemaV1 = policyObjectSchemaV1.superRefine((policy, ctx) => {
-  if (policy.gates && Object.prototype.hasOwnProperty.call(policy.gates, ROOT_GATE_ID)) {
-    ctx.addIssue({
-      code: external_exports.ZodIssueCode.custom,
-      path: ["gates", ROOT_GATE_ID],
-      message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`
-    });
-  }
-});
+var policySchemaV1 = policyObjectSchemaV1;
 var schemaV13 = fromZod("1", policyObjectSchemaV1);
 createMigrationGraph({
   id: "attest-it-policy",

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -46361,23 +46361,18 @@ var rootGateSchemaV1 = external_exports.object({
   maxAge: durationSchema.default("365d"),
   description: external_exports.string().min(1, "Root gate description cannot be empty").optional()
 }).strict();
+var ordinaryGateSlugSchemaV1 = external_exports.string().refine((slug) => slug !== ROOT_GATE_ID, {
+  message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`
+});
 var policyObjectSchemaV1 = external_exports.object({
   version: versionSchema2(1),
   minVersion: semverSchema.optional(),
   settings: policySettingsSchemaV1.default({}),
   rootGate: rootGateSchemaV1.optional(),
   team: external_exports.record(external_exports.string(), teamMemberSchema).optional(),
-  gates: external_exports.record(external_exports.string(), gateSchema).optional()
+  gates: external_exports.record(ordinaryGateSlugSchemaV1, gateSchema).optional()
 }).strict();
-var policySchemaV1 = policyObjectSchemaV1.superRefine((policy, ctx) => {
-  if (policy.gates && Object.prototype.hasOwnProperty.call(policy.gates, ROOT_GATE_ID)) {
-    ctx.addIssue({
-      code: external_exports.ZodIssueCode.custom,
-      path: ["gates", ROOT_GATE_ID],
-      message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`
-    });
-  }
-});
+var policySchemaV1 = policyObjectSchemaV1;
 var schemaV13 = fromZod("1", policyObjectSchemaV1);
 createMigrationGraph({
   id: "attest-it-policy",

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -29168,7 +29168,7 @@ var require_public_api = __commonJS({
         return docs;
       return Object.assign([], { empty: true }, composer$1.streamInfo());
     }
-    function parseDocument(source, options = {}) {
+    function parseDocument2(source, options = {}) {
       const { lineCounter: lineCounter2, prettyErrors } = parseOptions(options);
       const parser$1 = new parser.Parser(lineCounter2?.addNewLine);
       const composer$1 = new composer.Composer(options);
@@ -29194,7 +29194,7 @@ var require_public_api = __commonJS({
       } else if (options === void 0 && reviver && typeof reviver === "object") {
         options = reviver;
       }
-      const doc = parseDocument(src, options);
+      const doc = parseDocument2(src, options);
       if (!doc)
         return null;
       doc.warnings.forEach((warning2) => log2.warn(doc.options.logLevel, warning2));
@@ -29230,7 +29230,7 @@ var require_public_api = __commonJS({
     }
     exports.parse = parse3;
     exports.parseAllDocuments = parseAllDocuments;
-    exports.parseDocument = parseDocument;
+    exports.parseDocument = parseDocument2;
     exports.stringify = stringify2;
   }
 });

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -206,7 +206,7 @@ var require_file_command = __commonJS({
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
     var crypto = __importStar(__require("crypto"));
-    var fs4 = __importStar(__require("fs"));
+    var fs2 = __importStar(__require("fs"));
     var os3 = __importStar(__require("os"));
     var utils_1 = require_utils();
     function issueFileCommand(command, message) {
@@ -214,10 +214,10 @@ var require_file_command = __commonJS({
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
       }
-      if (!fs4.existsSync(filePath)) {
+      if (!fs2.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`);
       }
-      fs4.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os3.EOL}`, {
+      fs2.appendFileSync(filePath, `${(0, utils_1.toCommandValue)(message)}${os3.EOL}`, {
         encoding: "utf8"
       });
     }
@@ -1029,14 +1029,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`;
-        let path4 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path3 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin.endsWith("/")) {
           origin = origin.substring(0, origin.length - 1);
         }
-        if (path4 && !path4.startsWith("/")) {
-          path4 = `/${path4}`;
+        if (path3 && !path3.startsWith("/")) {
+          path3 = `/${path3}`;
         }
-        url = new URL(origin + path4);
+        url = new URL(origin + path3);
       }
       return url;
     }
@@ -2659,20 +2659,20 @@ var require_basename = __commonJS({
   "../../node_modules/.pnpm/@fastify+busboy@2.1.1/node_modules/@fastify/busboy/lib/utils/basename.js"(exports, module) {
     "use strict";
     init_esm_shims();
-    module.exports = function basename2(path4) {
-      if (typeof path4 !== "string") {
+    module.exports = function basename2(path3) {
+      if (typeof path3 !== "string") {
         return "";
       }
-      for (var i = path4.length - 1; i >= 0; --i) {
-        switch (path4.charCodeAt(i)) {
+      for (var i = path3.length - 1; i >= 0; --i) {
+        switch (path3.charCodeAt(i)) {
           case 47:
           // '/'
           case 92:
-            path4 = path4.slice(i + 1);
-            return path4 === ".." || path4 === "." ? "" : path4;
+            path3 = path3.slice(i + 1);
+            return path3 === ".." || path3 === "." ? "" : path3;
         }
       }
-      return path4 === ".." || path4 === "." ? "" : path4;
+      return path3 === ".." || path3 === "." ? "" : path3;
     };
   }
 });
@@ -4072,8 +4072,8 @@ var require_util2 = __commonJS({
     function createDeferredPromise() {
       let res;
       let rej;
-      const promise2 = new Promise((resolve6, reject) => {
-        res = resolve6;
+      const promise2 = new Promise((resolve7, reject) => {
+        res = resolve7;
         rej = reject;
       });
       return { promise: promise2, resolve: res, reject: rej };
@@ -5584,8 +5584,8 @@ Content-Type: ${value.type || "application/octet-stream"}\r
                 });
               }
             });
-            const busboyResolve = new Promise((resolve6, reject) => {
-              busboy.on("finish", resolve6);
+            const busboyResolve = new Promise((resolve7, reject) => {
+              busboy.on("finish", resolve7);
               busboy.on("error", (err) => reject(new TypeError(err)));
             });
             if (this.body !== null) for await (const chunk of consumeBody(this[kState].body)) busboy.write(chunk);
@@ -5717,7 +5717,7 @@ var require_request = __commonJS({
     }
     var Request2 = class _Request {
       constructor(origin, {
-        path: path4,
+        path: path3,
         method,
         body,
         headers,
@@ -5731,11 +5731,11 @@ var require_request = __commonJS({
         throwOnError,
         expectContinue
       }, handler2) {
-        if (typeof path4 !== "string") {
+        if (typeof path3 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path4[0] !== "/" && !(path4.startsWith("http://") || path4.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path3[0] !== "/" && !(path3.startsWith("http://") || path3.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.exec(path4) !== null) {
+        } else if (invalidPathRegex.exec(path3) !== null) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -5798,7 +5798,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? util2.buildURL(path4, query) : path4;
+        this.path = query ? util2.buildURL(path3, query) : path3;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6122,9 +6122,9 @@ var require_dispatcher_base = __commonJS({
       }
       close(callback2) {
         if (callback2 === void 0) {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             this.close((err, data) => {
-              return err ? reject(err) : resolve6(data);
+              return err ? reject(err) : resolve7(data);
             });
           });
         }
@@ -6162,12 +6162,12 @@ var require_dispatcher_base = __commonJS({
           err = null;
         }
         if (callback2 === void 0) {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             this.destroy(err, (err2, data) => {
               return err2 ? (
                 /* istanbul ignore next: should never error */
                 reject(err2)
-              ) : resolve6(data);
+              ) : resolve7(data);
             });
           });
         }
@@ -6812,9 +6812,9 @@ var require_RedirectHandler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util2.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path4 = search ? `${pathname}${search}` : pathname;
+        const path3 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path4;
+        this.opts.path = path3;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -7237,16 +7237,16 @@ var require_client = __commonJS({
         return this[kNeedDrain] < 2;
       }
       async [kClose]() {
-        return new Promise((resolve6) => {
+        return new Promise((resolve7) => {
           if (!this[kSize]) {
-            resolve6(null);
+            resolve7(null);
           } else {
-            this[kClosedResolve] = resolve6;
+            this[kClosedResolve] = resolve7;
           }
         });
       }
       async [kDestroy](err) {
-        return new Promise((resolve6) => {
+        return new Promise((resolve7) => {
           const requests = this[kQueue].splice(this[kPendingIdx]);
           for (let i = 0; i < requests.length; i++) {
             const request2 = requests[i];
@@ -7257,7 +7257,7 @@ var require_client = __commonJS({
               this[kClosedResolve]();
               this[kClosedResolve] = null;
             }
-            resolve6();
+            resolve7();
           };
           if (this[kHTTP2Session] != null) {
             util2.destroy(this[kHTTP2Session], err);
@@ -7837,7 +7837,7 @@ var require_client = __commonJS({
         });
       }
       try {
-        const socket = await new Promise((resolve6, reject) => {
+        const socket = await new Promise((resolve7, reject) => {
           client[kConnector]({
             host,
             hostname,
@@ -7849,7 +7849,7 @@ var require_client = __commonJS({
             if (err) {
               reject(err);
             } else {
-              resolve6(socket2);
+              resolve7(socket2);
             }
           });
         });
@@ -8060,7 +8060,7 @@ var require_client = __commonJS({
         writeH2(client, client[kHTTP2Session], request2);
         return;
       }
-      const { body, method, path: path4, host, upgrade, headers, blocking, reset } = request2;
+      const { body, method, path: path3, host, upgrade, headers, blocking, reset } = request2;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
         body.read(0);
@@ -8110,7 +8110,7 @@ var require_client = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path4} HTTP/1.1\r
+      let header = `${method} ${path3} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -8173,7 +8173,7 @@ upgrade: ${upgrade}\r
       return true;
     }
     function writeH2(client, session, request2) {
-      const { body, method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
+      const { body, method, path: path3, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
       let headers;
       if (typeof reqHeaders === "string") headers = Request2[kHTTP2CopyHeaders](reqHeaders.trim());
       else headers = reqHeaders;
@@ -8216,7 +8216,7 @@ upgrade: ${upgrade}\r
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path4;
+      headers[HTTP2_HEADER_PATH] = path3;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -8473,12 +8473,12 @@ upgrade: ${upgrade}\r
           cb();
         }
       }
-      const waitForDrain = () => new Promise((resolve6, reject) => {
+      const waitForDrain = () => new Promise((resolve7, reject) => {
         assert(callback2 === null);
         if (socket[kError]) {
           reject(socket[kError]);
         } else {
-          callback2 = resolve6;
+          callback2 = resolve7;
         }
       });
       if (client[kHTTPConnVersion] === "h2") {
@@ -8827,8 +8827,8 @@ var require_pool_base = __commonJS({
         if (this[kQueue].isEmpty()) {
           return Promise.all(this[kClients].map((c) => c.close()));
         } else {
-          return new Promise((resolve6) => {
-            this[kClosedResolve] = resolve6;
+          return new Promise((resolve7) => {
+            this[kClosedResolve] = resolve7;
           });
         }
       }
@@ -9411,7 +9411,7 @@ var require_readable = __commonJS({
         if (this.closed) {
           return Promise.resolve(null);
         }
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           const signalListenerCleanup = signal ? util2.addAbortListener(signal, () => {
             this.destroy();
           }) : noop2;
@@ -9420,7 +9420,7 @@ var require_readable = __commonJS({
             if (signal && signal.aborted) {
               reject(signal.reason || Object.assign(new Error("The operation was aborted"), { name: "AbortError" }));
             } else {
-              resolve6(null);
+              resolve7(null);
             }
           }).on("error", noop2).on("data", function(chunk) {
             limit -= chunk.length;
@@ -9442,11 +9442,11 @@ var require_readable = __commonJS({
         throw new TypeError("unusable");
       }
       assert(!stream[kConsume]);
-      return new Promise((resolve6, reject) => {
+      return new Promise((resolve7, reject) => {
         stream[kConsume] = {
           type,
           stream,
-          resolve: resolve6,
+          resolve: resolve7,
           reject,
           length: 0,
           body: []
@@ -9481,12 +9481,12 @@ var require_readable = __commonJS({
       }
     }
     function consumeEnd(consume2) {
-      const { type, body, resolve: resolve6, stream, length } = consume2;
+      const { type, body, resolve: resolve7, stream, length } = consume2;
       try {
         if (type === "text") {
-          resolve6(toUSVString(Buffer.concat(body)));
+          resolve7(toUSVString(Buffer.concat(body)));
         } else if (type === "json") {
-          resolve6(JSON.parse(Buffer.concat(body)));
+          resolve7(JSON.parse(Buffer.concat(body)));
         } else if (type === "arrayBuffer") {
           const dst = new Uint8Array(length);
           let pos = 0;
@@ -9494,12 +9494,12 @@ var require_readable = __commonJS({
             dst.set(buf, pos);
             pos += buf.byteLength;
           }
-          resolve6(dst.buffer);
+          resolve7(dst.buffer);
         } else if (type === "blob") {
           if (!Blob2) {
             Blob2 = __require("buffer").Blob;
           }
-          resolve6(new Blob2(body, { type: stream[kContentType] }));
+          resolve7(new Blob2(body, { type: stream[kContentType] }));
         }
         consumeFinish(consume2);
       } catch (err) {
@@ -9759,9 +9759,9 @@ var require_api_request = __commonJS({
     };
     function request2(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           request2.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -9935,9 +9935,9 @@ var require_api_stream = __commonJS({
     };
     function stream(opts, factory, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           stream.call(this, opts, factory, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -10220,9 +10220,9 @@ var require_api_upgrade = __commonJS({
     };
     function upgrade(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           upgrade.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -10312,9 +10312,9 @@ var require_api_connect = __commonJS({
     };
     function connect(opts, callback2) {
       if (callback2 === void 0) {
-        return new Promise((resolve6, reject) => {
+        return new Promise((resolve7, reject) => {
           connect.call(this, opts, (err, data) => {
-            return err ? reject(err) : resolve6(data);
+            return err ? reject(err) : resolve7(data);
           });
         });
       }
@@ -10478,20 +10478,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path4) {
-      if (typeof path4 !== "string") {
-        return path4;
+    function safeUrl(path3) {
+      if (typeof path3 !== "string") {
+        return path3;
       }
-      const pathSegments = path4.split("?");
+      const pathSegments = path3.split("?");
       if (pathSegments.length !== 2) {
-        return path4;
+        return path3;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path4, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path4);
+    function matchKey(mockDispatch2, { path: path3, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path3);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10509,7 +10509,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path4 }) => matchValue(safeUrl(path4), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path3 }) => matchValue(safeUrl(path3), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10546,9 +10546,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path4, method, body, headers, query } = opts;
+      const { path: path3, method, body, headers, query } = opts;
       return {
-        path: path4,
+        path: path3,
         method,
         body,
         headers,
@@ -11002,10 +11002,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path4, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path3, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path4,
+            Path: path3,
             "Status code": statusCode,
             Persistent: persist ? "\u2705" : "\u274C",
             Invocations: timesInvoked,
@@ -13955,7 +13955,7 @@ var require_fetch = __commonJS({
       async function dispatch({ body }) {
         const url = requestCurrentURL(request2);
         const agent = fetchParams.controller.dispatcher;
-        return new Promise((resolve6, reject) => agent.dispatch(
+        return new Promise((resolve7, reject) => agent.dispatch(
           {
             path: url.pathname + url.search,
             origin: url.origin,
@@ -14031,7 +14031,7 @@ var require_fetch = __commonJS({
                   }
                 }
               }
-              resolve6({
+              resolve7({
                 status,
                 statusText,
                 headersList: headers[kHeadersList],
@@ -14074,7 +14074,7 @@ var require_fetch = __commonJS({
                 const val = headersList[n + 1].toString("latin1");
                 headers[kHeadersList].append(key, val);
               }
-              resolve6({
+              resolve7({
                 status,
                 statusText: STATUS_CODES[status],
                 headersList: headers[kHeadersList],
@@ -15646,8 +15646,8 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path4) {
-      for (const char of path4) {
+    function validateCookiePath(path3) {
+      for (const char of path3) {
         const code = char.charCodeAt(0);
         if (code < 33 || char === ";") {
           throw new Error("Invalid cookie path");
@@ -17338,11 +17338,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path4 = opts.path;
+          let path3 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path4 = `/${path4}`;
+            path3 = `/${path3}`;
           }
-          url = new URL(util2.parseOrigin(url).origin + path4);
+          url = new URL(util2.parseOrigin(url).origin + path3);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -17451,11 +17451,11 @@ var require_lib = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -17471,7 +17471,7 @@ var require_lib = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -17557,26 +17557,26 @@ var require_lib = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve6(output.toString());
+              resolve7(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve6(Buffer.concat(chunks));
+              resolve7(Buffer.concat(chunks));
             });
           }));
         });
@@ -17785,14 +17785,14 @@ var require_lib = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve6(res);
+                resolve7(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -17974,12 +17974,12 @@ var require_lib = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
+          return new Promise((resolve7) => setTimeout(() => resolve7(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -17987,7 +17987,7 @@ var require_lib = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve6(response);
+              resolve7(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -18026,7 +18026,7 @@ var require_lib = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve6(response);
+              resolve7(response);
             }
           }));
         });
@@ -18044,11 +18044,11 @@ var require_auth = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18064,7 +18064,7 @@ var require_auth = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18149,11 +18149,11 @@ var require_oidc_utils = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18169,7 +18169,7 @@ var require_oidc_utils = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18248,11 +18248,11 @@ var require_summary = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18268,7 +18268,7 @@ var require_summary = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18570,7 +18570,7 @@ var require_path_utils = __commonJS({
     };
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-    var path4 = __importStar(__require("path"));
+    var path3 = __importStar(__require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -18580,7 +18580,7 @@ var require_path_utils = __commonJS({
     }
     exports.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path4.sep);
+      return pth.replace(/[/\\]/g, path3.sep);
     }
     exports.toPlatformPath = toPlatformPath;
   }
@@ -18616,11 +18616,11 @@ var require_io_util = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18636,7 +18636,7 @@ var require_io_util = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18644,12 +18644,12 @@ var require_io_util = __commonJS({
     var _a;
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
-    var fs4 = __importStar(__require("fs"));
-    var path4 = __importStar(__require("path"));
-    _a = fs4.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
+    var fs2 = __importStar(__require("fs"));
+    var path3 = __importStar(__require("path"));
+    _a = fs2.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
     exports.IS_WINDOWS = process.platform === "win32";
     exports.UV_FS_O_EXLOCK = 268435456;
-    exports.READONLY = fs4.constants.O_RDONLY;
+    exports.READONLY = fs2.constants.O_RDONLY;
     function exists(fsPath) {
       return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -18694,7 +18694,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports.IS_WINDOWS) {
-            const upperExt = path4.extname(filePath).toUpperCase();
+            const upperExt = path3.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -18718,11 +18718,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports.IS_WINDOWS) {
               try {
-                const directory = path4.dirname(filePath);
-                const upperName = path4.basename(filePath).toUpperCase();
+                const directory = path3.dirname(filePath);
+                const upperName = path3.basename(filePath).toUpperCase();
                 for (const actualName of yield exports.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path4.join(directory, actualName);
+                    filePath = path3.join(directory, actualName);
                     break;
                   }
                 }
@@ -18790,11 +18790,11 @@ var require_io = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -18810,7 +18810,7 @@ var require_io = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -18818,7 +18818,7 @@ var require_io = __commonJS({
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
     var assert_1 = __require("assert");
-    var path4 = __importStar(__require("path"));
+    var path3 = __importStar(__require("path"));
     var ioUtil = __importStar(require_io_util());
     function cp(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
@@ -18827,7 +18827,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path4.join(dest, path4.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path3.join(dest, path3.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -18839,7 +18839,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path4.relative(source, newDest) === "") {
+          if (path3.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile(source, newDest, force);
@@ -18852,7 +18852,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path4.join(dest, path4.basename(source));
+            dest = path3.join(dest, path3.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -18863,7 +18863,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path4.dirname(dest));
+        yield mkdirP(path3.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -18926,7 +18926,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path4.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path3.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -18939,12 +18939,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path4.sep)) {
+        if (tool.includes(path3.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path4.delimiter)) {
+          for (const p of process.env.PATH.split(path3.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -18952,7 +18952,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path4.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path3.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -19039,11 +19039,11 @@ var require_toolrunner = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19059,7 +19059,7 @@ var require_toolrunner = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19069,7 +19069,7 @@ var require_toolrunner = __commonJS({
     var os3 = __importStar(__require("os"));
     var events = __importStar(__require("events"));
     var child = __importStar(__require("child_process"));
-    var path4 = __importStar(__require("path"));
+    var path3 = __importStar(__require("path"));
     var io = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = __require("timers");
@@ -19284,10 +19284,10 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path4.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io.which(this.toolPath, true);
-          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
             this._debug(`exec tool: ${this.toolPath}`);
             this._debug("arguments:");
             for (const arg of this.args) {
@@ -19370,7 +19370,7 @@ var require_toolrunner = __commonJS({
               if (error2) {
                 reject(error2);
               } else {
-                resolve6(exitCode);
+                resolve7(exitCode);
               }
             });
             if (this.options.input) {
@@ -19524,11 +19524,11 @@ var require_exec = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19544,7 +19544,7 @@ var require_exec = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19636,11 +19636,11 @@ var require_platform = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19656,7 +19656,7 @@ var require_platform = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19756,11 +19756,11 @@ var require_core = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -19776,7 +19776,7 @@ var require_core = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -19787,7 +19787,7 @@ var require_core = __commonJS({
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os3 = __importStar(__require("os"));
-    var path4 = __importStar(__require("path"));
+    var path3 = __importStar(__require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -19815,7 +19815,7 @@ var require_core = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path4.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path3.delimiter}${process.env["PATH"]}`;
     }
     exports.addPath = addPath;
     function getInput2(name, options) {
@@ -22006,17 +22006,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path4) {
-      const ctrl = callVisitor(key, node, visitor, path4);
+    function visit_(key, node, visitor, path3) {
+      const ctrl = callVisitor(key, node, visitor, path3);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path4, ctrl);
-        return visit_(key, ctrl, visitor, path4);
+        replaceNode(key, path3, ctrl);
+        return visit_(key, ctrl, visitor, path3);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path4 = Object.freeze(path4.concat(node));
+          path3 = Object.freeze(path3.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path4);
+            const ci = visit_(i, node.items[i], visitor, path3);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22027,13 +22027,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path4 = Object.freeze(path4.concat(node));
-          const ck = visit_("key", node.key, visitor, path4);
+          path3 = Object.freeze(path3.concat(node));
+          const ck = visit_("key", node.key, visitor, path3);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path4);
+          const cv = visit_("value", node.value, visitor, path3);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22054,17 +22054,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path4) {
-      const ctrl = await callVisitor(key, node, visitor, path4);
+    async function visitAsync_(key, node, visitor, path3) {
+      const ctrl = await callVisitor(key, node, visitor, path3);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path4, ctrl);
-        return visitAsync_(key, ctrl, visitor, path4);
+        replaceNode(key, path3, ctrl);
+        return visitAsync_(key, ctrl, visitor, path3);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path4 = Object.freeze(path4.concat(node));
+          path3 = Object.freeze(path3.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path4);
+            const ci = await visitAsync_(i, node.items[i], visitor, path3);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22075,13 +22075,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path4 = Object.freeze(path4.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path4);
+          path3 = Object.freeze(path3.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path3);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path4);
+          const cv = await visitAsync_("value", node.value, visitor, path3);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22108,23 +22108,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path4) {
+    function callVisitor(key, node, visitor, path3) {
       if (typeof visitor === "function")
-        return visitor(key, node, path4);
+        return visitor(key, node, path3);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path4);
+        return visitor.Map?.(key, node, path3);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path4);
+        return visitor.Seq?.(key, node, path3);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path4);
+        return visitor.Pair?.(key, node, path3);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path4);
+        return visitor.Scalar?.(key, node, path3);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path4);
+        return visitor.Alias?.(key, node, path3);
       return void 0;
     }
-    function replaceNode(key, path4, node) {
-      const parent = path4[path4.length - 1];
+    function replaceNode(key, path3, node) {
+      const parent = path3[path3.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -22741,10 +22741,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path4, value) {
+    function collectionFromPath(schema, path3, value) {
       let v = value;
-      for (let i = path4.length - 1; i >= 0; --i) {
-        const k = path4[i];
+      for (let i = path3.length - 1; i >= 0; --i) {
+        const k = path3[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -22763,7 +22763,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path4) => path4 == null || typeof path4 === "object" && !!path4[Symbol.iterator]().next().done;
+    var isEmptyPath = (path3) => path3 == null || typeof path3 === "object" && !!path3[Symbol.iterator]().next().done;
     var Collection2 = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -22793,11 +22793,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path4, value) {
-        if (isEmptyPath(path4))
+      addIn(path3, value) {
+        if (isEmptyPath(path3))
           this.add(value);
         else {
-          const [key, ...rest] = path4;
+          const [key, ...rest] = path3;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -22811,8 +22811,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path4) {
-        const [key, ...rest] = path4;
+      deleteIn(path3) {
+        const [key, ...rest] = path3;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -22826,8 +22826,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path4, keepScalar) {
-        const [key, ...rest] = path4;
+      getIn(path3, keepScalar) {
+        const [key, ...rest] = path3;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -22845,8 +22845,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path4) {
-        const [key, ...rest] = path4;
+      hasIn(path3) {
+        const [key, ...rest] = path3;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -22856,8 +22856,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path4, value) {
-        const [key, ...rest] = path4;
+      setIn(path3, value) {
+        const [key, ...rest] = path3;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -25396,9 +25396,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path4, value) {
+      addIn(path3, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path4, value);
+          this.contents.addIn(path3, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -25473,14 +25473,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path4) {
-        if (Collection2.isEmptyPath(path4)) {
+      deleteIn(path3) {
+        if (Collection2.isEmptyPath(path3)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path4) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path3) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -25495,10 +25495,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path4, keepScalar) {
-        if (Collection2.isEmptyPath(path4))
+      getIn(path3, keepScalar) {
+        if (Collection2.isEmptyPath(path3))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path4, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path3, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -25509,10 +25509,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path4) {
-        if (Collection2.isEmptyPath(path4))
+      hasIn(path3) {
+        if (Collection2.isEmptyPath(path3))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path4) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path3) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -25529,13 +25529,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path4, value) {
-        if (Collection2.isEmptyPath(path4)) {
+      setIn(path3, value) {
+        if (Collection2.isEmptyPath(path3)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path4), value);
+          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path3), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path4, value);
+          this.contents.setIn(path3, value);
         }
       }
       /**
@@ -27507,9 +27507,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path4) => {
+    visit.itemAtPath = (cst, path3) => {
       let item = cst;
-      for (const [field, index] of path4) {
+      for (const [field, index] of path3) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -27518,23 +27518,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path4) => {
-      const parent = visit.itemAtPath(cst, path4.slice(0, -1));
-      const field = path4[path4.length - 1][0];
+    visit.parentCollection = (cst, path3) => {
+      const parent = visit.itemAtPath(cst, path3.slice(0, -1));
+      const field = path3[path3.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path4, item, visitor) {
-      let ctrl = visitor(item, path4);
+    function _visit(path3, item, visitor) {
+      let ctrl = visitor(item, path3);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path4.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path3.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -27545,10 +27545,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path4);
+            ctrl = ctrl(item, path3);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path4) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path3) : ctrl;
     }
     exports.visit = visit;
   }
@@ -28837,14 +28837,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs4 = this.flowScalar(this.type);
+              const fs2 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs4, sep: [] });
+                map.items.push({ start, key: fs2, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs4);
+                this.stack.push(fs2);
               } else {
-                Object.assign(it, { key: fs4, sep: [] });
+                Object.assign(it, { key: fs2, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -28972,13 +28972,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs4 = this.flowScalar(this.type);
+              const fs2 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs4, sep: [] });
+                fc.items.push({ start: [], key: fs2, sep: [] });
               else if (it.sep)
-                this.stack.push(fs4);
+                this.stack.push(fs2);
               else
-                Object.assign(it, { key: fs4, sep: [] });
+                Object.assign(it, { key: fs2, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -29696,8 +29696,8 @@ var require_utils3 = __commonJS({
       }
       return output;
     };
-    exports.basename = (path4, { windows } = {}) => {
-      const segs = path4.split(windows ? /[\\/]/ : "/");
+    exports.basename = (path3, { windows } = {}) => {
+      const segs = path3.split(windows ? /[\\/]/ : "/");
       const last = segs[segs.length - 1];
       if (last === "") {
         return segs[segs.length - 2];
@@ -31634,8 +31634,8 @@ ${val.stack}`;
     module.exports.__wbindgen_throw = function(arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     };
-    var path4 = __require("path").join(__dirname, "core_bg.wasm");
-    var bytes = __require("fs").readFileSync(path4);
+    var path3 = __require("path").join(__dirname, "core_bg.wasm");
+    var bytes = __require("fs").readFileSync(path3);
     var wasmModule = new WebAssembly.Module(bytes);
     var wasmInstance = new WebAssembly.Instance(wasmModule, imports);
     wasm = wasmInstance.exports;
@@ -31855,11 +31855,11 @@ var require_core3 = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -31875,7 +31875,7 @@ var require_core3 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32049,11 +32049,11 @@ var require_secrets = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32069,7 +32069,7 @@ var require_secrets = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32180,11 +32180,11 @@ var require_items_shares = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32200,7 +32200,7 @@ var require_items_shares = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32299,11 +32299,11 @@ var require_items_files = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32319,7 +32319,7 @@ var require_items_files = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32439,11 +32439,11 @@ var require_items = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32459,7 +32459,7 @@ var require_items = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32679,11 +32679,11 @@ var require_vaults = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32699,7 +32699,7 @@ var require_vaults = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -32912,11 +32912,11 @@ var require_groups = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -32932,7 +32932,7 @@ var require_groups = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33050,11 +33050,11 @@ var require_shared_lib_core = __commonJS({
     })();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33070,26 +33070,26 @@ var require_shared_lib_core = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
     };
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.SharedLibCore = void 0;
-    var fs4 = __importStar(__require("fs"));
+    var fs2 = __importStar(__require("fs"));
     var os3 = __importStar(__require("os"));
-    var path4 = __importStar(__require("path"));
+    var path3 = __importStar(__require("path"));
     var errors_1 = require_errors3();
     var find1PasswordLibPath = () => {
       const platform = os3.platform();
-      const appRoot = path4.dirname(process.execPath);
+      const appRoot = path3.dirname(process.execPath);
       let searchPaths = [];
       switch (platform) {
         case "darwin":
           searchPaths = [
             "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib",
-            path4.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
+            path3.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
           ];
           break;
         case "linux":
@@ -33101,17 +33101,17 @@ var require_shared_lib_core = __commonJS({
           break;
         case "win32":
           searchPaths = [
-            path4.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
+            path3.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
             "C:/Program Files/1Password/app/8/op_sdk_ipc_client.dll",
             "C:/Program Files (x86)/1Password/app/8/op_sdk_ipc_client.dll",
-            path4.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
+            path3.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
           ];
           break;
         default:
           throw new Error(`Unsupported platform: ${platform}`);
       }
       for (const addonPath of searchPaths) {
-        if (fs4.existsSync(addonPath)) {
+        if (fs2.existsSync(addonPath)) {
           return addonPath;
         }
       }
@@ -33196,11 +33196,11 @@ var require_client_builder = __commonJS({
     init_esm_shims();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33216,7 +33216,7 @@ var require_client_builder = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33268,11 +33268,11 @@ var require_sdk = __commonJS({
     };
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33288,7 +33288,7 @@ var require_sdk = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33337,8 +33337,8 @@ var require_context = __commonJS({
           if ((0, fs_1.existsSync)(process.env.GITHUB_EVENT_PATH)) {
             this.payload = JSON.parse((0, fs_1.readFileSync)(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
           } else {
-            const path4 = process.env.GITHUB_EVENT_PATH;
-            process.stdout.write(`GITHUB_EVENT_PATH ${path4} does not exist${os_1.EOL}`);
+            const path3 = process.env.GITHUB_EVENT_PATH;
+            process.stdout.write(`GITHUB_EVENT_PATH ${path3} does not exist${os_1.EOL}`);
           }
         }
         this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -33503,11 +33503,11 @@ var require_lib2 = __commonJS({
     })();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -33523,7 +33523,7 @@ var require_lib2 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -33610,26 +33610,26 @@ var require_lib2 = __commonJS({
       }
       readBody() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             let output = Buffer.alloc(0);
             this.message.on("data", (chunk) => {
               output = Buffer.concat([output, chunk]);
             });
             this.message.on("end", () => {
-              resolve6(output.toString());
+              resolve7(output.toString());
             });
           }));
         });
       }
       readBodyBuffer() {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7) => __awaiter(this, void 0, void 0, function* () {
             const chunks = [];
             this.message.on("data", (chunk) => {
               chunks.push(chunk);
             });
             this.message.on("end", () => {
-              resolve6(Buffer.concat(chunks));
+              resolve7(Buffer.concat(chunks));
             });
           }));
         });
@@ -33837,14 +33837,14 @@ var require_lib2 = __commonJS({
        */
       requestRaw(info2, data) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => {
+          return new Promise((resolve7, reject) => {
             function callbackForResult(err, res) {
               if (err) {
                 reject(err);
               } else if (!res) {
                 reject(new Error("Unknown error"));
               } else {
-                resolve6(res);
+                resolve7(res);
               }
             }
             this.requestRawWithCallback(info2, data, callbackForResult);
@@ -34088,12 +34088,12 @@ var require_lib2 = __commonJS({
         return __awaiter(this, void 0, void 0, function* () {
           retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
           const ms2 = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-          return new Promise((resolve6) => setTimeout(() => resolve6(), ms2));
+          return new Promise((resolve7) => setTimeout(() => resolve7(), ms2));
         });
       }
       _processResponse(res, options) {
         return __awaiter(this, void 0, void 0, function* () {
-          return new Promise((resolve6, reject) => __awaiter(this, void 0, void 0, function* () {
+          return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
             const statusCode = res.message.statusCode || 0;
             const response = {
               statusCode,
@@ -34101,7 +34101,7 @@ var require_lib2 = __commonJS({
               headers: {}
             };
             if (statusCode === HttpCodes.NotFound) {
-              resolve6(response);
+              resolve7(response);
             }
             function dateTimeDeserializer(key, value) {
               if (typeof value === "string") {
@@ -34140,7 +34140,7 @@ var require_lib2 = __commonJS({
               err.result = response.result;
               reject(err);
             } else {
-              resolve6(response);
+              resolve7(response);
             }
           }));
         });
@@ -34195,11 +34195,11 @@ var require_utils4 = __commonJS({
     })();
     var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
       function adopt(value) {
-        return value instanceof P ? value : new P(function(resolve6) {
-          resolve6(value);
+        return value instanceof P ? value : new P(function(resolve7) {
+          resolve7(value);
         });
       }
-      return new (P || (P = Promise))(function(resolve6, reject) {
+      return new (P || (P = Promise))(function(resolve7, reject) {
         function fulfilled(value) {
           try {
             step(generator.next(value));
@@ -34215,7 +34215,7 @@ var require_utils4 = __commonJS({
           }
         }
         function step(result) {
-          result.done ? resolve6(result.value) : adopt(result.value).then(fulfilled, rejected);
+          result.done ? resolve7(result.value) : adopt(result.value).then(fulfilled, rejected);
         }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
       });
@@ -38278,7 +38278,7 @@ var require_github = __commonJS({
 // src/index.ts
 init_esm_shims();
 var core = __toESM(require_core(), 1);
-import { resolve as resolve5 } from "path";
+import { resolve as resolve6 } from "path";
 
 // ../core/dist/index.js
 init_esm_shims();
@@ -38286,8 +38286,8 @@ import * as fs from "fs";
 import { readFileSync as readFileSync3, mkdirSync as mkdirSync2, writeFileSync as writeFileSync2 } from "fs";
 var import_semver = __toESM(require_semver2(), 1);
 var import_yaml = __toESM(require_dist(), 1);
-import * as path3 from "path";
-import { join as join4, dirname as dirname4 } from "path";
+import * as path4 from "path";
+import { join as join4, dirname as dirname4, relative as relative3, resolve as resolve5 } from "path";
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/index.js
 init_esm_shims();
@@ -38782,8 +38782,8 @@ function getErrorMap() {
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js
 init_esm_shims();
 var makeIssue = (params) => {
-  const { data, path: path4, errorMaps, issueData } = params;
-  const fullPath = [...path4, ...issueData.path || []];
+  const { data, path: path3, errorMaps, issueData } = params;
+  const fullPath = [...path3, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -38903,11 +38903,11 @@ var errorUtil;
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path4, key) {
+  constructor(parent, value, path3, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path4;
+    this._path = path3;
     this._key = key;
   }
   get path() {
@@ -42848,7 +42848,7 @@ var MigrationGraphImpl = class {
         hasIrreversibleStep: false
       };
     }
-    const path4 = findPath(
+    const path3 = findPath(
       normalizedFrom,
       normalizedTo,
       this.adjacencyList,
@@ -42856,10 +42856,10 @@ var MigrationGraphImpl = class {
       this.versionStrategy,
       (from, to) => this.getMigrationKey(from, to)
     );
-    if (!path4) {
+    if (!path3) {
       throw new NoPathError(fromVersion, toVersion);
     }
-    return path4;
+    return path3;
   }
   migrate(data, fromVersion, toVersion, options = {}) {
     const startTime = performance.now();
@@ -42888,12 +42888,12 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path4;
+    let path3;
     try {
       const pathStartTime = performance.now();
-      path4 = this.getPath(normalizedFrom, normalizedTo);
+      path3 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path4, pathDuration);
+      this.telemetry?.onPathComputed?.(path3, pathDuration);
     } catch (err) {
       return {
         success: false,
@@ -42903,27 +42903,27 @@ var MigrationGraphImpl = class {
         error: err
       };
     }
-    if (path4.steps.length === 0) {
+    if (path3.steps.length === 0) {
       return {
         success: true,
         data,
-        path: path4,
+        path: path3,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
     }
-    const context = createMigrationContext(path4.steps.length, options.initialStash);
+    const context = createMigrationContext(path3.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path4.steps.length; i++) {
-      const step = path4.steps[i];
+    for (let i = 0; i < path3.steps.length; i++) {
+      const step = path3.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path4.steps.length
+        totalSteps: path3.steps.length
       });
-      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
       const stepStartTime = performance.now();
       try {
         if (step.direction === "up") {
@@ -42948,20 +42948,20 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, step, context);
         return {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: error2
         };
       }
-      if (options.validateIntermediate && i < path4.steps.length - 1) {
+      if (options.validateIntermediate && i < path3.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             return {
               success: false,
-              path: path4,
+              path: path3,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -42985,7 +42985,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, null, context);
         const result2 = {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43005,7 +43005,7 @@ var MigrationGraphImpl = class {
           this.telemetry?.onError?.(error2, null, context);
           const result2 = {
             success: false,
-            path: path4,
+            path: path3,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43021,7 +43021,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path4,
+      path: path3,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43053,11 +43053,11 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path4;
+    let path3;
     try {
       const pathStartTime = performance.now();
-      path4 = this.getPath(normalizedFrom, normalizedTo);
-      this.telemetry?.onPathComputed?.(path4, performance.now() - pathStartTime);
+      path3 = this.getPath(normalizedFrom, normalizedTo);
+      this.telemetry?.onPathComputed?.(path3, performance.now() - pathStartTime);
     } catch (err) {
       const result2 = {
         success: false,
@@ -43069,30 +43069,30 @@ var MigrationGraphImpl = class {
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    if (path4.steps.length === 0) {
+    if (path3.steps.length === 0) {
       const result2 = {
         success: true,
         data,
-        path: path4,
+        path: path3,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    const context = createMigrationContext(path4.steps.length, options.initialStash);
+    const context = createMigrationContext(path3.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path4.steps.length; i++) {
-      const step = path4.steps[i];
+    for (let i = 0; i < path3.steps.length; i++) {
+      const step = path3.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path4.steps.length
+        totalSteps: path3.steps.length
       });
       const stepStartTime = performance.now();
-      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
       try {
         if (step.direction === "up") {
           const result2 = step.migration.up(currentData, context);
@@ -43107,7 +43107,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(err, step, context);
         const result2 = {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: new MigrationError(
@@ -43123,14 +43123,14 @@ var MigrationGraphImpl = class {
         this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
         return result2;
       }
-      if (options.validateIntermediate && i < path4.steps.length - 1) {
+      if (options.validateIntermediate && i < path3.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             const result2 = {
               success: false,
-              path: path4,
+              path: path3,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -43151,7 +43151,7 @@ var MigrationGraphImpl = class {
       if (!validation.success) {
         const result2 = {
           success: false,
-          path: path4,
+          path: path3,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43168,7 +43168,7 @@ var MigrationGraphImpl = class {
         if (!validation.success) {
           const result2 = {
             success: false,
-            path: path4,
+            path: path3,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43186,7 +43186,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path4,
+      path: path3,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43198,12 +43198,12 @@ var MigrationGraphImpl = class {
   migrateMany(data, fromVersion, toVersion, options = {}) {
     const normalizedFrom = this.normalizeVersion(fromVersion);
     const normalizedTo = this.normalizeVersion(toVersion);
-    let path4;
+    let path3;
     try {
       const pathStartTime = performance.now();
-      path4 = this.getPath(normalizedFrom, normalizedTo);
+      path3 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path4, pathDuration);
+      this.telemetry?.onPathComputed?.(path3, pathDuration);
     } catch {
       return {
         total: 0,
@@ -43229,7 +43229,7 @@ var MigrationGraphImpl = class {
           for (let j = i + 1; j < items.length; j++) {
             results.push({
               success: false,
-              path: path4,
+              path: path3,
               stash: { consumed: [], unconsumed: [], lossless: true },
               preservedFields: [],
               error: new MigrationError(
@@ -43250,7 +43250,7 @@ var MigrationGraphImpl = class {
       succeeded,
       failed,
       results,
-      path: path4
+      path: path3
     };
   }
   getVersions() {
@@ -43330,8 +43330,8 @@ function createMigrationGraph(options) {
 
 // ../../node_modules/.pnpm/@migrex+zod@1.0.0-alpha.1_@migrex+core@0.2.0-alpha.1_zod@3.25.76/node_modules/@migrex/zod/dist/index.js
 init_esm_shims();
-function pathToStringArray(path4) {
-  return path4.map((p) => String(p));
+function pathToStringArray(path3) {
+  return path3.map((p) => String(p));
 }
 function zodErrorToValidationErrors(error2) {
   return error2.issues.map((issue) => ({
@@ -43363,7 +43363,7 @@ function fromZod(version2, zodSchema, options) {
 }
 
 // ../core/dist/index.js
-import * as fs2 from "fs/promises";
+import * as fs32 from "fs/promises";
 import { readFile as readFile3, mkdir as mkdir3, writeFile as writeFile3, stat as stat2 } from "fs/promises";
 import * as crypto22 from "crypto";
 
@@ -43379,27 +43379,27 @@ import { createRequire } from "module";
 import { basename, dirname, normalize, relative, resolve, sep } from "path";
 import * as nativeFs from "fs";
 var __require2 = /* @__PURE__ */ createRequire(import.meta.url);
-function cleanPath(path4) {
-  let normalized = normalize(path4);
+function cleanPath(path3) {
+  let normalized = normalize(path3);
   if (normalized.length > 1 && normalized[normalized.length - 1] === sep) normalized = normalized.substring(0, normalized.length - 1);
   return normalized;
 }
 var SLASHES_REGEX = /[\\/]/g;
-function convertSlashes(path4, separator) {
-  return path4.replace(SLASHES_REGEX, separator);
+function convertSlashes(path3, separator) {
+  return path3.replace(SLASHES_REGEX, separator);
 }
 var WINDOWS_ROOT_DIR_REGEX = /^[a-z]:[\\/]$/i;
-function isRootDirectory(path4) {
-  return path4 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path4);
+function isRootDirectory(path3) {
+  return path3 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path3);
 }
-function normalizePath(path4, options) {
+function normalizePath(path3, options) {
   const { resolvePaths, normalizePath: normalizePath$1, pathSeparator } = options;
-  const pathNeedsCleaning = process.platform === "win32" && path4.includes("/") || path4.startsWith(".");
-  if (resolvePaths) path4 = resolve(path4);
-  if (normalizePath$1 || pathNeedsCleaning) path4 = cleanPath(path4);
-  if (path4 === ".") return "";
-  const needsSeperator = path4[path4.length - 1] !== pathSeparator;
-  return convertSlashes(needsSeperator ? path4 + pathSeparator : path4, pathSeparator);
+  const pathNeedsCleaning = process.platform === "win32" && path3.includes("/") || path3.startsWith(".");
+  if (resolvePaths) path3 = resolve(path3);
+  if (normalizePath$1 || pathNeedsCleaning) path3 = cleanPath(path3);
+  if (path3 === ".") return "";
+  const needsSeperator = path3[path3.length - 1] !== pathSeparator;
+  return convertSlashes(needsSeperator ? path3 + pathSeparator : path3, pathSeparator);
 }
 function joinPathWithBasePath(filename, directoryPath) {
   return directoryPath + filename;
@@ -43436,8 +43436,8 @@ var pushDirectory = (directoryPath, paths) => {
   paths.push(directoryPath || ".");
 };
 var pushDirectoryFilter = (directoryPath, paths, filters) => {
-  const path4 = directoryPath || ".";
-  if (filters.every((filter) => filter(path4, true))) paths.push(path4);
+  const path3 = directoryPath || ".";
+  if (filters.every((filter) => filter(path3, true))) paths.push(path3);
 };
 var empty$2 = () => {
 };
@@ -43489,26 +43489,26 @@ var empty = () => {
 function build$3(options) {
   return options.group ? groupFiles : empty;
 }
-var resolveSymlinksAsync = function(path4, state, callback$1) {
-  const { queue, fs: fs4, options: { suppressErrors } } = state;
+var resolveSymlinksAsync = function(path3, state, callback$1) {
+  const { queue, fs: fs2, options: { suppressErrors } } = state;
   queue.enqueue();
-  fs4.realpath(path4, (error2, resolvedPath) => {
+  fs2.realpath(path3, (error2, resolvedPath) => {
     if (error2) return queue.dequeue(suppressErrors ? null : error2, state);
-    fs4.stat(resolvedPath, (error$1, stat3) => {
+    fs2.stat(resolvedPath, (error$1, stat3) => {
       if (error$1) return queue.dequeue(suppressErrors ? null : error$1, state);
-      if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return queue.dequeue(null, state);
+      if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return queue.dequeue(null, state);
       callback$1(stat3, resolvedPath);
       queue.dequeue(null, state);
     });
   });
 };
-var resolveSymlinks = function(path4, state, callback$1) {
-  const { queue, fs: fs4, options: { suppressErrors } } = state;
+var resolveSymlinks = function(path3, state, callback$1) {
+  const { queue, fs: fs2, options: { suppressErrors } } = state;
   queue.enqueue();
   try {
-    const resolvedPath = fs4.realpathSync(path4);
-    const stat3 = fs4.statSync(resolvedPath);
-    if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return;
+    const resolvedPath = fs2.realpathSync(path3);
+    const stat3 = fs2.statSync(resolvedPath);
+    if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return;
     callback$1(stat3, resolvedPath);
   } catch (e) {
     if (!suppressErrors) throw e;
@@ -43518,9 +43518,9 @@ function build$2(options, isSynchronous) {
   if (!options.resolveSymlinks || options.excludeSymlinks) return null;
   return isSynchronous ? resolveSymlinks : resolveSymlinksAsync;
 }
-function isRecursive(path4, resolved, state) {
+function isRecursive(path3, resolved, state) {
   if (state.options.useRealPaths) return isRecursiveUsingRealPaths(resolved, state);
-  let parent = dirname(path4);
+  let parent = dirname(path3);
   let depth = 1;
   while (parent !== state.root && depth < 2) {
     const resolvedPath = state.symlinks.get(parent);
@@ -43528,7 +43528,7 @@ function isRecursive(path4, resolved, state) {
     if (isSameRoot) depth++;
     else parent = dirname(parent);
   }
-  state.symlinks.set(path4, resolved);
+  state.symlinks.set(path3, resolved);
   return depth > 1;
 }
 function isRecursiveUsingRealPaths(resolved, state) {
@@ -43577,22 +43577,22 @@ var readdirOpts = { withFileTypes: true };
 var walkAsync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
   state.queue.enqueue();
   if (currentDepth < 0) return state.queue.dequeue(null, state);
-  const { fs: fs4 } = state;
+  const { fs: fs2 } = state;
   state.visited.push(crawlPath);
   state.counts.directories++;
-  fs4.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
+  fs2.readdir(crawlPath || ".", readdirOpts, (error2, entries = []) => {
     callback$1(entries, directoryPath, currentDepth);
     state.queue.dequeue(state.options.suppressErrors ? null : error2, state);
   });
 };
 var walkSync = (state, crawlPath, directoryPath, currentDepth, callback$1) => {
-  const { fs: fs4 } = state;
+  const { fs: fs2 } = state;
   if (currentDepth < 0) return;
   state.visited.push(crawlPath);
   state.counts.directories++;
   let entries = [];
   try {
-    entries = fs4.readdirSync(crawlPath || ".", readdirOpts);
+    entries = fs2.readdirSync(crawlPath || ".", readdirOpts);
   } catch (e) {
     if (!state.options.suppressErrors) throw e;
   }
@@ -43700,19 +43700,19 @@ var Walker = class {
         const filename = this.joinPath(entry.name, directoryPath);
         this.pushFile(filename, files, this.state.counts, filters);
       } else if (entry.isDirectory()) {
-        let path4 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
-        if (exclude && exclude(entry.name, path4)) continue;
-        this.pushDirectory(path4, paths, filters);
-        this.walkDirectory(this.state, path4, path4, depth - 1, this.walk);
+        let path3 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
+        if (exclude && exclude(entry.name, path3)) continue;
+        this.pushDirectory(path3, paths, filters);
+        this.walkDirectory(this.state, path3, path3, depth - 1, this.walk);
       } else if (this.resolveSymlink && entry.isSymbolicLink()) {
-        let path4 = joinPathWithBasePath(entry.name, directoryPath);
-        this.resolveSymlink(path4, this.state, (stat3, resolvedPath) => {
+        let path3 = joinPathWithBasePath(entry.name, directoryPath);
+        this.resolveSymlink(path3, this.state, (stat3, resolvedPath) => {
           if (stat3.isDirectory()) {
             resolvedPath = normalizePath(resolvedPath, this.state.options);
-            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path4 + pathSeparator)) return;
-            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path4 + pathSeparator, depth - 1, this.walk);
+            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path3 + pathSeparator)) return;
+            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path3 + pathSeparator, depth - 1, this.walk);
           } else {
-            resolvedPath = useRealPaths ? resolvedPath : path4;
+            resolvedPath = useRealPaths ? resolvedPath : path3;
             const filename = basename(resolvedPath);
             const directoryPath$1 = normalizePath(dirname(resolvedPath), this.state.options);
             resolvedPath = this.joinPath(filename, directoryPath$1);
@@ -43878,7 +43878,7 @@ var Builder = class {
       isMatch = globFn(patterns, ...options);
       this.globCache[patterns.join("\0")] = isMatch;
     }
-    this.options.filters.push((path4) => isMatch(path4));
+    this.options.filters.push((path3) => isMatch(path3));
     return this;
   }
 };
@@ -44037,10 +44037,10 @@ function processPatterns({ patterns = ["**/*"], ignore = [], expandDirectories =
     ignore: ignorePatterns
   };
 }
-function formatPaths(paths, relative3) {
+function formatPaths(paths, relative4) {
   for (let i = paths.length - 1; i >= 0; i--) {
     const path$1 = paths[i];
-    paths[i] = relative3(path$1);
+    paths[i] = relative4(path$1);
   }
   return paths;
 }
@@ -44137,17 +44137,17 @@ function getCrawler(patterns, inputOptions = {}) {
   props.root = props.root.replace(BACKSLASHES, "");
   const root = props.root;
   if (options.debug) log("internal properties:", props);
-  const relative3 = cwd !== root && !options.absolute && buildRelative(cwd, props.root);
-  return [new Builder(fdirOptions).crawl(root), relative3];
+  const relative4 = cwd !== root && !options.absolute && buildRelative(cwd, props.root);
+  return [new Builder(fdirOptions).crawl(root), relative4];
 }
 async function glob(patternsOrOptions, options) {
   if (patternsOrOptions && (options === null || options === void 0 ? void 0 : options.patterns)) throw new Error("Cannot pass patterns as both an argument and an option");
   const isModern = isReadonlyArray(patternsOrOptions) || typeof patternsOrOptions === "string";
   const opts = isModern ? options : patternsOrOptions;
   const patterns = isModern ? patternsOrOptions : patternsOrOptions.patterns;
-  const [crawler, relative3] = getCrawler(patterns, opts);
-  if (!relative3) return crawler.withPromise();
-  return formatPaths(await crawler.withPromise(), relative3);
+  const [crawler, relative4] = getCrawler(patterns, opts);
+  if (!relative4) return crawler.withPromise();
+  return formatPaths(await crawler.withPromise(), relative4);
 }
 
 // ../core/dist/index.js
@@ -46346,6 +46346,7 @@ createMigrationGraph({
   schemas: [schemaV12],
   migrations: []
 });
+var ROOT_GATE_ID = "__root__";
 function versionSchema2(version2) {
   return external_exports.union([external_exports.literal(version2), external_exports.literal(String(version2))]).transform(() => version2);
 }
@@ -46355,14 +46356,29 @@ var policySettingsSchemaV1 = external_exports.object({
   attestationsPath: external_exports.string().default(".attest-it/attestations.json"),
   sealsPath: external_exports.string().default(".attest-it/seals.json")
 }).strict();
-var policySchemaV1 = external_exports.object({
+var rootGateSchemaV1 = external_exports.object({
+  authorizedSigners: external_exports.array(external_exports.string().min(1, "Root-gate signer slug cannot be empty")).min(1, "The root gate requires at least one authorized signer"),
+  maxAge: durationSchema.default("365d"),
+  description: external_exports.string().min(1, "Root gate description cannot be empty").optional()
+}).strict();
+var policyObjectSchemaV1 = external_exports.object({
   version: versionSchema2(1),
   minVersion: semverSchema.optional(),
   settings: policySettingsSchemaV1.default({}),
+  rootGate: rootGateSchemaV1.optional(),
   team: external_exports.record(external_exports.string(), teamMemberSchema).optional(),
   gates: external_exports.record(external_exports.string(), gateSchema).optional()
 }).strict();
-var schemaV13 = fromZod("1", policySchemaV1);
+var policySchemaV1 = policyObjectSchemaV1.superRefine((policy, ctx) => {
+  if (policy.gates && Object.prototype.hasOwnProperty.call(policy.gates, ROOT_GATE_ID)) {
+    ctx.addIssue({
+      code: external_exports.ZodIssueCode.custom,
+      path: ["gates", ROOT_GATE_ID],
+      message: `'${ROOT_GATE_ID}' is a reserved gate id for the root gate and cannot be used as an ordinary gate. Use the top-level 'rootGate' section instead.`
+    });
+  }
+});
+var schemaV13 = fromZod("1", policyObjectSchemaV1);
 createMigrationGraph({
   id: "attest-it-policy",
   versionStrategy: integerStrategy,
@@ -46588,6 +46604,16 @@ function mergeConfigs(policy, operational) {
     settings,
     suites
   };
+  if (policy.rootGate !== void 0) {
+    const rootGate = {
+      authorizedSigners: policy.rootGate.authorizedSigners,
+      maxAge: policy.rootGate.maxAge
+    };
+    if (policy.rootGate.description !== void 0) {
+      rootGate.description = policy.rootGate.description;
+    }
+    config.rootGate = rootGate;
+  }
   if (policy.team !== void 0) {
     const team = {};
     for (const [slug, member] of Object.entries(policy.team)) {
@@ -46808,7 +46834,7 @@ function sortFiles(files) {
   });
 }
 function normalizePath2(filePath) {
-  return filePath.split(path3.sep).join("/");
+  return filePath.split(path4.sep).join("/");
 }
 function computeFinalFingerprint(fileHashes) {
   const sorted = [...fileHashes].sort((a, b) => {
@@ -46823,7 +46849,7 @@ function computeFinalFingerprint(fileHashes) {
 }
 async function hashFileAsync(realPath, normalizedPath, stats) {
   if (stats.size > LARGE_FILE_THRESHOLD) {
-    return new Promise((resolve52, reject) => {
+    return new Promise((resolve62, reject) => {
       const hash2 = crypto22.createHash("sha256");
       hash2.update(normalizedPath);
       hash2.update(":");
@@ -46832,7 +46858,7 @@ async function hashFileAsync(realPath, normalizedPath, stats) {
         hash2.update(chunk);
       });
       stream.on("end", () => {
-        resolve52(hash2.digest());
+        resolve62(hash2.digest());
       });
       stream.on("error", reject);
     });
@@ -46854,7 +46880,7 @@ function validateOptions(options) {
   const baseDir = options.baseDir ?? process.cwd();
   for (const p of options.paths) {
     if (!isGlobPattern(p)) {
-      const resolvedPath = path3.resolve(baseDir, p);
+      const resolvedPath = path4.resolve(baseDir, p);
       if (!fs.existsSync(resolvedPath)) {
         throw new Error(`Path does not exist: ${resolvedPath}`);
       }
@@ -46869,7 +46895,7 @@ async function computeFingerprint(options) {
   const fileHashCache = /* @__PURE__ */ new Map();
   const fileHashInputs = [];
   for (const file of sortedFiles) {
-    const filePath = path3.resolve(baseDir, file);
+    const filePath = path4.resolve(baseDir, file);
     let realPath = filePath;
     let stats = await fs.promises.lstat(filePath);
     if (stats.isSymbolicLink()) {
@@ -46909,7 +46935,7 @@ function resolvePackagePattern(pkg, baseDir) {
   if (isGlobPattern(pkg)) {
     return pkg;
   }
-  const fullPath = path3.resolve(baseDir, pkg);
+  const fullPath = path4.resolve(baseDir, pkg);
   try {
     const stats = fs.statSync(fullPath);
     return stats.isFile() ? pkg : `${pkg}/**/*`;
@@ -46940,17 +46966,10 @@ async function listPackageFiles(packages, ignore = [], baseDir = process.cwd()) 
   }
   return allFiles;
 }
-async function setKeyPermissions(keyPath) {
-  if (process.platform === "win32") {
-    await fs2.chmod(keyPath, 384);
-  } else {
-    await fs2.chmod(keyPath, 384);
-  }
-}
 function isBuffer(value) {
   return Buffer.isBuffer(value);
 }
-function generateKeyPair2(options = {}) {
+function generateKeyPair(options = {}) {
   try {
     const { passphrase } = options;
     const keyPair = passphrase !== void 0 && passphrase.length > 0 ? crypto22.generateKeyPairSync("ed25519", {
@@ -46998,7 +47017,7 @@ function generateKeyPair2(options = {}) {
     );
   }
 }
-function verify3(data, signature, publicKeyBase64) {
+function verify2(data, signature, publicKeyBase64) {
   try {
     const dataBuffer = typeof data === "string" ? Buffer.from(data, "utf8") : data;
     const signatureBuffer = Buffer.from(signature, "base64");
@@ -47042,241 +47061,120 @@ function verify3(data, signature, publicKeyBase64) {
     );
   }
 }
-var VaultKeyProvider = class {
-  type;
-  displayName;
-  backend;
-  /**
-   * Create a new VaultKeyProvider.
-   * @param options - Provider options including the VaultKeeper backend
-   */
-  constructor(options) {
-    this.backend = options.backend;
-    this.type = options.backend.type;
-    this.displayName = options.displayName;
+function isFileNotFoundError(error2) {
+  if (error2 && typeof error2 === "object" && "code" in error2) {
+    const errorWithCode = error2;
+    return errorWithCode.code === "ENOENT" || errorWithCode.code === "ENOTDIR";
   }
-  /**
-   * Check if the underlying VaultKeeper backend is available.
-   */
-  async isAvailable() {
-    return this.backend.isAvailable();
-  }
-  /**
-   * Check if a key exists in the VaultKeeper backend.
-   * @param keyRef - Secret identifier in the backend
-   */
-  async keyExists(keyRef) {
-    return this.backend.exists(keyRef);
-  }
-  /**
-   * Retrieve the private key from VaultKeeper for signing.
-   *
-   * @remarks
-   * Downloads the PEM to a secure temporary file (mode 0o600) and returns
-   * a cleanup function that overwrites the file with random bytes before deletion.
-   *
-   * @param keyRef - Secret identifier in the backend
-   * @throws Error if the key does not exist in the backend
-   */
-  async getPrivateKey(keyRef) {
-    const pemContent = await this.backend.retrieve(keyRef);
-    const tempDir = await fs2.mkdtemp(path3.join(os2.tmpdir(), "attest-it-vk-"));
-    const tempKeyPath = path3.join(tempDir, "private.pem");
-    try {
-      await fs2.writeFile(tempKeyPath, pemContent, "utf-8");
-      await setKeyPermissions(tempKeyPath);
-      return {
-        keyPath: tempKeyPath,
-        cleanup: async () => {
-          try {
-            const stat3 = await fs2.stat(tempKeyPath);
-            await fs2.writeFile(tempKeyPath, crypto22.randomBytes(stat3.size));
-            await fs2.unlink(tempKeyPath);
-            await fs2.rmdir(tempDir);
-          } catch (cleanupError) {
-            console.warn(
-              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-            );
-          }
-        }
-      };
-    } catch (error2) {
-      try {
-        await fs2.rm(tempDir, { recursive: true, force: true });
-      } catch (cleanupError) {
-        console.warn(
-          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-        );
-      }
-      throw error2;
-    }
-  }
-  /**
-   * Generate a new Ed25519 keypair and store the private key in VaultKeeper.
-   *
-   * @remarks
-   * The public key is written to the filesystem for repository commit.
-   * The private key is stored in the VaultKeeper backend and the local
-   * copy is securely deleted.
-   *
-   * @param options - Key generation options
-   */
-  async generateKeyPair(options) {
-    const { publicKeyPath, force = false } = options;
-    if (!force) {
-      try {
-        await fs2.access(publicKeyPath);
-        throw new Error(
-          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
-        );
-      } catch (err) {
-        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
-          throw err;
-        }
-      }
-    }
-    const keyPair = generateKeyPair2();
-    await fs2.mkdir(path3.dirname(publicKeyPath), { recursive: true });
-    await fs2.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
-    const secretId = `attest-it-${crypto22.randomUUID()}`;
-    await this.backend.store(secretId, keyPair.privateKey);
-    return {
-      privateKeyRef: secretId,
-      publicKeyPath,
-      storageDescription: `VaultKeeper (${this.backend.displayName}): ${secretId}`
-    };
-  }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return {
-      type: this.type,
-      options: { backendType: this.backend.type }
-    };
-  }
-};
-function resolveLegacyPath(p) {
-  if (p === "~" || p.startsWith("~/")) {
-    return path3.join(homedir3(), p.slice(1));
-  }
-  return p;
+  return false;
 }
-var LegacyFilesystemKeyProvider = class {
-  type = "filesystem-legacy";
-  displayName = "Filesystem (Legacy)";
-  /**
-   * Check if this provider is available.
-   * The legacy filesystem provider is always available.
-   */
-  async isAvailable() {
-    return Promise.resolve(true);
-  }
-  /**
-   * Check if a key exists at the given filesystem path.
-   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
-   */
-  async keyExists(keyRef) {
-    try {
-      await fs2.access(resolveLegacyPath(keyRef));
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  /**
-   * Get the private key path for signing.
-   * Returns the resolved (tilde-expanded) path with a no-op cleanup function.
-   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
-   */
-  async getPrivateKey(keyRef) {
-    if (!await this.keyExists(keyRef)) {
-      throw new Error(`Private key not found: ${keyRef}`);
-    }
+function verifySeal(seal2, config) {
+  const { gateId, fingerprint: fingerprint2, timestamp, sealedBy, signature } = seal2;
+  if (!config.team) {
     return {
-      keyPath: resolveLegacyPath(keyRef),
-      // No-op cleanup — key stays on filesystem
-      cleanup: async () => {
-      }
+      valid: false,
+      error: `No team configuration found`
     };
   }
-  /**
-   * Not supported — legacy provider does not create new keys.
-   * @param _options - Unused key generation options
-   * @throws Always throws an informative error directing the user to `identity create`
-   */
-  // Must stay async so the throw below becomes a rejected Promise, matching the KeyProvider interface contract
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async generateKeyPair(_options) {
-    throw new Error(
-      'Legacy filesystem provider does not support key generation. Use "attest-it identity create" with a VaultKeeper-backed provider.'
-    );
+  const teamMember = config.team[sealedBy];
+  if (!teamMember) {
+    return {
+      valid: false,
+      error: `Team member '${sealedBy}' not found in configuration`
+    };
   }
-  /**
-   * Get the configuration for this provider.
-   */
-  getConfig() {
-    return { type: this.type, options: {} };
+  const canonicalString = `${gateId}:${fingerprint2}:${timestamp}`;
+  try {
+    const isValid2 = verify2(canonicalString, signature, teamMember.publicKey);
+    if (!isValid2) {
+      return {
+        valid: false,
+        error: "Signature verification failed"
+      };
+    }
+    return { valid: true };
+  } catch (error2) {
+    return {
+      valid: false,
+      error: `Signature verification error: ${error2 instanceof Error ? error2.message : String(error2)}`
+    };
   }
-};
-var KeyProviderRegistry = class {
-  static providers = /* @__PURE__ */ new Map();
-  /**
-   * Register a key provider factory.
-   * @param type - Provider type identifier
-   * @param factory - Factory function to create provider instances
-   */
-  static register(type, factory) {
-    this.providers.set(type, factory);
+}
+function createEmptySealsFile() {
+  return {
+    version: 1,
+    seals: {}
+  };
+}
+function detectFormat2(filepath) {
+  const ext = filepath.split(".").pop()?.toLowerCase();
+  if (ext === "json") return "json";
+  return "yaml";
+}
+function parseSealsContent(content, format) {
+  let data;
+  try {
+    data = format === "yaml" ? (0, import_yaml.parse)(content) : JSON.parse(content);
+  } catch (error2) {
+    if (error2 instanceof SyntaxError || error2 instanceof Error && error2.name === "YAMLParseError") {
+      throw new Error(`Failed to read seals file: Invalid ${format.toUpperCase()}`);
+    }
+    throw error2;
   }
-  /**
-   * Create a key provider from configuration.
-   * @param config - Provider configuration
-   * @returns A key provider instance
-   * @throws Error if the provider type is not registered
-   */
-  static create(config) {
-    const factory = this.providers.get(config.type);
-    if (!factory) {
+  if (typeof data === "object" && data !== null && "version" in data) {
+    const dataObj = data;
+    const version2 = dataObj.version;
+    if (version2 !== 1 && version2 !== "1") {
+      throw new Error(`Unsupported seals file version: ${String(version2)}`);
+    }
+  }
+  const result = sealsFileSchemaV1.safeParse(data);
+  if (!result.success) {
+    const errors = result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ");
+    throw new Error(`Failed to read seals file: Validation failed: ${errors}`);
+  }
+  return result.data;
+}
+async function readSeals(dir, sealsPathOverride) {
+  if (sealsPathOverride) {
+    const sealsPath = path4.resolve(dir, sealsPathOverride);
+    let content;
+    try {
+      content = await fs.promises.readFile(sealsPath, "utf8");
+    } catch (error2) {
+      if (isFileNotFoundError(error2)) {
+        return createEmptySealsFile();
+      }
       throw new Error(
-        `Unknown key provider type: ${config.type}. Available types: ${Array.from(this.providers.keys()).join(", ")}`
+        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
       );
     }
-    return factory(config);
+    return parseSealsContent(content, detectFormat2(sealsPath));
   }
-  /**
-   * Get all registered provider types.
-   * @returns Array of provider type identifiers
-   */
-  static getProviderTypes() {
-    return Array.from(this.providers.keys());
+  const yamlPath = path4.join(dir, ".attest-it", "seals.yaml");
+  const jsonPath = path4.join(dir, ".attest-it", "seals.json");
+  try {
+    const content = await fs.promises.readFile(yamlPath, "utf8");
+    return parseSealsContent(content, "yaml");
+  } catch (error2) {
+    if (!isFileNotFoundError(error2)) {
+      throw new Error(
+        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
+      );
+    }
   }
-};
-KeyProviderRegistry.register("filesystem", (_config) => {
-  const backend = BackendRegistry.create("file");
-  return new VaultKeyProvider({ backend, displayName: "Filesystem" });
-});
-KeyProviderRegistry.register("1password", (_config) => {
-  const backend = BackendRegistry.create("1password");
-  return new VaultKeyProvider({ backend, displayName: "1Password" });
-});
-KeyProviderRegistry.register("macos-keychain", (_config) => {
-  const backend = BackendRegistry.create("keychain");
-  return new VaultKeyProvider({ backend, displayName: "macOS Keychain" });
-});
-KeyProviderRegistry.register("yubikey", (_config) => {
-  const backend = BackendRegistry.create("yubikey");
-  return new VaultKeyProvider({ backend, displayName: "YubiKey" });
-});
-KeyProviderRegistry.register("filesystem-legacy", (_config) => {
-  return new LegacyFilesystemKeyProvider();
-});
-var cliExperienceSchema = external_exports.object({
-  declinedCompletionInstall: external_exports.boolean().optional()
-}).strict();
-var userPreferencesSchema = external_exports.object({
-  cliExperience: cliExperienceSchema.optional()
-}).strict();
+  try {
+    const content = await fs.promises.readFile(jsonPath, "utf8");
+    return parseSealsContent(content, "json");
+  } catch (error2) {
+    if (isFileNotFoundError(error2)) {
+      return createEmptySealsFile();
+    }
+    throw new Error(
+      `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
+    );
+  }
+}
 function isAuthorizedSigner(config, gateId, publicKey) {
   const gate = config.gates?.[gateId];
   if (!gate) {
@@ -47330,120 +47228,6 @@ function parseDuration(duration) {
     throw new Error(`Invalid duration string: ${duration}`);
   }
   return result;
-}
-function isFileNotFoundError(error2) {
-  if (error2 && typeof error2 === "object" && "code" in error2) {
-    const errorWithCode = error2;
-    return errorWithCode.code === "ENOENT" || errorWithCode.code === "ENOTDIR";
-  }
-  return false;
-}
-function verifySeal(seal2, config) {
-  const { gateId, fingerprint: fingerprint2, timestamp, sealedBy, signature } = seal2;
-  if (!config.team) {
-    return {
-      valid: false,
-      error: `No team configuration found`
-    };
-  }
-  const teamMember = config.team[sealedBy];
-  if (!teamMember) {
-    return {
-      valid: false,
-      error: `Team member '${sealedBy}' not found in configuration`
-    };
-  }
-  const canonicalString = `${gateId}:${fingerprint2}:${timestamp}`;
-  try {
-    const isValid2 = verify3(canonicalString, signature, teamMember.publicKey);
-    if (!isValid2) {
-      return {
-        valid: false,
-        error: "Signature verification failed"
-      };
-    }
-    return { valid: true };
-  } catch (error2) {
-    return {
-      valid: false,
-      error: `Signature verification error: ${error2 instanceof Error ? error2.message : String(error2)}`
-    };
-  }
-}
-function createEmptySealsFile() {
-  return {
-    version: 1,
-    seals: {}
-  };
-}
-function detectFormat2(filepath) {
-  const ext = filepath.split(".").pop()?.toLowerCase();
-  if (ext === "json") return "json";
-  return "yaml";
-}
-function parseSealsContent(content, format) {
-  let data;
-  try {
-    data = format === "yaml" ? (0, import_yaml.parse)(content) : JSON.parse(content);
-  } catch (error2) {
-    if (error2 instanceof SyntaxError || error2 instanceof Error && error2.name === "YAMLParseError") {
-      throw new Error(`Failed to read seals file: Invalid ${format.toUpperCase()}`);
-    }
-    throw error2;
-  }
-  if (typeof data === "object" && data !== null && "version" in data) {
-    const dataObj = data;
-    const version2 = dataObj.version;
-    if (version2 !== 1 && version2 !== "1") {
-      throw new Error(`Unsupported seals file version: ${String(version2)}`);
-    }
-  }
-  const result = sealsFileSchemaV1.safeParse(data);
-  if (!result.success) {
-    const errors = result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ");
-    throw new Error(`Failed to read seals file: Validation failed: ${errors}`);
-  }
-  return result.data;
-}
-async function readSeals(dir, sealsPathOverride) {
-  if (sealsPathOverride) {
-    const sealsPath = path3.resolve(dir, sealsPathOverride);
-    let content;
-    try {
-      content = await fs.promises.readFile(sealsPath, "utf8");
-    } catch (error2) {
-      if (isFileNotFoundError(error2)) {
-        return createEmptySealsFile();
-      }
-      throw new Error(
-        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
-      );
-    }
-    return parseSealsContent(content, detectFormat2(sealsPath));
-  }
-  const yamlPath = path3.join(dir, ".attest-it", "seals.yaml");
-  const jsonPath = path3.join(dir, ".attest-it", "seals.json");
-  try {
-    const content = await fs.promises.readFile(yamlPath, "utf8");
-    return parseSealsContent(content, "yaml");
-  } catch (error2) {
-    if (!isFileNotFoundError(error2)) {
-      throw new Error(
-        `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
-      );
-    }
-  }
-  try {
-    const content = await fs.promises.readFile(jsonPath, "utf8");
-    return parseSealsContent(content, "json");
-  } catch (error2) {
-    if (isFileNotFoundError(error2)) {
-      return createEmptySealsFile();
-    }
-    throw new Error(
-      `Failed to read seals file: ${error2 instanceof Error ? error2.message : String(error2)}`
-    );
-  }
 }
 function verifyGateSeal(config, gateId, seals, currentFingerprint) {
   const gate = getGate(config, gateId);
@@ -47554,6 +47338,317 @@ function verifyAllSeals(config, seals, fingerprints) {
   }
   return results;
 }
+var DEFAULT_POLICY_REL_PATH = ".attest-it/policy.yaml";
+function synthesizeRootGate(rootGate, policyRelPath) {
+  return {
+    name: "Root Gate",
+    description: rootGate.description ?? "Trust anchor over .attest-it/policy.yaml",
+    authorizedSigners: rootGate.authorizedSigners,
+    fingerprint: { paths: [policyRelPath] },
+    maxAge: rootGate.maxAge
+  };
+}
+function toPolicyRelPath(baseDir, policyPath) {
+  const rel = relative3(resolve5(baseDir), resolve5(policyPath));
+  if (rel.length === 0 || rel.startsWith("..")) {
+    return DEFAULT_POLICY_REL_PATH;
+  }
+  return rel.split("\\").join("/");
+}
+async function computePolicyFingerprint(baseDir, policyPath) {
+  const relPath = toPolicyRelPath(baseDir, policyPath);
+  const result = await computeFingerprint({ paths: [relPath], baseDir });
+  return result.fingerprint;
+}
+function describeRootState(state, base) {
+  switch (state) {
+    case "VALID":
+      return "Root gate is valid: .attest-it/policy.yaml is sealed by an authorized root signer.";
+    case "MISSING":
+      return "Untrusted policy: .attest-it/policy.yaml is not sealed by a root signer. The trust-critical policy (team & gate authorization) has no root seal. Have a root signer run `attest-it seal --root` to anchor it.";
+    case "FINGERPRINT_MISMATCH":
+      return "Untrusted change to .attest-it/policy.yaml: the trust-critical policy (team &/or gate authorization) was modified, but the modification is not sealed by a root signer. The existing root seal covers a different policy fingerprint. Have a root signer re-run `attest-it seal --root` to authorize this change.";
+    case "UNKNOWN_SIGNER":
+      return "Untrusted policy change: the root seal over .attest-it/policy.yaml was created by a signer that is not an authorized root signer. A branch cannot bootstrap a new root of trust for itself \u2014 changing the root signers requires a seal from an existing root signer." + (base ? ` (${base})` : "");
+    case "INVALID_SIGNATURE":
+      return "Untrusted policy: the root seal over .attest-it/policy.yaml has an invalid signature and does not authorize the current policy." + (base ? ` (${base})` : "");
+    case "STALE":
+      return "The root seal over .attest-it/policy.yaml is stale (exceeds the root gate maxAge). Have a root signer re-run `attest-it seal --root`.";
+    case "NOT_ANCHORED":
+      return "Policy is not trust-anchored: .attest-it/policy.yaml defines no rootGate. Run the `attest-it init` bootstrap ceremony to establish a root signer.";
+    default: {
+      const _exhaustive = state;
+      return `Root gate verification failed${base ? ` (${base})` : ""}: ${String(_exhaustive)}`;
+    }
+  }
+}
+function verifyRootGate(params) {
+  const { config, policyFingerprint, seals, trustedSourceLabel } = params;
+  if (!config.rootGate) {
+    return {
+      gateId: ROOT_GATE_ID,
+      state: "NOT_ANCHORED",
+      message: describeRootState("NOT_ANCHORED", trustedSourceLabel)
+    };
+  }
+  const syntheticGate = synthesizeRootGate(config.rootGate, DEFAULT_POLICY_REL_PATH);
+  const configWithRoot = {
+    ...config,
+    gates: { ...config.gates, [ROOT_GATE_ID]: syntheticGate }
+  };
+  const result = verifyGateSeal(configWithRoot, ROOT_GATE_ID, seals, policyFingerprint);
+  return {
+    gateId: ROOT_GATE_ID,
+    state: result.state,
+    ...result.seal && { seal: result.seal },
+    message: describeRootState(result.state, trustedSourceLabel)
+  };
+}
+function isBlockingRootGateState(state) {
+  return state !== "VALID" && state !== "STALE" && state !== "NOT_ANCHORED";
+}
+async function setKeyPermissions(keyPath) {
+  if (process.platform === "win32") {
+    await fs32.chmod(keyPath, 384);
+  } else {
+    await fs32.chmod(keyPath, 384);
+  }
+}
+var VaultKeyProvider = class {
+  type;
+  displayName;
+  backend;
+  /**
+   * Create a new VaultKeyProvider.
+   * @param options - Provider options including the VaultKeeper backend
+   */
+  constructor(options) {
+    this.backend = options.backend;
+    this.type = options.backend.type;
+    this.displayName = options.displayName;
+  }
+  /**
+   * Check if the underlying VaultKeeper backend is available.
+   */
+  async isAvailable() {
+    return this.backend.isAvailable();
+  }
+  /**
+   * Check if a key exists in the VaultKeeper backend.
+   * @param keyRef - Secret identifier in the backend
+   */
+  async keyExists(keyRef) {
+    return this.backend.exists(keyRef);
+  }
+  /**
+   * Retrieve the private key from VaultKeeper for signing.
+   *
+   * @remarks
+   * Downloads the PEM to a secure temporary file (mode 0o600) and returns
+   * a cleanup function that overwrites the file with random bytes before deletion.
+   *
+   * @param keyRef - Secret identifier in the backend
+   * @throws Error if the key does not exist in the backend
+   */
+  async getPrivateKey(keyRef) {
+    const pemContent = await this.backend.retrieve(keyRef);
+    const tempDir = await fs32.mkdtemp(path4.join(os2.tmpdir(), "attest-it-vk-"));
+    const tempKeyPath = path4.join(tempDir, "private.pem");
+    try {
+      await fs32.writeFile(tempKeyPath, pemContent, "utf-8");
+      await setKeyPermissions(tempKeyPath);
+      return {
+        keyPath: tempKeyPath,
+        cleanup: async () => {
+          try {
+            const stat3 = await fs32.stat(tempKeyPath);
+            await fs32.writeFile(tempKeyPath, crypto22.randomBytes(stat3.size));
+            await fs32.unlink(tempKeyPath);
+            await fs32.rmdir(tempDir);
+          } catch (cleanupError) {
+            console.warn(
+              `Warning: Failed to clean up temporary key file at ${tempKeyPath}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+            );
+          }
+        }
+      };
+    } catch (error2) {
+      try {
+        await fs32.rm(tempDir, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.warn(
+          `Warning: Failed to clean up temporary key directory at ${tempDir}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+        );
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Generate a new Ed25519 keypair and store the private key in VaultKeeper.
+   *
+   * @remarks
+   * The public key is written to the filesystem for repository commit.
+   * The private key is stored in the VaultKeeper backend and the local
+   * copy is securely deleted.
+   *
+   * @param options - Key generation options
+   */
+  async generateKeyPair(options) {
+    const { publicKeyPath, force = false } = options;
+    if (!force) {
+      try {
+        await fs32.access(publicKeyPath);
+        throw new Error(
+          `Public key file already exists: ${publicKeyPath}. Use force: true to overwrite.`
+        );
+      } catch (err) {
+        if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) {
+          throw err;
+        }
+      }
+    }
+    const keyPair = generateKeyPair();
+    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
+    await fs32.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
+    const secretId = `attest-it-${crypto22.randomUUID()}`;
+    await this.backend.store(secretId, keyPair.privateKey);
+    return {
+      privateKeyRef: secretId,
+      publicKeyPath,
+      storageDescription: `VaultKeeper (${this.backend.displayName}): ${secretId}`
+    };
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return {
+      type: this.type,
+      options: { backendType: this.backend.type }
+    };
+  }
+};
+function resolveLegacyPath(p) {
+  if (p === "~" || p.startsWith("~/")) {
+    return path4.join(homedir3(), p.slice(1));
+  }
+  return p;
+}
+var LegacyFilesystemKeyProvider = class {
+  type = "filesystem-legacy";
+  displayName = "Filesystem (Legacy)";
+  /**
+   * Check if this provider is available.
+   * The legacy filesystem provider is always available.
+   */
+  async isAvailable() {
+    return Promise.resolve(true);
+  }
+  /**
+   * Check if a key exists at the given filesystem path.
+   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
+   */
+  async keyExists(keyRef) {
+    try {
+      await fs32.access(resolveLegacyPath(keyRef));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  /**
+   * Get the private key path for signing.
+   * Returns the resolved (tilde-expanded) path with a no-op cleanup function.
+   * @param keyRef - Filesystem path to the private key file (may contain a leading `~`)
+   */
+  async getPrivateKey(keyRef) {
+    if (!await this.keyExists(keyRef)) {
+      throw new Error(`Private key not found: ${keyRef}`);
+    }
+    return {
+      keyPath: resolveLegacyPath(keyRef),
+      // No-op cleanup — key stays on filesystem
+      cleanup: async () => {
+      }
+    };
+  }
+  /**
+   * Not supported — legacy provider does not create new keys.
+   * @param _options - Unused key generation options
+   * @throws Always throws an informative error directing the user to `identity create`
+   */
+  // Must stay async so the throw below becomes a rejected Promise, matching the KeyProvider interface contract
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async generateKeyPair(_options) {
+    throw new Error(
+      'Legacy filesystem provider does not support key generation. Use "attest-it identity create" with a VaultKeeper-backed provider.'
+    );
+  }
+  /**
+   * Get the configuration for this provider.
+   */
+  getConfig() {
+    return { type: this.type, options: {} };
+  }
+};
+var KeyProviderRegistry = class {
+  static providers = /* @__PURE__ */ new Map();
+  /**
+   * Register a key provider factory.
+   * @param type - Provider type identifier
+   * @param factory - Factory function to create provider instances
+   */
+  static register(type, factory) {
+    this.providers.set(type, factory);
+  }
+  /**
+   * Create a key provider from configuration.
+   * @param config - Provider configuration
+   * @returns A key provider instance
+   * @throws Error if the provider type is not registered
+   */
+  static create(config) {
+    const factory = this.providers.get(config.type);
+    if (!factory) {
+      throw new Error(
+        `Unknown key provider type: ${config.type}. Available types: ${Array.from(this.providers.keys()).join(", ")}`
+      );
+    }
+    return factory(config);
+  }
+  /**
+   * Get all registered provider types.
+   * @returns Array of provider type identifiers
+   */
+  static getProviderTypes() {
+    return Array.from(this.providers.keys());
+  }
+};
+KeyProviderRegistry.register("filesystem", (_config) => {
+  const backend = BackendRegistry.create("file");
+  return new VaultKeyProvider({ backend, displayName: "Filesystem" });
+});
+KeyProviderRegistry.register("1password", (_config) => {
+  const backend = BackendRegistry.create("1password");
+  return new VaultKeyProvider({ backend, displayName: "1Password" });
+});
+KeyProviderRegistry.register("macos-keychain", (_config) => {
+  const backend = BackendRegistry.create("keychain");
+  return new VaultKeyProvider({ backend, displayName: "macOS Keychain" });
+});
+KeyProviderRegistry.register("yubikey", (_config) => {
+  const backend = BackendRegistry.create("yubikey");
+  return new VaultKeyProvider({ backend, displayName: "YubiKey" });
+});
+KeyProviderRegistry.register("filesystem-legacy", (_config) => {
+  return new LegacyFilesystemKeyProvider();
+});
+var cliExperienceSchema = external_exports.object({
+  declinedCompletionInstall: external_exports.boolean().optional()
+}).strict();
+var userPreferencesSchema = external_exports.object({
+  cliExperience: cliExperienceSchema.optional()
+}).strict();
 var version = getPackageVersion();
 
 // src/fetch-policy.ts
@@ -47652,7 +47747,7 @@ async function run() {
             content: policyResult.content,
             format: policyFormat
           },
-          operationalPath: resolve5(process.cwd(), operationalConfigPath)
+          operationalPath: resolve6(process.cwd(), operationalConfigPath)
         });
       } else {
         core.info("Loading configuration from filesystem");
@@ -47660,9 +47755,9 @@ async function run() {
         config = await loadSplitConfig({
           policySource: {
             type: "filesystem",
-            path: resolve5(process.cwd(), policyPath)
+            path: resolve6(process.cwd(), policyPath)
           },
-          operationalPath: resolve5(process.cwd(), operationalConfigPath)
+          operationalPath: resolve6(process.cwd(), operationalConfigPath)
         });
       }
     } catch (err) {
@@ -47711,6 +47806,24 @@ async function run() {
       } else {
         throw err;
       }
+    }
+    if (config.rootGate) {
+      const workingTreePolicyPath = resolve6(process.cwd(), policyPath);
+      const policyFingerprint = await computePolicyFingerprint(process.cwd(), workingTreePolicyPath);
+      const rootResult = verifyRootGate({
+        config,
+        policyFingerprint,
+        seals,
+        trustedSourceLabel: effectivePolicyRef ? `root signers from ${effectivePolicyRef}` : void 0
+      });
+      if (isBlockingRootGateState(rootResult.state)) {
+        core.setFailed(rootResult.message);
+        return;
+      }
+      if (rootResult.state === "STALE") {
+        core.warning(rootResult.message);
+      }
+      core.info("\u2713 Root gate verified: policy.yaml is sealed by an authorized root signer");
     }
     const fingerprints = {};
     if (config.gates) {

--- a/packages/github-action/src/index.ts
+++ b/packages/github-action/src/index.ts
@@ -4,6 +4,9 @@ import {
   readSeals,
   verifyAllSeals,
   computeFingerprint,
+  computePolicyFingerprint,
+  verifyRootGate,
+  isBlockingRootGateState,
   type SealVerificationResult,
   type AttestItConfig,
   type SealsFile,
@@ -170,6 +173,37 @@ export async function run(): Promise<void> {
       } else {
         throw err
       }
+    }
+
+    // MANDATORY PRE-STEP: verify the config's OWN seal chain against the root
+    // gate BEFORE evaluating any other gate. In a PR context `config` (and thus
+    // the root gate's authorized signers) is loaded from the BASE branch — the
+    // trusted source — while the policy fingerprint and seals come from the PR
+    // working tree. A branch that modifies the trust-critical policy without a
+    // fresh root seal from a base-branch-authorized root signer therefore fails
+    // here, before any gate is trusted. A branch that adds itself as a root
+    // signer and self-seals is rejected as UNKNOWN_SIGNER (the base branch does
+    // not list it) — a branch cannot bootstrap a new root of trust for itself.
+    if (config.rootGate) {
+      const workingTreePolicyPath = resolve(process.cwd(), policyPath)
+      const policyFingerprint = await computePolicyFingerprint(process.cwd(), workingTreePolicyPath)
+      const rootResult = verifyRootGate({
+        config,
+        policyFingerprint,
+        seals,
+        trustedSourceLabel: effectivePolicyRef
+          ? `root signers from ${effectivePolicyRef}`
+          : undefined,
+      })
+
+      if (isBlockingRootGateState(rootResult.state)) {
+        core.setFailed(rootResult.message)
+        return
+      }
+      if (rootResult.state === 'STALE') {
+        core.warning(rootResult.message)
+      }
+      core.info('✓ Root gate verified: policy.yaml is sealed by an authorized root signer')
     }
 
     // Compute fingerprints for all gates

--- a/schemas/v1/policy.schema.json
+++ b/schemas/v1/policy.schema.json
@@ -40,6 +40,29 @@
           "additionalProperties": false,
           "default": {}
         },
+        "rootGate": {
+          "type": "object",
+          "properties": {
+            "authorizedSigners": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "maxAge": {
+              "type": "string",
+              "default": "365d"
+            },
+            "description": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": ["authorizedSigners"],
+          "additionalProperties": false
+        },
         "team": {
           "type": "object",
           "additionalProperties": {


### PR DESCRIPTION
## Summary

Implements the **sealed root gate** trust anchor over `.attest-it/policy.yaml` (PRD R1). The policy file — which holds the trust-critical `team` and `gates` — is now itself a gated, sealed artifact. Verification checks the policy's own seal chain **first**, before evaluating any other gate, so a pull request can no longer add itself to `team`, authorize itself on a gate, and pass verification.

Refs #72

## Root-gate representation: dedicated `rootGate:` section (not a reserved slug in `gates:`)

I chose a **dedicated top-level `rootGate:` section** over a reserved `__root__` entry inside the user-editable `gates:` map. Rationale:

- **Semantics over expedience.** The root gate is a fundamentally different concern from ordinary gates; it deserves its own namespace rather than sharing the user-editable one. A reserved slug living in `gates:` would require reserved-name enforcement anyway and risks category-wide gate logic (evaluation loops, suite→gate reference validation) accidentally sweeping it in.
- **Can't be redefined by a PR.** There is exactly one `rootGate` field, and the reserved id `__root__` is rejected as an ordinary gate (schema `superRefine`), so a PR cannot repoint "which gate is root."
- **Reuses the same primitives.** `verifyRootGate` materializes the root gate into a reserved, non-persisted `__root__` slot at verify time and defers entirely to `verifyGateSeal` — so the root seal is created/verified by the *same* code path as any other gate seal (`createSeal`/`verifyGateSeal`), keeping one trust system to audit.
- **Covered artifact is fixed.** `rootGate` has no user-configurable `fingerprint`; it always covers `policy.yaml`, so a branch can't repoint it at empty content.

## How verification ordering is enforced

`verify` (CLI) and the GitHub Action run a **mandatory pre-step** before any gate is evaluated:

1. load config → 2. if `config.rootGate` is present, compute the policy fingerprint and call `verifyRootGate` → 3. if the root state is blocking (anything other than `VALID`/`STALE`), fail closed **before** `validateSuiteGateReferences`/gate evaluation.

- CLI: `packages/cli/src/commands/verify.ts` — pre-step inserted right after seals are read, before the gate loop.
- Action: `packages/github-action/src/index.ts` — pre-step after seals are read, before per-gate fingerprints. In PR context `config` (and thus the root signer set) is loaded from the **base branch**, so a branch that self-adds a root signer and self-seals is rejected as `UNKNOWN_SIGNER`.
- Blocking states surface a **non-generic** message naming `.attest-it/policy.yaml` and the untrusted trust-data change.
- Backward compatible: a repo with no `rootGate` reports `NOT_ANCHORED` (non-blocking) and proceeds, so existing repos keep working until they bootstrap.

## How the bootstrap ceremony works

One human-run step establishes the trust anchor (`packages/cli/src/commands/init.ts`):

```
attest-it identity create --name "…" --slug you   # general onboarding
attest-it init --root-signer you                   # THE ceremony
```

`init --root-signer <slug>` (or an interactive confirmation when a TTY + active identity are present — never silently defaulted) adds the identity to `team`, records `rootGate.authorizedSigners`, and creates the anchoring seal over `policy.yaml`, all in one invocation. Changing the root signers later requires a fresh root seal from an **existing** root signer via `attest-it seal --root` — a branch cannot bootstrap a new root of trust for itself.

## PRD R1 acceptance criteria → where satisfied

| AC | Satisfied by |
| --- | --- |
| Adversarial: add public key to `team` + authorize on a gate, seal with it → `verify` fails naming the untrusted config change | Code: root pre-step in `verify.ts` + `verifyRootGate` (FINGERPRINT_MISMATCH, message names `policy.yaml`). Tests: `packages/core/test/root-gate.test.ts` "adversarial AC 1"; `packages/cli/test/integration/root-gate.integration.test.ts` "ADVERSARIAL 1" |
| Adversarial: modify an existing gate's `authorizedSigners` → verify fails absent a valid root-signer seal | Same code path. Tests: core "adversarial AC 2"; CLI "ADVERSARIAL 2" |
| Positive: config change sealed by a root signer verifies, and subsequent gates evaluate against the new config | Code: `verifyRootGate` VALID → gate loop proceeds. Tests: core "after a root signer re-seals … gates evaluate against the NEW config"; CLI "POSITIVE" + "POSITIVE follow-up" |
| Bootstrap ceremony documented; fresh repo reaches trusted state in one human step | Code: `init --root-signer`. Docs: `docs/threat-model.md`, `docs/configuration.md`. Test: CLI "bootstrap ceremony reaches trusted state in one human-run step" |
| Threat-model doc covering all four items | `docs/threat-model.md` (T1 config, T2 workflow file w/ Q2 posture, T3 seal replay, T4 PATH-shadow) |
| `init` establishes root signer(s) as an explicit, interactive, human-run step | `init --root-signer` + interactive confirm (`maybeBootstrapRootGate`) |
| Verification order: root seal → then gates; never evaluate against an unverified policy | Pre-step in `verify.ts` + Action; `isBlockingRootGateState` |
| Adversarial tests automated + run in CI | Both test files run under `pnpm run test` (CI `build` job) — see below |
| Changing root signers requires an existing root signer | Root signer set sourced from trusted policy (base branch in the Action); `seal --root` authorization check. Tests: core "AC 5" (both variants) |

## CI

The adversarial + positive + bootstrap tests live in `packages/core/test/root-gate.test.ts` and `packages/cli/test/integration/root-gate.integration.test.ts`. Both run in the standard suite (`vitest run`) invoked by the CI `build` job's `pnpm run test` step (`.github/workflows/ci.yml`) on every PR — not manual/doc-only.

## Accommodating not-yet-landed dependencies (#69, #70)

- **#70 (file-per-seal storage) — not landed.** I used the **current** monolithic seals-file storage: the root seal is stored under the reserved `__root__` key in the existing `seals.json`/`seals.yaml`, read/written with the existing `readSeals`/`writeSeals`. No new storage scheme invented.
- **#69 (pattern gates) — not landed.** Built assuming it *conceptually* but not implemented. Practical consequence, documented for reviewers: without pattern gates, any change to `policy.yaml` (e.g. adding a gate) requires a `attest-it seal --root` re-anchor. This is the "R1 needs R2 to be livable" tradeoff called out in the issue.

## Notes for the PM (please weigh in)

1. **Backward-compatibility vs. major bump.** The implementation is backward compatible — a repo without `rootGate` verifies as before (`NOT_ANCHORED`, non-blocking). The changeset is marked **major** per the task's explicit instruction ("treat as major bump with migration guidance"), but since nothing breaks for un-bootstrapped repos, you may prefer **minor**. Easy to flip.
2. **`@attest-it/github-action` changeset.** The task asked to include the Action in the changeset, but `.changeset/config.json` lists `@attest-it/github-action` in `ignore` (it's versioned outside changesets). I documented the Action's behavior change in the changeset body and did **not** add it as a changeset entry (which would error). Flagging in case you want it versioned differently.
3. **`status` left informational.** The mandatory pre-step is enforced in `verify` and the Action. `status` retains its "always exits 0" informational contract (a recent, deliberate design point) and was not made to fail on root-gate issues. Confirm this scoping is acceptable.
4. **Local vs. merge-gate trust.** Local `attest-it verify` trusts the local policy's root signers (no base branch to compare against). The self-bootstrap guarantee (AC 5) is enforced at the merge gate, where the Action loads the root signer set from the base branch. This is documented in `docs/threat-model.md` (T2 + Residual risks). The Action self-check of base-branch *workflow definitions* is documented as a non-goal per the issue.
