### PR TITLE
fix: preserve comments in policy.yaml across team join/add/remove writes

### DIFF
--- a/.changeset/policy-yaml-preserve-comments.md
+++ b/.changeset/policy-yaml-preserve-comments.md
@@ -1,0 +1,9 @@
+---
+'@attest-it/core': patch
+'@attest-it/cli': patch
+'attest-it': patch
+---
+
+Fix `team join`/`team add`/`team remove` silently stripping every human-authored comment (including the `# yaml-language-server: $schema=...` directive `init` scaffolds) from `.attest-it/policy.yaml` on write.
+
+These commands now round-trip through a comment-preserving YAML `Document` edit (`@attest-it/core`'s new `loadEditablePolicy`/`serializeEditablePolicy`) that only replaces the specific fields that actually changed, instead of parsing to a plain object and re-serializing the whole file. Untouched comments -- including the schema directive, trust-model header, and commented onboarding examples -- as well as untouched sibling fields on a partially-changed section (e.g. an unrelated gate's `name`/`fingerprint` when only its `authorizedSigners` changed), now survive every write.

--- a/packages/cli/src/commands/team/add.ts
+++ b/packages/cli/src/commands/team/add.ts
@@ -3,10 +3,13 @@ import { input } from '@inquirer/prompts'
 import { log, success } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
 import { getTheme } from '../../components/theme.js'
-import { writeFile } from 'node:fs/promises'
-import { stringify as stringifyYaml } from 'yaml'
 import { resolveOrPrompt, isInteractiveTTY, handlePromptableError } from '../../utils/prompts.js'
-import { resolveGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
+import {
+  resolveGateAuthorization,
+  addTeamMemberToPolicy,
+  loadPolicyForEdit,
+  writePolicyEdit,
+} from './utils.js'
 
 interface AddOptions {
   slug?: string
@@ -83,7 +86,8 @@ async function runAdd(options: AddOptions = {}): Promise<void> {
     log('')
 
     // Load existing policy (team + gates live in policy.yaml)
-    const { policy, path: policyPath } = loadPolicyForEdit()
+    const editablePolicy = loadPolicyForEdit()
+    const { policy } = editablePolicy
     const existingTeam = policy.team ?? {}
 
     const validateSlugInput = (value: string): true | string => {
@@ -169,9 +173,8 @@ async function runAdd(options: AddOptions = {}): Promise<void> {
     }
     const updatedPolicy = addTeamMemberToPolicy(policy, slug, memberData, authorizedGates)
 
-    // Write policy back to file
-    const yamlContent = stringifyYaml(updatedPolicy)
-    await writeFile(policyPath, yamlContent, 'utf8')
+    // Write policy back to file, preserving existing comments (issue #102)
+    await writePolicyEdit(editablePolicy, updatedPolicy)
 
     log('')
     success(`Team member "${slug}" added successfully`)

--- a/packages/cli/src/commands/team/join.ts
+++ b/packages/cli/src/commands/team/join.ts
@@ -4,10 +4,13 @@ import { loadLocalConfig, getActiveIdentity } from '@attest-it/core'
 import { log, success, error, info } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
 import { getTheme } from '../../components/theme.js'
-import { writeFile } from 'node:fs/promises'
-import { stringify as stringifyYaml } from 'yaml'
 import { resolveOrPrompt, handlePromptableError } from '../../utils/prompts.js'
-import { resolveGateAuthorization, addTeamMemberToPolicy, loadPolicyForEdit } from './utils.js'
+import {
+  resolveGateAuthorization,
+  addTeamMemberToPolicy,
+  loadPolicyForEdit,
+  writePolicyEdit,
+} from './utils.js'
 
 interface JoinOptions {
   slug?: string
@@ -62,7 +65,8 @@ export async function runJoin(options: JoinOptions = {}): Promise<void> {
     log('')
 
     // Load project policy (team + gates live in policy.yaml)
-    const { policy, path: policyPath } = loadPolicyForEdit()
+    const editablePolicy = loadPolicyForEdit()
+    const { policy } = editablePolicy
     const existingTeam = policy.team ?? {}
 
     // Check if public key already exists
@@ -119,9 +123,8 @@ export async function runJoin(options: JoinOptions = {}): Promise<void> {
     }
     const updatedPolicy = addTeamMemberToPolicy(policy, slug, memberData, authorizedGates)
 
-    // Write policy back to file
-    const yamlContent = stringifyYaml(updatedPolicy)
-    await writeFile(policyPath, yamlContent, 'utf8')
+    // Write policy back to file, preserving existing comments (issue #102)
+    await writePolicyEdit(editablePolicy, updatedPolicy)
 
     log('')
     success(`Team member "${slug}" added successfully`)

--- a/packages/cli/src/commands/team/remove.ts
+++ b/packages/cli/src/commands/team/remove.ts
@@ -5,9 +5,7 @@ import { log, success, error, warn } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
 import { handlePromptableError, resolveConfirmation } from '../../utils/prompts.js'
 import { getTheme } from '../../components/theme.js'
-import { writeFile } from 'node:fs/promises'
-import { stringify as stringifyYaml } from 'yaml'
-import { loadPolicyForEdit } from './utils.js'
+import { loadPolicyForEdit, writePolicyEdit } from './utils.js'
 
 export const removeCommand = new Command('remove')
   .description('Remove a team member')
@@ -32,7 +30,8 @@ export async function runRemove(slug: string, options: { force?: boolean }): Pro
     const theme = getTheme()
 
     // Load existing policy (team + gates live in policy.yaml)
-    const { policy, path: policyPath } = loadPolicyForEdit()
+    const editablePolicy = loadPolicyForEdit()
+    const { policy } = editablePolicy
 
     // Check if member exists
     // eslint-disable-next-line security/detect-object-injection
@@ -120,22 +119,30 @@ export async function runRemove(slug: string, options: { force?: boolean }): Pro
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete, security/detect-object-injection
     delete updatedTeam[slug]
 
+    // Remove from all gate authorizations. Builds an entirely new `gates`
+    // object rather than mutating `policy.gates`/`gate.authorizedSigners` in
+    // place: `policy` is also the "before" snapshot the comment-preserving
+    // writer diffs against below, and `{ ...policy, team: updatedTeam }`
+    // keeps the same `gates` object reference, so mutating it in place would
+    // corrupt that snapshot and make every gate look unchanged. See issue #102.
+    const updatedGates = policy.gates
+      ? Object.fromEntries(
+          Object.entries(policy.gates).map(([gateId, gate]) => [
+            gateId,
+            { ...gate, authorizedSigners: gate.authorizedSigners.filter((s) => s !== slug) },
+          ]),
+        )
+      : policy.gates
+
     // Update policy
     const updatedPolicy: PolicyConfig = {
       ...policy,
       team: updatedTeam,
+      gates: updatedGates,
     }
 
-    // Remove from all gate authorizations
-    if (updatedPolicy.gates) {
-      for (const gate of Object.values(updatedPolicy.gates)) {
-        gate.authorizedSigners = gate.authorizedSigners.filter((s) => s !== slug)
-      }
-    }
-
-    // Write policy back to file
-    const yamlContent = stringifyYaml(updatedPolicy)
-    await writeFile(policyPath, yamlContent, 'utf8')
+    // Write policy back to file, preserving existing comments (issue #102)
+    await writePolicyEdit(editablePolicy, updatedPolicy)
 
     log('')
     success(`Team member "${slug}" removed successfully`)

--- a/packages/cli/src/commands/team/utils.ts
+++ b/packages/cli/src/commands/team/utils.ts
@@ -1,6 +1,13 @@
 import { readFileSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
 import { checkbox } from '@inquirer/prompts'
-import { findPolicyPath, parsePolicyContent, type PolicyConfig } from '@attest-it/core'
+import {
+  findPolicyPath,
+  loadEditablePolicy,
+  serializeEditablePolicy,
+  type EditablePolicy,
+  type PolicyConfig,
+} from '@attest-it/core'
 import { isInteractiveTTY } from '../../utils/prompts.js'
 
 /**
@@ -9,11 +16,18 @@ import { isInteractiveTTY } from '../../utils/prompts.js'
  * Team members and gates are trust-critical and live in `.attest-it/policy.yaml`.
  * Team commands read, mutate, and write this file directly.
  *
- * @returns The parsed policy config and the path it was loaded from.
+ * The returned {@link EditablePolicy} retains enough state (a parsed YAML
+ * document, for `.yaml`/`.yml` files) to write updates back via
+ * {@link writePolicyEdit} without losing comments -- including the
+ * `# yaml-language-server:` schema directive and any human-authored
+ * annotations. See issue #102.
+ *
+ * @returns The editable policy: parsed policy config, the path it was
+ * loaded from, and document state needed for a comment-preserving write.
  * @throws If no policy file is found.
  * @public
  */
-export function loadPolicyForEdit(): { policy: PolicyConfig; path: string } {
+export function loadPolicyForEdit(): EditablePolicy {
   const path = findPolicyPath()
   if (!path) {
     throw new Error(
@@ -21,9 +35,23 @@ export function loadPolicyForEdit(): { policy: PolicyConfig; path: string } {
     )
   }
   const content = readFileSync(path, 'utf8')
-  const format = path.endsWith('.json') ? 'json' : 'yaml'
-  const policy = parsePolicyContent(content, format)
-  return { policy, path }
+  return loadEditablePolicy(path, content)
+}
+
+/**
+ * Write an updated policy back to disk, preserving existing comments (and the
+ * `# yaml-language-server:` schema directive) wherever possible.
+ *
+ * @param editable - The policy as loaded by {@link loadPolicyForEdit}.
+ * @param updatedPolicy - The new policy value to persist.
+ * @public
+ */
+export async function writePolicyEdit(
+  editable: EditablePolicy,
+  updatedPolicy: PolicyConfig,
+): Promise<void> {
+  const content = serializeEditablePolicy(editable, updatedPolicy)
+  await writeFile(editable.path, content, 'utf8')
 }
 
 /**
@@ -101,6 +129,16 @@ export async function resolveGateAuthorization(
 /**
  * Add a team member to the policy and update gate authorizations.
  *
+ * @remarks
+ * Builds an entirely new `gates` object rather than mutating
+ * `policy.gates`/`gate.authorizedSigners` in place. The input `policy` is
+ * also the "before" snapshot {@link writePolicyEdit} diffs against to decide
+ * which sections of the on-disk YAML document need to change; mutating
+ * shared gate objects in place would corrupt that snapshot (since
+ * `{ ...policy, team: {...} }` keeps the same `gates` object reference) and
+ * make every gate look unchanged even when an `authorizedSigners` array was
+ * just pushed into. See issue #102.
+ *
  * @param policy - The existing policy config
  * @param memberSlug - The slug/identifier for the team member
  * @param memberData - The team member data to add
@@ -122,8 +160,18 @@ export function addTeamMemberToPolicy(
 ): PolicyConfig {
   const existingTeam = policy.team ?? {}
 
-  // Build the updated policy with the new team member
-  const updatedPolicy: PolicyConfig = {
+  const updatedGates = policy.gates
+    ? Object.fromEntries(
+        Object.entries(policy.gates).map(([gateId, gate]) => {
+          if (authorizedGates.includes(gateId) && !gate.authorizedSigners.includes(memberSlug)) {
+            return [gateId, { ...gate, authorizedSigners: [...gate.authorizedSigners, memberSlug] }]
+          }
+          return [gateId, gate]
+        }),
+      )
+    : policy.gates
+
+  return {
     ...policy,
     team: {
       ...existingTeam,
@@ -135,21 +183,6 @@ export function addTeamMemberToPolicy(
         ...(memberData.github ? { github: memberData.github } : {}),
       },
     },
+    gates: updatedGates,
   }
-
-  // Update gate authorizations
-  if (authorizedGates.length > 0 && updatedPolicy.gates) {
-    for (const gateId of authorizedGates) {
-      // eslint-disable-next-line security/detect-object-injection
-      const gate = updatedPolicy.gates[gateId]
-      if (gate) {
-        // Add to authorizedSigners if not already present
-        if (!gate.authorizedSigners.includes(memberSlug)) {
-          gate.authorizedSigners.push(memberSlug)
-        }
-      }
-    }
-  }
-
-  return updatedPolicy
 }

--- a/packages/cli/test/integration/policy-comment-preservation.integration.test.ts
+++ b/packages/cli/test/integration/policy-comment-preservation.integration.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression test for issue #102: CLI commands that write `policy.yaml`
+ * silently stripped every human-authored comment (including the
+ * `# yaml-language-server: $schema=...` directive `init` scaffolds) the
+ * moment a documented, required step (`team join`) ran.
+ *
+ * This test drives the real, built CLI as subprocesses -- `init` scaffolds
+ * `policy.yaml` with its schema directive, trust-model header, and commented
+ * onboarding examples; `team join` then mutates it. Before the fix, `team
+ * join`'s `stringify(parsedPolicyObject)` write destroyed all of that. The
+ * assertions below fail against the pre-fix code (the file would contain
+ * none of these strings) and pass once `team join` round-trips through a
+ * comment-preserving YAML `Document` edit instead.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+
+const CLI_CALL_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run the built CLI as a real subprocess with stdin closed (equivalent to
+ * `< /dev/null`) and a hard timeout, so a regression that reintroduces an
+ * interactive prompt fails loudly instead of hanging the suite.
+ */
+function runCliNonInteractive(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(CLI_CALL_TIMEOUT_MS)}ms: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/** Read the public key attest-it just wrote for `slug` under a temp ATTEST_IT_HOME. */
+async function readCreatedPublicKey(homeDir: string, slug: string): Promise<string> {
+  const { parse: parseYaml } = await import('yaml')
+  const content = await fs.promises.readFile(path.join(homeDir, 'config.yaml'), 'utf8')
+  const parsed: unknown = parseYaml(content)
+  if (!isRecordOfUnknown(parsed) || !isRecordOfUnknown(parsed.identities)) {
+    throw new Error('Expected local config to contain an identities map')
+  }
+  const identity = parsed.identities[slug]
+  if (!isRecordOfUnknown(identity) || typeof identity.publicKey !== 'string') {
+    throw new Error(`Expected identity "${slug}" to have a string publicKey`)
+  }
+  return identity.publicKey
+}
+
+describe('policy.yaml comment preservation across mutating commands (issue #102)', () => {
+  let projectDir: string
+  let homeDir: string
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-policy-comments-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-policy-comments-home-'))
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  it(
+    'keeps the schema directive and header/example comments after `team join` mutates a freshly-scaffolded policy.yaml',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir }
+      const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+
+      // 1. init: scaffolds policy.yaml with the schema directive, trust-model
+      // header, and commented team/gates examples.
+      const initResult = await runCliNonInteractive(['init'], projectDir, env)
+      expect(initResult.exitCode).toBe(0)
+
+      const scaffolded = await fs.promises.readFile(policyPath, 'utf8')
+      expect(scaffolded).toContain(
+        '# yaml-language-server: $schema=https://raw.githubusercontent.com/mike-north/attest-it/main/schemas/v1/policy.schema.json',
+      )
+      expect(scaffolded).toContain('# attest-it policy configuration (trust-critical)')
+      expect(scaffolded).toContain('# Team members who can sign seals.')
+
+      // 2. identity create: the identity `team join` will add.
+      const createResult = await runCliNonInteractive(
+        ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+        projectDir,
+        env,
+      )
+      expect(createResult.exitCode).toBe(0)
+      const publicKey = await readCreatedPublicKey(homeDir, 'test-user')
+      void publicKey // identity create's own output is sufficient; join re-reads it internally
+
+      // 3. team join: the documented, required onboarding step that
+      // previously rewrote policy.yaml as a bare, comment-free YAML dump.
+      const joinResult = await runCliNonInteractive(['team', 'join'], projectDir, env)
+      expect(joinResult.exitCode).toBe(0)
+      expect(joinResult.stdout).toContain('added successfully')
+
+      const afterJoin = await fs.promises.readFile(policyPath, 'utf8')
+
+      // The schema directive must survive -- this is the exact regression
+      // reported in issue #102 (editor tooling silently loses its `$schema`
+      // hint the moment a teammate runs `team join`).
+      expect(afterJoin).toContain(
+        '# yaml-language-server: $schema=https://raw.githubusercontent.com/mike-north/attest-it/main/schemas/v1/policy.schema.json',
+      )
+      // Representative header and onboarding-example comments must survive.
+      expect(afterJoin).toContain('# attest-it policy configuration (trust-critical)')
+      expect(afterJoin).toContain('This file defines WHO may sign and WHAT is protected.')
+      expect(afterJoin).toContain('# Team members who can sign seals.')
+      expect(afterJoin).toContain('# Gates define what code areas require a seal and who can sign.')
+
+      // ...and the mutation itself must have actually happened.
+      expect(afterJoin).toContain('test-user:')
+    },
+    CLI_CALL_TIMEOUT_MS * 3,
+  )
+
+  it(
+    'keeps preserving comments across a second mutating command (`team add`) on the same file',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir }
+      const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+
+      await runCliNonInteractive(['init'], projectDir, env)
+      await runCliNonInteractive(
+        ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+        projectDir,
+        env,
+      )
+      await runCliNonInteractive(['team', 'join'], projectDir, env)
+
+      const addResult = await runCliNonInteractive(
+        [
+          'team',
+          'add',
+          '--slug',
+          'bob',
+          '--name',
+          'Bob',
+          '--public-key',
+          'oB5OUxsnFR7GdTPURp9loSGinbcb6EKDTrFGKl2VTPk=',
+        ],
+        projectDir,
+        env,
+      )
+      expect(addResult.exitCode).toBe(0)
+
+      const afterAdd = await fs.promises.readFile(policyPath, 'utf8')
+      expect(afterAdd).toContain(
+        '# yaml-language-server: $schema=https://raw.githubusercontent.com/mike-north/attest-it/main/schemas/v1/policy.schema.json',
+      )
+      expect(afterAdd).toContain('# Gates define what code areas require a seal and who can sign.')
+      expect(afterAdd).toContain('test-user:')
+      expect(afterAdd).toContain('bob:')
+    },
+    CLI_CALL_TIMEOUT_MS * 4,
+  )
+})

--- a/packages/cli/test/team-add.test.ts
+++ b/packages/cli/test/team-add.test.ts
@@ -7,7 +7,7 @@ import * as core from '@attest-it/core'
 import type { PolicyConfig } from '@attest-it/core'
 import * as fs from 'node:fs/promises'
 import * as prompts from '@inquirer/prompts'
-import YAML from 'yaml'
+import YAML, { parseDocument, stringify as stringifyYaml } from 'yaml'
 
 /** Parse the policy YAML written by the most recent fs.writeFile call. */
 function getWrittenPolicyYaml(): string {
@@ -39,7 +39,7 @@ vi.mock('@attest-it/core', async () => {
   return {
     ...actual,
     findPolicyPath: vi.fn(),
-    parsePolicyContent: vi.fn(),
+    loadEditablePolicy: vi.fn(),
   }
 })
 
@@ -62,9 +62,22 @@ const mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
   throw new Error('process.exit called')
 })
 
+/**
+ * `loadEditablePolicy` is mocked directly (rather than the lower-level
+ * `parsePolicyContent`) because it now owns parsing *and* keeps a parsed YAML
+ * `Document` around for comment-preserving writes -- the real
+ * `serializeEditablePolicy` (unmocked) is exercised against that document, so
+ * the backing document is seeded from `stringifyYaml(policy)` to match what a
+ * real read of `path` would have produced.
+ */
 function mockPolicy(policy: PolicyConfig, path = '/test/policy.yaml'): void {
   vi.mocked(core.findPolicyPath).mockReturnValue(path)
-  vi.mocked(core.parsePolicyContent).mockReturnValue(policy)
+  vi.mocked(core.loadEditablePolicy).mockReturnValue({
+    policy,
+    path,
+    format: 'yaml',
+    document: parseDocument(stringifyYaml(policy)),
+  })
 }
 
 const BASE_POLICY: PolicyConfig = {

--- a/packages/cli/test/team-join.test.ts
+++ b/packages/cli/test/team-join.test.ts
@@ -7,7 +7,7 @@ type PolicyGateConfig = NonNullable<PolicyConfig['gates']>[string]
 import * as fs from 'node:fs/promises'
 import * as fsSync from 'node:fs'
 import * as prompts from '@inquirer/prompts'
-import YAML from 'yaml'
+import YAML, { parseDocument, stringify as stringifyYaml } from 'yaml'
 
 // Mock the core module
 vi.mock('@attest-it/core', async () => {
@@ -17,7 +17,7 @@ vi.mock('@attest-it/core', async () => {
     loadLocalConfig: vi.fn(),
     getActiveIdentity: vi.fn(),
     findPolicyPath: vi.fn(),
-    parsePolicyContent: vi.fn(),
+    loadEditablePolicy: vi.fn(),
   }
 })
 
@@ -65,10 +65,22 @@ function makeGate(
 /**
  * Configure the mocks so that `loadPolicyForEdit()` resolves to the given
  * policy, as if it had been read from `/test/policy.yaml`.
+ *
+ * `loadEditablePolicy` is mocked directly (rather than the lower-level
+ * `parsePolicyContent`) because it now owns parsing *and* keeps a parsed YAML
+ * `Document` around for comment-preserving writes -- the real
+ * `serializeEditablePolicy` (unmocked) is exercised against that document, so
+ * the backing document is seeded from `stringifyYaml(policy)` to match what a
+ * real read of `path` would have produced.
  */
 function mockPolicy(policy: PolicyConfig, path = '/test/policy.yaml'): void {
   vi.mocked(core.findPolicyPath).mockReturnValue(path)
-  vi.mocked(core.parsePolicyContent).mockReturnValue(policy)
+  vi.mocked(core.loadEditablePolicy).mockReturnValue({
+    policy,
+    path,
+    format: 'yaml',
+    document: parseDocument(stringifyYaml(policy)),
+  })
 }
 
 const PUBLIC_KEY = 'dGVzdHB1YmxpY2tleXRlc3RwdWJsaWNrZXl0ZXN0cHVibGlja2V5'

--- a/packages/cli/test/team-remove.test.ts
+++ b/packages/cli/test/team-remove.test.ts
@@ -15,6 +15,7 @@ import * as core from '@attest-it/core'
 import type { PolicyConfig } from '@attest-it/core'
 import * as fs from 'node:fs/promises'
 import * as prompts from '@inquirer/prompts'
+import { parseDocument, stringify as stringifyYaml } from 'yaml'
 import { ExitCode } from '../src/utils/exit-codes.js'
 
 vi.mock('@attest-it/core', async () => {
@@ -22,7 +23,7 @@ vi.mock('@attest-it/core', async () => {
   return {
     ...actual,
     findPolicyPath: vi.fn(),
-    parsePolicyContent: vi.fn(),
+    loadEditablePolicy: vi.fn(),
     readSealsSync: vi.fn(),
   }
 })
@@ -45,9 +46,22 @@ const mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
   throw new Error('process.exit called')
 })
 
+/**
+ * `loadEditablePolicy` is mocked directly (rather than the lower-level
+ * `parsePolicyContent`) because it now owns parsing *and* keeps a parsed YAML
+ * `Document` around for comment-preserving writes -- the real
+ * `serializeEditablePolicy` (unmocked) is exercised against that document, so
+ * the backing document is seeded from `stringifyYaml(policy)` to match what a
+ * real read of `path` would have produced.
+ */
 function mockPolicy(policy: PolicyConfig, path = '/test/policy.yaml'): void {
   vi.mocked(core.findPolicyPath).mockReturnValue(path)
-  vi.mocked(core.parsePolicyContent).mockReturnValue(policy)
+  vi.mocked(core.loadEditablePolicy).mockReturnValue({
+    policy,
+    path,
+    format: 'yaml',
+    document: parseDocument(stringifyYaml(policy)),
+  })
 }
 
 const BASE_POLICY: PolicyConfig = {

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Document } from 'yaml';
 import { SecretBackend } from 'vaultkeeper';
 import { z } from 'zod';
 
@@ -119,6 +120,18 @@ export interface Ed25519KeyPair {
     privateKey: string;
     publicKey: string;
 }
+
+// @public
+export type EditablePolicy = {
+    document: Document.Parsed;
+    format: 'yaml';
+    path: string;
+    policy: PolicyConfig;
+} | {
+    format: 'json';
+    path: string;
+    policy: PolicyConfig;
+};
 
 // @public
 export type FailureClass = 'expired' | 'fingerprint-mismatch' | 'malformed' | 'unauthorized-signer' | 'unsealed' | 'untrusted-config';
@@ -371,6 +384,9 @@ export function listPackageFiles(packages: string[], ignore?: string[], baseDir?
 
 // @public
 export function listYubiKeyDevices(): Promise<YubiKeyInfo[]>;
+
+// @public
+export function loadEditablePolicy(path: string, content: string): EditablePolicy;
 
 // @public
 export function loadLocalConfig(configPath?: string): Promise<LocalConfig | null>;
@@ -848,6 +864,9 @@ export interface SealVerificationResult {
     seal?: Seal;
     state: VerificationState;
 }
+
+// @public
+export function serializeEditablePolicy(editable: EditablePolicy, updatedPolicy: PolicyConfig): string;
 
 // @public
 export function setAttestItHomeDir(dir: null | string): void;

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -11,6 +11,10 @@
 export type { PolicyConfig } from './policy-schema.js'
 export { PolicyValidationError, parsePolicyContent, policySchema } from './policy-schema.js'
 
+// Comment-preserving policy read/write round-trip
+export type { EditablePolicy } from './policy-writer.js'
+export { loadEditablePolicy, serializeEditablePolicy } from './policy-writer.js'
+
 // Operational configuration
 export type { OperationalConfig } from './operational-schema.js'
 export {

--- a/packages/core/src/config/policy-writer.ts
+++ b/packages/core/src/config/policy-writer.ts
@@ -1,0 +1,174 @@
+/**
+ * Comment-preserving read/write round-trip for policy.yaml.
+ *
+ * `policy.yaml` is scaffolded by `attest-it init` with a
+ * `# yaml-language-server: $schema=...` directive, a trust-model header, and
+ * commented onboarding examples. Commands that mutate the file in place
+ * (`team join`, `team add`, `team remove`, and any future policy-mutating
+ * command) must not silently strip that human-authored content on write.
+ *
+ * This module provides a document/AST-level edit path -- using the `yaml`
+ * package's `Document` API -- instead of the "parse to plain object, then
+ * `stringify()` the whole thing" pattern that destroys comments.
+ *
+ * @module
+ */
+
+import { Document, parseDocument } from 'yaml'
+import { parsePolicyContent, type PolicyConfig } from './policy-schema.js'
+
+/**
+ * A policy file loaded for editing, retaining enough state (a parsed YAML
+ * `Document` for `.yaml`/`.yml` files) to write updates back without losing
+ * comments.
+ * @public
+ */
+export type EditablePolicy =
+  | {
+      policy: PolicyConfig
+      path: string
+      format: 'yaml'
+      document: Document.Parsed
+    }
+  | {
+      policy: PolicyConfig
+      path: string
+      format: 'json'
+    }
+
+/**
+ * Load a policy file's content for editing.
+ *
+ * For YAML policy files, this also parses a `Document` so that
+ * {@link serializeEditablePolicy} can perform a comment-preserving write.
+ * JSON policy files have no comments to preserve, so no document is kept.
+ *
+ * @param path - Path the policy content was read from (used to pick the
+ * format and returned unchanged for later writes).
+ * @param content - Raw file content, as read from `path`.
+ * @returns The parsed, validated policy plus the state needed to write it
+ * back losslessly.
+ * @throws {@link PolicyValidationError} If validation fails.
+ * @public
+ */
+export function loadEditablePolicy(path: string, content: string): EditablePolicy {
+  const format = path.endsWith('.json') ? 'json' : 'yaml'
+  const policy = parsePolicyContent(content, format)
+
+  if (format === 'json') {
+    return { policy, path, format }
+  }
+
+  return { policy, path, format, document: parseDocument(content) }
+}
+
+/**
+ * Deep-equality for JSON-shaped values (arrays/plain objects/primitives).
+ */
+function deepEqualJson(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((item, i) => deepEqualJson(item, b[i]))
+    )
+  }
+  if (isPlainRecord(a) && isPlainRecord(b)) {
+    const aKeys = Object.keys(a)
+    const bKeys = Object.keys(b)
+    if (aKeys.length !== bKeys.length) {
+      return false
+    }
+    return aKeys.every((key) => Object.hasOwn(b, key) && deepEqualJson(a[key], b[key]))
+  }
+  return false
+}
+
+/**
+ * A plain JSON-shaped object (not an array, not a class instance).
+ */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  )
+}
+
+/**
+ * Recursively set only the leaves that changed between `before` and `after`
+ * onto `document` at `path`, leaving every untouched node -- and therefore
+ * every comment attached to it -- exactly as it was.
+ *
+ * Recursion descends through plain objects (so an unrelated sibling, like an
+ * untouched gate's `name`/`description`/`fingerprint`, is never re-written
+ * just because a *different* field on the same object changed). Arrays and
+ * primitives are replaced wholesale once a difference is found, since the
+ * `yaml` package has no meaningful notion of a "diff" within a scalar or
+ * array value.
+ */
+function applyPolicyDiff(
+  document: Document.Parsed,
+  path: (string | number)[],
+  before: unknown,
+  after: unknown,
+): void {
+  if (deepEqualJson(before, after)) {
+    return
+  }
+
+  if (isPlainRecord(before) && isPlainRecord(after)) {
+    const keys = new Set([...Object.keys(before), ...Object.keys(after)])
+    for (const key of keys) {
+      applyPolicyDiff(document, [...path, key], before[key], after[key])
+    }
+    return
+  }
+
+  if (after === undefined) {
+    document.deleteIn(path)
+  } else {
+    document.setIn(path, after)
+  }
+}
+
+/**
+ * Serialize an updated policy for writing back to disk.
+ *
+ * For YAML policy files, this recursively diffs `editable.policy` against
+ * `updatedPolicy` and sets only the leaves that actually changed on the
+ * original parsed `Document` -- an AST-level edit -- rather than
+ * re-serializing the whole object from scratch. A comment survives unless
+ * it's attached to a node that was itself replaced by the diff; in
+ * particular, the leading `# yaml-language-server:` schema directive and
+ * trust-model header (which precede every top-level key) are never touched,
+ * and sibling fields on a partially-changed object (e.g. an unrelated gate's
+ * `name`/`fingerprint` when only its `authorizedSigners` array changed) keep
+ * their own comments too. This also keeps the file's shape stable so
+ * security-reviewed diffs stay reviewable (issue #102).
+ *
+ * JSON policy files have no comments to preserve, so they're re-serialized
+ * directly.
+ *
+ * @param editable - The policy as loaded by {@link loadEditablePolicy}.
+ * @param updatedPolicy - The new policy value to persist.
+ * @returns The file content to write back to `editable.path`.
+ * @public
+ */
+export function serializeEditablePolicy(
+  editable: EditablePolicy,
+  updatedPolicy: PolicyConfig,
+): string {
+  if (editable.format === 'json') {
+    return JSON.stringify(updatedPolicy, null, 2) + '\n'
+  }
+
+  applyPolicyDiff(editable.document, [], editable.policy, updatedPolicy)
+
+  return String(editable.document)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,10 @@ export {
   policySchema,
   parsePolicyContent,
   PolicyValidationError,
+  // Comment-preserving policy read/write round-trip
+  type EditablePolicy,
+  loadEditablePolicy,
+  serializeEditablePolicy,
   // Operational config
   type OperationalConfig,
   operationalSchema,

--- a/packages/core/test/config/policy-writer.test.ts
+++ b/packages/core/test/config/policy-writer.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the comment-preserving policy.yaml read/write round-trip
+ * (issue #102).
+ *
+ * `policy.yaml` is scaffolded with a `# yaml-language-server:` schema
+ * directive, a trust-model header, and commented onboarding examples. Prior
+ * to this fix, any command that mutated the file (`team join`/`add`/`remove`)
+ * parsed it to a plain object and re-`stringify()`d the whole thing, silently
+ * discarding every comment. These tests assert the replacement
+ * `loadEditablePolicy`/`serializeEditablePolicy` round-trip preserves
+ * comments via a document/AST-level edit instead.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parseDocument } from 'yaml'
+import {
+  loadEditablePolicy,
+  serializeEditablePolicy,
+  type EditablePolicy,
+} from '../../src/config/policy-writer.js'
+import { PolicyValidationError } from '../../src/config/policy-schema.js'
+import type { PolicyConfig } from '../../src/config/policy-schema.js'
+
+const SCHEMA_DIRECTIVE =
+  '# yaml-language-server: $schema=https://raw.githubusercontent.com/mike-north/attest-it/main/schemas/v1/policy.schema.json'
+
+const ANNOTATED_POLICY_YAML = `${SCHEMA_DIRECTIVE}
+# attest-it policy configuration (trust-critical)
+#
+# This file defines WHO may sign and WHAT is protected.
+
+version: 1
+
+settings:
+  # How long a seal remains valid (in days)
+  maxAgeDays: 30
+
+# Team members who can sign seals.
+# Add members with: attest-it team join (for yourself) or team add (for others)
+#
+# team:
+#   mike-north:
+#     name: Mike North
+#     publicKey: Fzpq2YHEvpA2BwjGnW5ZcZF+WyUbsiyTFFMjPEK3SfA=
+
+team: {}
+
+# Gates define what code areas require a seal and who can sign.
+#
+# Example:
+#
+# gates:
+#   cli-interactive:
+#     name: CLI Interactive Tests
+#     authorizedSigners:
+#       - mike-north
+
+gates:
+  ci-gate:
+    name: CI Gate
+    description: Automated CI checks
+    authorizedSigners:
+      - carol
+    fingerprint:
+      paths:
+        - src
+    maxAge: 90d # keep seals fresh
+`
+
+function loadAnnotatedPolicy(): EditablePolicy {
+  return loadEditablePolicy('/project/.attest-it/policy.yaml', ANNOTATED_POLICY_YAML)
+}
+
+describe('loadEditablePolicy', () => {
+  it('parses and validates YAML policy content, keeping a Document for later writes', () => {
+    const editable = loadAnnotatedPolicy()
+
+    expect(editable.format).toBe('yaml')
+    expect(editable.policy.version).toBe(1)
+    expect(editable.policy.team).toEqual({})
+    if (editable.format === 'yaml') {
+      expect(editable.document.toString()).toContain(SCHEMA_DIRECTIVE)
+    }
+  })
+
+  it('parses JSON policy content without keeping a Document (no comments to preserve)', () => {
+    const json = JSON.stringify({
+      version: 1,
+      settings: { maxAgeDays: 30 },
+      team: {},
+    })
+
+    const editable = loadEditablePolicy('/project/.attest-it/policy.json', json)
+
+    expect(editable.format).toBe('json')
+    expect(editable.policy.version).toBe(1)
+    expect('document' in editable).toBe(false)
+  })
+
+  // Negative test: malformed policy content must fail validation rather than
+  // silently producing a garbage EditablePolicy that a later write would
+  // persist.
+  it('throws PolicyValidationError for structurally invalid policy content', () => {
+    expect(() =>
+      loadEditablePolicy('/project/.attest-it/policy.yaml', 'team: not-an-object'),
+    ).toThrow(PolicyValidationError)
+  })
+})
+
+describe('serializeEditablePolicy (YAML)', () => {
+  it('preserves the schema directive and header comments when only `team` changes', () => {
+    const editable = loadAnnotatedPolicy()
+    const updated: PolicyConfig = {
+      ...editable.policy,
+      team: {
+        alice: { name: 'Alice', publicKey: 'pk-alice', publicKeyAlgorithm: 'ed25519' },
+      },
+    }
+
+    const output = serializeEditablePolicy(editable, updated)
+
+    expect(output).toContain(SCHEMA_DIRECTIVE)
+    expect(output).toContain('# attest-it policy configuration (trust-critical)')
+    expect(output).toContain('# Team members who can sign seals.')
+    expect(output).toContain('#   mike-north:')
+    expect(output).toContain('alice:')
+  })
+
+  it('preserves comments nested inside an unrelated, unchanged section', () => {
+    const editable = loadAnnotatedPolicy()
+    const updated: PolicyConfig = {
+      ...editable.policy,
+      team: {
+        alice: { name: 'Alice', publicKey: 'pk-alice', publicKeyAlgorithm: 'ed25519' },
+      },
+    }
+
+    const output = serializeEditablePolicy(editable, updated)
+
+    // `settings` was never touched by this write -- its nested comment must
+    // survive even though the write replaced a *different* top-level key.
+    expect(output).toContain('# How long a seal remains valid (in days)')
+  })
+
+  it('preserves sibling fields and their comments on a gate whose authorizedSigners changed', () => {
+    const editable = loadAnnotatedPolicy()
+    const updated: PolicyConfig = {
+      ...editable.policy,
+      gates: {
+        'ci-gate': {
+          ...(editable.policy.gates?.['ci-gate'] ?? {
+            name: 'CI Gate',
+            authorizedSigners: [],
+            fingerprint: { paths: ['src'] },
+            maxAge: '90d',
+          }),
+          authorizedSigners: ['carol', 'alice'],
+        },
+      },
+    }
+
+    const output = serializeEditablePolicy(editable, updated)
+
+    // Only authorizedSigners should change on ci-gate -- its other fields and
+    // their own trailing comment must be left exactly as they were.
+    expect(output).toContain('description: Automated CI checks')
+    expect(output).toContain('maxAge: 90d # keep seals fresh')
+    expect(output).toContain('- alice')
+  })
+
+  it('leaves the document byte-for-byte unchanged (aside from formatting) when nothing changed', () => {
+    const editable = loadAnnotatedPolicy()
+
+    const output = serializeEditablePolicy(editable, editable.policy)
+
+    expect(output).toContain(SCHEMA_DIRECTIVE)
+    expect(output).toContain('# How long a seal remains valid (in days)')
+    expect(output).toContain('#   mike-north:')
+  })
+
+  it('removes a deleted top-level field from the document', () => {
+    const editable = loadEditablePolicy(
+      '/project/.attest-it/policy.yaml',
+      `${SCHEMA_DIRECTIVE}\nversion: 1\nsettings:\n  maxAgeDays: 30\nminVersion: '0.1.0'\nteam: {}\n`,
+    )
+    const { minVersion: _minVersion, ...rest } = editable.policy
+    const updated: PolicyConfig = rest
+
+    const output = serializeEditablePolicy(editable, updated)
+
+    expect(output).not.toContain('minVersion')
+  })
+})
+
+describe('serializeEditablePolicy (JSON)', () => {
+  it('re-serializes JSON directly (no comments to preserve)', () => {
+    const json = JSON.stringify({ version: 1, settings: { maxAgeDays: 30 }, team: {} })
+    const editable = loadEditablePolicy('/project/.attest-it/policy.json', json)
+    const updated: PolicyConfig = {
+      ...editable.policy,
+      team: { bob: { name: 'Bob', publicKey: 'pk-bob', publicKeyAlgorithm: 'ed25519' } },
+    }
+
+    const output = serializeEditablePolicy(editable, updated)
+    const parsed: unknown = JSON.parse(output)
+
+    expect(parsed).toMatchObject({ team: { bob: { name: 'Bob' } } })
+  })
+})
+
+describe('sanity: yaml Document.setIn preserves unrelated comments', () => {
+  // A direct, minimal check of the `yaml` package behavior this module
+  // depends on -- protects against a future `yaml` upgrade silently changing
+  // that contract out from under `serializeEditablePolicy`.
+  it('keeps a leading comment on an untouched key after setIn on a different key', () => {
+    const doc = parseDocument('# leading comment\nfoo: 1\nbar: 2\n')
+    doc.setIn(['bar'], 3)
+    expect(doc.toString()).toContain('# leading comment')
+  })
+})


### PR DESCRIPTION
## Summary

`team join`/`team add`/`team remove` parsed `.attest-it/policy.yaml` into a plain object and re-`stringify()`d the whole file on write, silently discarding every human-authored comment -- including the `# yaml-language-server: $schema=...` directive and trust-model header `init` scaffolds. This fixes it with a comment-preserving YAML round-trip.

- **`@attest-it/core`**: adds `loadEditablePolicy`/`serializeEditablePolicy` (`packages/core/src/config/policy-writer.ts`), a document/AST-level edit path using the `yaml` package's `Document` API. `serializeEditablePolicy` recursively diffs the old and new policy and only `setIn`/`deleteIn`s the leaves that actually changed on the original parsed `Document` -- so a comment survives unless it's attached to a node that was itself replaced. This also keeps sibling fields on a partially-changed object (e.g. an unrelated gate's `name`/`fingerprint` when only its `authorizedSigners` changed) byte-identical, which keeps the file's shape stable for security review.
- **`@attest-it/cli`**: `team join`, `team add`, and `team remove` (the only commands that write `policy.yaml` after `init`) are routed through `loadPolicyForEdit`/`writePolicyEdit` in `packages/cli/src/commands/team/utils.ts`, which now wrap the new core functions instead of `parsePolicyContent` + `stringify()`.
- **Bonus fix surfaced by the new diff-based writer**: `addTeamMemberToPolicy` and `team remove`'s gate-authorization cleanup both mutated `policy.gates`/`gate.authorizedSigners` *in place*. Since `{ ...policy, team: {...} }` keeps the same `gates` object reference, that mutation corrupted the "before" snapshot the new diff depends on to detect changes (every gate looked unchanged even when `authorizedSigners` had just been pushed into). Both now build an entirely new `gates` object instead.

Full comment preservation was achieved -- no fallback (re-emitting only the header) was needed, and no `getting-started.md` caveat about comments being normalized away is required.

### Policy.yaml writers found and routed through the preserving path

Searched every reference to `policy.yaml`/`policyPath`/`writeFileSync`/`writeFile` across `packages/cli` and `packages/core`. Writers found:

| Writer | Status |
|---|---|
| `team join` (`packages/cli/src/commands/team/join.ts`) | routed through `writePolicyEdit` |
| `team add` (`packages/cli/src/commands/team/add.ts`) | routed through `writePolicyEdit` |
| `team remove` (`packages/cli/src/commands/team/remove.ts`) | routed through `writePolicyEdit` |
| `init` (fresh scaffold, `packages/cli/src/commands/init.ts`) | unchanged -- writes the commented template directly, no pre-existing file to preserve |
| `init --migrate` (`runMigrate` in `init.ts`) | unchanged -- writes a fresh header + converted unified config, no pre-existing policy.yaml to preserve |
| `@attest-it/github-action` | read-only, never writes `policy.yaml` |

No other command mutates `policy.yaml`.

## Acceptance criteria mapping

1. **Commands that mutate `policy.yaml` preserve existing comments and the schema directive via a document/AST-level edit, not parse-to-object-then-dump** -- covered by `packages/core/test/config/policy-writer.test.ts` (`serializeEditablePolicy (YAML)` describe block: schema directive/header survival, nested-comment survival in an untouched section, sibling-field/comment survival on a partially-changed gate) and the mandatory regression test below.
2. **Fallback only if infeasible (re-emit header + document getting-started.md)** -- not applicable; full preservation was achieved, so no fallback or doc caveat was added.
3. **Keep file shape stable so security-reviewed diffs stay reviewable** -- covered by `packages/core/test/config/policy-writer.test.ts`'s "preserves sibling fields and their comments on a gate whose authorizedSigners changed" test, which asserts unrelated fields (`description`, `maxAge` with its own trailing comment) on the same gate are left untouched.
4. **Regression test: scaffold via `init`, run `team join`, assert schema directive + representative comments survive** -- covered by `packages/cli/test/integration/policy-comment-preservation.integration.test.ts`, which drives the real built CLI as subprocesses (`init` -> `identity create` -> `team join`, plus a second test chaining `team add`) and asserts on the actual file content. Verified to **fail against the pre-fix code** (confirmed manually by reverting the writer files and re-running: the schema directive/header/example comments are absent from `policy.yaml` after `team join`) and pass with the fix.

## Test plan

- [x] `packages/core/test/config/policy-writer.test.ts` (new): unit tests for `loadEditablePolicy`/`serializeEditablePolicy` -- YAML comment preservation (schema directive, nested unrelated-section comments, sibling-field preservation on a partial gate change, no-op write), JSON re-serialization, and negative tests (malformed policy content throws `PolicyValidationError`).
- [x] `packages/cli/test/integration/policy-comment-preservation.integration.test.ts` (new, mandatory regression test): real subprocess CLI flow (`init` -> `identity create` -> `team join` -> `team add`), asserting the schema directive and representative header/example comments survive across both mutating commands. Confirmed to fail pre-fix.
- [x] Updated `packages/cli/test/team-join.test.ts`, `team-add.test.ts`, `team-remove.test.ts` to mock at the new `loadEditablePolicy` boundary (previously mocked `parsePolicyContent`, which is no longer the CLI's direct entry point) -- all existing assertions preserved and passing.
- [x] Full `pnpm test` (all 4 packages: core, cli, attest-it, github-action) green.
- [x] Full `pnpm check:packages` (lint + typecheck + api-report) green across all packages; `packages/core/api-report/core.api.md` regenerated for the new public `EditablePolicy`/`loadEditablePolicy`/`serializeEditablePolicy` exports.
- [x] `prettier --check .` clean.

Refs #102
