### PR TITLE
fix: make CANCELLED exit code reachable for declined prompts and Ctrl-C

### DIFF
--- a/.changeset/fix-cancelled-exit-code-reachability.md
+++ b/.changeset/fix-cancelled-exit-code-reachability.md
@@ -1,0 +1,29 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Fix `CANCELLED` (4) exit code being unreachable, and reconcile the exit-code docs with reality.
+
+**Behavior change — a declined seal or a Ctrl-C now exits `CANCELLED` (4) instead of `SUCCESS`
+(0) or an uncaught-signal termination.** `AI_ASSISTANT_GUIDE.md` and `docs/configuration.md`
+(from #98) documented `CANCELLED` (4) as reachable by declining a confirmation prompt or by
+Ctrl-C, but neither path actually produced it:
+
+- **Declining `attest-it run`'s seal prompt** (typing `n` at "Create seal for gate 'x'?") now
+  exits `CANCELLED` (4). Previously it logged "Seal creation skipped" and fell through to the
+  normal "Suite completed!" success path with an implicit exit `0` -- a CI script reading the
+  exit code could not distinguish a declined seal from a successful one.
+- **Ctrl-C (`SIGINT`) now exits `CANCELLED` (4) everywhere in the CLI**, not just while
+  `@inquirer/core`'s own force-close detection happens to be active. The CLI installs a
+  process-wide `SIGINT` handler for its entire lifetime. Previously, a real SIGINT delivered
+  outside that narrow window fell through to Node's default, uncaught-signal termination
+  (observed by a parent shell as the conventional 130), not a clean `process.exit(4)`.
+- **Missing a required flag with no interactive terminal available (e.g.
+  `run --suite x < /dev/null` without `--yes`) remains `CONFIG_ERROR` (3), unchanged.** No
+  prompt ever starts in this case, so there's nothing to cancel -- the docs previously implied
+  this was also `CANCELLED`; they now correctly describe it as a usage error, the same class as
+  any other missing-required-input mistake.
+
+The exit-code docs-pin test (`packages/cli/test/exit-codes.test.ts`, from #81/#98) is extended
+to assert the prose itself, not just the table, so this can't silently drift again.

--- a/AI_ASSISTANT_GUIDE.md
+++ b/AI_ASSISTANT_GUIDE.md
@@ -218,10 +218,26 @@ same thing**: `verify` uses them to report gate validity; `status` uses only `SU
 
 **A cancelled prompt is always `CANCELLED` (4), never `CONFIG_ERROR`.** This applies to every
 interactive confirmation in the CLI (`identity create`/`remove`, `init`, `team add`/`join`/`remove`,
-`run`) — whether the user explicitly declines, or the prompt is interrupted/force-closed (e.g.
-Ctrl-C, or a piped stdin that closes mid-prompt). Prior to issue #95, a force-closed prompt fell
-through to `CONFIG_ERROR` with `@inquirer/core`'s raw, unpolished message; it's now reported as a
-clean `Cancelled` line under the documented `CANCELLED` code.
+`run`) — whether the user explicitly declines (e.g. types `n` at "Create seal for gate 'x'?"), or
+the prompt is interrupted/force-closed (e.g. `@inquirer/core`'s own force-close detection, or a
+piped stdin that closes mid-prompt). Prior to issue #95, a force-closed prompt fell through to
+`CONFIG_ERROR` with `@inquirer/core`'s raw, unpolished message; prior to issue #100, a _declined_
+prompt fell through to `SUCCESS` (0) instead of `CANCELLED`. Both are now reported as a clean
+`Cancelled` line under the documented `CANCELLED` code.
+
+**Ctrl-C (`SIGINT`) is always `CANCELLED` (4), everywhere in the CLI, not the shell's
+conventional 130.** The CLI installs a process-wide `SIGINT` handler for its entire lifetime (see
+`registerSigintHandler` in `packages/cli/src/index.ts`) precisely so this holds during a prompt
+and not just when `@inquirer/core`'s own force-close detection happens to catch it. Do not tell a
+user that pressing Ctrl-C exits 130 — it doesn't.
+
+**Missing a required flag with no interactive terminal available is `CONFIG_ERROR` (3), not
+`CANCELLED`.** For example, `run --suite x` (no `--yes`) or `identity remove x` (no `--yes`) with
+stdin piped from `/dev/null`: the CLI detects there is no TTY to prompt on _before_ any prompt
+starts, and fails fast with an error naming the missing flag. No prompt ever ran, so there is
+nothing to "cancel" — this is a usage error, the same class as any other invalid invocation, so it
+gets `CONFIG_ERROR` like other configuration/usage problems. Do not suggest this case should be
+`CANCELLED`; point the user at the named flag instead.
 
 **A dirty working tree is `DIRTY_WORKING_TREE` (6), never `CONFIG_ERROR`.** `run` refuses to
 execute a suite (and create its seal) when `git status --porcelain` reports uncommitted changes,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -504,8 +504,17 @@ across commands, but `verify` and `status` use them differently:
 | 5    | MISSING_KEY        | Required private key file is missing                                                   |
 | 6    | DIRTY_WORKING_TREE | `run` refused because the git working tree has uncommitted changes                     |
 
-**A cancelled prompt is `CANCELLED` (4), never `CONFIG_ERROR`** — whether declined or
-force-closed/interrupted (e.g. Ctrl-C, or a piped stdin that closes mid-prompt).
+**A cancelled prompt is `CANCELLED` (4), never `CONFIG_ERROR`** — whether the user explicitly
+declines a confirmation (e.g. types `n` at "Create seal for gate 'x'?"), presses Ctrl-C, or the
+prompt is force-closed/interrupted another way (e.g. a piped stdin that closes mid-prompt).
+Ctrl-C is `CANCELLED` (4) everywhere in the CLI, not the shell's conventional 130 — a process-wide
+`SIGINT` handler (`registerSigintHandler` in `packages/cli/src/index.ts`) guarantees this for the
+whole process lifetime, not just while `@inquirer/core`'s own force-close detection is active.
+
+**A missing required flag with no interactive terminal available is `CONFIG_ERROR` (3), not
+`CANCELLED`.** For example, `attest-it run --suite x < /dev/null` without `--yes` fails fast with
+an error naming the missing flag _before_ any prompt starts — there's nothing to cancel, so it's
+a usage/configuration error like any other, not a cancellation.
 
 **A dirty working tree is `DIRTY_WORKING_TREE` (6), never `CONFIG_ERROR`.** `run` refuses to run
 a suite when the working tree has uncommitted changes (unless `ATTEST_IT_ALLOW_DIRTY` is set) —

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     },
     "onlyBuiltDependencies": [
       "esbuild",
+      "node-pty",
       "nx"
     ]
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "execa": "^9.6.1",
     "fixturify-project": "^7.1.3",
     "ink-testing-library": "^4.0.0",
+    "node-pty": "^1.1.0",
     "tsup": "^8.3.5",
     "tsx": "^4.21.0",
     "typescript": "5.8.3",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -407,6 +407,12 @@ async function runSingleSuite(
  * `--yes`, this fails fast instead of hanging on a prompt that can never
  * resolve. See issue #80.
  *
+ * A user who explicitly declines the prompt exits {@link ExitCode.CANCELLED}
+ * rather than falling through to the caller's normal "Suite completed!"
+ * success path -- tests passing is not the same as attestation succeeding,
+ * and a CI script must be able to tell a declined seal apart from
+ * `SUCCESS` (0). See issue #100.
+ *
  * @param suiteName - Name of the suite that was executed
  * @param gateId - ID of the gate linked to the suite
  * @param config - Configuration object
@@ -462,8 +468,11 @@ async function promptForSeal(
   }
 
   if (!shouldSeal) {
-    log('Seal creation skipped')
-    return
+    // The user was explicitly asked and declined -- this is a cancellation,
+    // not a skip. Exiting SUCCESS here would let a CI script read a declined
+    // seal as a passing attestation. See issue #100.
+    log('Cancelled')
+    process.exit(ExitCode.CANCELLED)
   }
 
   try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,9 +9,10 @@ import { identityCommand } from './commands/identity/index.js'
 import { whoamiCommand } from './commands/whoami.js'
 import { teamCommand } from './commands/team/index.js'
 import { completionCommand, createCompletionServerCommand } from './commands/completion.js'
-import { setOutputOptions, initTheme } from './utils/output.js'
+import { setOutputOptions, initTheme, log } from './utils/output.js'
 import { setAttestItHomeDir } from '@attest-it/core'
 import { getPackageVersion } from './utils/version.js'
+import { ExitCode } from './utils/exit-codes.js'
 
 const program = new Command()
 
@@ -54,7 +55,43 @@ function processHomeDirOption(): void {
   }
 }
 
+/**
+ * Register a process-wide `SIGINT` (Ctrl-C) handler that exits
+ * {@link ExitCode.CANCELLED} with a clean message.
+ *
+ * @remarks
+ * Without an explicit `process.on('SIGINT', ...)` listener, Node's default
+ * action on a real SIGINT is to terminate the process immediately -- which a
+ * parent shell typically reports as exit code 130 (128 + signal 2), not a
+ * clean `process.exit()`. `@inquirer/core`'s prompts install their own
+ * `SIGINT` handling on the readline interface and convert it to
+ * `ExitPromptError` (already mapped to `CANCELLED` by `handlePromptableError`
+ * in `utils/prompts.ts`), but that only fires when the terminal is in the
+ * raw/keypress mode a prompt puts it in; a real SIGINT delivered by the
+ * kernel outside of that window (or before a prompt has attached its own
+ * listener) bypasses it entirely and falls through to Node's default,
+ * uncatchable-by-`try/catch` termination.
+ *
+ * Installing this listener for the whole CLI lifetime closes that gap: any
+ * Ctrl-C the process receives -- during a prompt or not -- is treated as the
+ * user cancelling the operation and reported the same way every other
+ * cancellation is: {@link ExitCode.CANCELLED} (4), documented in
+ * `AI_ASSISTANT_GUIDE.md` and `docs/configuration.md`. See issue #100.
+ *
+ * @public
+ */
+export function registerSigintHandler(): void {
+  process.on('SIGINT', () => {
+    log('\nCancelled')
+    process.exit(ExitCode.CANCELLED)
+  })
+}
+
 export async function run(): Promise<void> {
+  // Catch Ctrl-C for the whole process lifetime before doing anything else
+  // that could be interrupted (including a prompt). See issue #100.
+  registerSigintHandler()
+
   // Process --home-dir before anything else (hidden option for testing)
   processHomeDirOption()
 

--- a/packages/cli/test/exit-codes.test.ts
+++ b/packages/cli/test/exit-codes.test.ts
@@ -15,7 +15,20 @@
  * way, and the row-count/enum-membership assertions below now require both
  * to be present and correctly mapped.
  *
+ * Extended for #100: #98 documented `CANCELLED` (4) as reachable by a
+ * declined prompt and by Ctrl-C, but neither path actually produced it (a
+ * declined prompt exited `SUCCESS`; a raw `SIGINT` fell through to Node's
+ * default, uncaught-signal termination, not a clean `process.exit`). Both
+ * docs also described "a piped stdin that closes mid-prompt" without
+ * distinguishing it from the separate "missing required flag, no TTY" path,
+ * which has always been (and remains) `CONFIG_ERROR`. These tests pin the
+ * prose to the decisions made for #100 so it can't silently drift from
+ * reachable behavior again: a declined prompt and Ctrl-C are both
+ * `CANCELLED`; a missing flag on non-interactive stdin is `CONFIG_ERROR`.
+ *
  * @see ../src/utils/exit-codes.ts
+ * @see ../src/commands/run.ts
+ * @see ../src/index.ts
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -121,4 +134,41 @@ describe('exit-code documentation matches the ExitCode enum (#81)', () => {
     expect(ExitCode.DIRTY_WORKING_TREE).toBe(6)
     expect(ExitCode.DIRTY_WORKING_TREE).not.toBe(ExitCode.CONFIG_ERROR)
   })
+
+  it.each([
+    ['AI_ASSISTANT_GUIDE.md', join(REPO_ROOT, 'AI_ASSISTANT_GUIDE.md')],
+    ['docs/configuration.md', join(REPO_ROOT, 'docs/configuration.md')],
+  ])(
+    '%s documents a declined prompt and Ctrl-C as CANCELLED, and a missing flag on ' +
+      'non-interactive stdin as CONFIG_ERROR -- issue #100',
+    (_label, docPath) => {
+      const doc = readFileSync(docPath, 'utf8')
+
+      // Declining a confirmation must be documented as reachable CANCELLED,
+      // not folded silently into "force-closed" language that could be
+      // misread as excluding an explicit "n" answer.
+      expect(doc).toMatch(/declin(e|es|ed|ing)/i)
+
+      // Ctrl-C must be documented as CANCELLED (4). Some prose contrasts this
+      // with the shell's conventional 130 to make reachability unambiguous
+      // (e.g. "not the shell's conventional 130") -- that's fine as long as
+      // it's phrased as a rejection, not a claim that 130 is what happens.
+      expect(doc).toContain('Ctrl-C')
+      const ctrlCContext = doc.slice(
+        Math.max(0, doc.indexOf('Ctrl-C') - 200),
+        doc.indexOf('Ctrl-C') + 200,
+      )
+      expect(ctrlCContext).toMatch(/CANCELLED/)
+      if (/\b130\b/.test(ctrlCContext)) {
+        expect(ctrlCContext).toMatch(/not[\s\S]{0,40}?130/)
+      }
+
+      // The missing-flag/non-interactive case must be pinned to CONFIG_ERROR,
+      // not left implying CANCELLED.
+      expect(doc).toMatch(/missing (a )?required flag/i)
+      const missingFlagIndex = doc.search(/missing (a )?required flag/i)
+      const missingFlagContext = doc.slice(missingFlagIndex, missingFlagIndex + 400)
+      expect(missingFlagContext).toMatch(/CONFIG_ERROR/)
+    },
+  )
 })

--- a/packages/cli/test/helpers/pty-fixture.ts
+++ b/packages/cli/test/helpers/pty-fixture.ts
@@ -1,0 +1,208 @@
+/**
+ * Shared fixture setup for pty-driven `run` tests (issue #100).
+ *
+ * Builds a real, git-committed project with a real local identity
+ * authorized to seal its one gate, using the same documented sequence as
+ * `test/integration/getting-started.integration.test.ts` (`identity create`
+ * -> `init` -> hand-define gate/suite -> `team join` -> commit), so that
+ * `attest-it run --suite <name>` (run inside a pty, without `--yes`) reaches
+ * the real "Create seal for gate ... ?" confirmation prompt.
+ *
+ * @packageDocumentation
+ */
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { stringify as stringifyYaml, parse as parseYaml } from 'yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+export const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/** Run the built CLI as a real subprocess with stdin closed and a hard timeout. */
+function runCliNonInteractive(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 15000,
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(timeoutMs)}ms: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, timeoutMs)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+async function runGit(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', args, { cwd, stdio: 'ignore' })
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`git ${args.join(' ')} exited with code ${String(code)}`))
+      }
+    })
+    child.on('error', reject)
+  })
+}
+
+function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export interface SealPromptFixture {
+  /** Directory containing the git repo + attest-it project configuration. */
+  projectDir: string
+  /** Directory used as this fixture's isolated `ATTEST_IT_HOME`. */
+  homeDir: string
+  /** Env vars (`ATTEST_IT_HOME`) to pass to any CLI invocation against this fixture. */
+  env: NodeJS.ProcessEnv
+  /** Name of the suite/gate configured, authorized for the fixture's identity. */
+  suiteName: string
+  gateId: string
+  /** Remove both temp directories. */
+  cleanup: () => Promise<void>
+}
+
+/**
+ * Build a project + local identity such that `attest-it run --suite <suiteName>`
+ * reaches the real seal-confirmation prompt after tests pass.
+ */
+export async function setupSealPromptFixture(): Promise<SealPromptFixture> {
+  const projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-pty-project-'))
+  const homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-pty-home-'))
+  const env = { ATTEST_IT_HOME: homeDir, NO_COLOR: '1' }
+  const suiteName = 'smoke'
+  const gateId = 'smoke'
+
+  await fs.promises.writeFile(
+    path.join(projectDir, 'package.json'),
+    JSON.stringify({ name: 'pty-fixture', version: '0.0.0', private: true }, null, 2),
+  )
+  await fs.promises.mkdir(path.join(projectDir, 'src'), { recursive: true })
+  await fs.promises.writeFile(path.join(projectDir, 'src', 'index.ts'), 'export const x = 1\n')
+  await runGit(['init'], projectDir)
+  await runGit(['config', 'user.email', 'test@example.com'], projectDir)
+  await runGit(['config', 'user.name', 'Test User'], projectDir)
+
+  const createResult = await runCliNonInteractive(
+    ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+    projectDir,
+    env,
+  )
+  if (createResult.exitCode !== 0) {
+    throw new Error(
+      `identity create failed (exit ${String(createResult.exitCode)}):\n${createResult.stderr}`,
+    )
+  }
+
+  const initResult = await runCliNonInteractive(['init'], projectDir, env)
+  if (initResult.exitCode !== 0) {
+    throw new Error(`init failed (exit ${String(initResult.exitCode)}):\n${initResult.stderr}`)
+  }
+
+  const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+  await fs.promises.writeFile(
+    policyPath,
+    stringifyYaml({
+      version: 1,
+      settings: { maxAgeDays: 30 },
+      team: {},
+      gates: {
+        [gateId]: {
+          name: 'Smoke Test',
+          description: 'A trivial gate for pty-driven cancellation tests',
+          authorizedSigners: ['test-user'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      },
+    }),
+    'utf8',
+  )
+  const configPath = path.join(projectDir, '.attest-it', 'config.yaml')
+  await fs.promises.writeFile(
+    configPath,
+    stringifyYaml({
+      version: 1,
+      settings: {},
+      suites: { [suiteName]: { gate: gateId, command: 'node -e "console.log(1)"' } },
+    }),
+    'utf8',
+  )
+
+  const joinResult = await runCliNonInteractive(
+    ['team', 'join', '--gates', gateId],
+    projectDir,
+    env,
+  )
+  if (joinResult.exitCode !== 0) {
+    throw new Error(`team join failed (exit ${String(joinResult.exitCode)}):\n${joinResult.stderr}`)
+  }
+
+  await runGit(['add', '.'], projectDir)
+  await runGit(['commit', '-m', 'configure gate, suite, and team'], projectDir)
+
+  // Sanity check: the local identity's public key really is authorized.
+  const policyAfterJoin: unknown = parseYaml(await fs.promises.readFile(policyPath, 'utf8'))
+  if (
+    !isRecordOfUnknown(policyAfterJoin) ||
+    !isRecordOfUnknown(policyAfterJoin.team) ||
+    !isRecordOfUnknown(policyAfterJoin.team['test-user'])
+  ) {
+    throw new Error('Fixture setup did not add test-user to the team as expected')
+  }
+
+  return {
+    projectDir,
+    homeDir,
+    env,
+    suiteName,
+    gateId,
+    cleanup: async () => {
+      await Promise.all([
+        fs.promises.rm(projectDir, { recursive: true, force: true }),
+        fs.promises.rm(homeDir, { recursive: true, force: true }),
+      ])
+    },
+  }
+}

--- a/packages/cli/test/helpers/pty.ts
+++ b/packages/cli/test/helpers/pty.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared helpers for pty-driven CLI tests (issue #100).
+ *
+ * These tests attach the real built CLI (`dist/bin/attest-it.js`) to a real
+ * pseudo-terminal via `node-pty` so `process.stdin.isTTY` is genuinely
+ * `true` inside the CLI process -- exercising the actual keystroke/signal
+ * input contract a human types at, not a hand-built approximation (a piped
+ * stdin never reaches the interactive-prompt or raw-SIGINT code paths this
+ * issue is about).
+ *
+ * @packageDocumentation
+ */
+import { chmodSync, existsSync } from 'node:fs'
+import { platform, arch } from 'node:os'
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+import * as pty from 'node-pty'
+
+/**
+ * `node-pty` ships prebuilt native helper binaries (`spawn-helper` on
+ * POSIX). pnpm's content-addressable store does not restore the original
+ * executable bit for files outside a package's declared `bin` field, so a
+ * plain `pnpm install` can leave `spawn-helper` non-executable, and
+ * `pty.spawn` then fails with `posix_spawnp failed`. Re-assert the bit
+ * before every spawn so these tests are deterministic regardless of how the
+ * package manager happened to extract the file.
+ */
+function ensureNodePtyHelperExecutable(): void {
+  if (platform() === 'win32') {
+    return
+  }
+  const require = createRequire(import.meta.url)
+  const pkgPath = require.resolve('node-pty/package.json')
+  const helperPath = join(dirname(pkgPath), 'prebuilds', `${platform()}-${arch()}`, 'spawn-helper')
+  if (existsSync(helperPath)) {
+    chmodSync(helperPath, 0o755)
+  }
+}
+
+export interface SpawnPtyOptions {
+  cwd: string
+  env?: NodeJS.ProcessEnv
+  cols?: number
+  rows?: number
+}
+
+/** Spawn `file args...` attached to a real pseudo-terminal. */
+export function spawnPty(file: string, args: string[], options: SpawnPtyOptions): pty.IPty {
+  ensureNodePtyHelperExecutable()
+  return pty.spawn(file, args, {
+    name: 'xterm-256color',
+    cols: options.cols ?? 100,
+    rows: options.rows ?? 30,
+    cwd: options.cwd,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- node-pty's env type requires string values only; process.env entries are string | undefined
+    env: { ...process.env, ...options.env } as Record<string, string>,
+  })
+}
+
+/**
+ * Wait until the pty's accumulated output satisfies `predicate`, or reject
+ * after `timeoutMs`.
+ */
+export async function waitForOutput(
+  term: pty.IPty,
+  predicate: (accumulated: string) => boolean,
+  timeoutMs = 20000,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let acc = ''
+    const disposable = term.onData((chunk: string) => {
+      acc += chunk
+      if (predicate(acc)) {
+        cleanup()
+        resolve(acc)
+      }
+    })
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(
+        new Error(
+          `Timed out after ${String(timeoutMs)}ms waiting for expected pty output. ` +
+            `Output received so far:\n${acc}`,
+        ),
+      )
+    }, timeoutMs)
+    function cleanup(): void {
+      clearTimeout(timer)
+      disposable.dispose()
+    }
+  })
+}
+
+/** Wait for the pty-attached process to exit, returning its exit code. */
+export async function waitForPtyExit(term: pty.IPty, timeoutMs = 20000): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out after ${String(timeoutMs)}ms waiting for pty process to exit`))
+    }, timeoutMs)
+    term.onExit(({ exitCode }: { exitCode: number }) => {
+      clearTimeout(timer)
+      resolve(exitCode)
+    })
+  })
+}

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit coverage for `registerSigintHandler` (issue #100).
+ *
+ * This is a fast, focused check that the handler itself does the right
+ * thing when a `SIGINT` event fires. It intentionally does not attempt to
+ * prove that a real, kernel-delivered `SIGINT` reaches this handler --
+ * that's the job of the pty-driven integration test in
+ * `test/pty/run-cancellation.pty.test.ts`, which drives the actual built CLI
+ * through a real pseudo-terminal and sends a genuine Ctrl-C keystroke.
+ *
+ * @see ../src/index.ts
+ * @see ./pty/run-cancellation.pty.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { registerSigintHandler } from '../src/index.js'
+import { ExitCode } from '../src/utils/exit-codes.js'
+
+describe('registerSigintHandler (issue #100)', () => {
+  const mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+  const mockProcessExit = vi
+    .spyOn(process, 'exit')
+    // @ts-expect-error - Mocking process.exit which has a complex signature
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    .mockImplementation(() => {})
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // Every test registers its own listener via process.on('SIGINT', ...) --
+    // remove them all so they don't leak into other test files (and don't
+    // trip Node's MaxListenersExceededWarning across the whole run).
+    process.removeAllListeners('SIGINT')
+  })
+
+  it('exits CANCELLED with a clean message when the process receives SIGINT', () => {
+    registerSigintHandler()
+
+    process.emit('SIGINT')
+
+    expect(mockConsoleLog).toHaveBeenCalledWith('\nCancelled')
+    expect(mockProcessExit).toHaveBeenCalledTimes(1)
+    expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CANCELLED)
+  })
+})

--- a/packages/cli/test/pty/run-cancellation.pty.test.ts
+++ b/packages/cli/test/pty/run-cancellation.pty.test.ts
@@ -1,0 +1,96 @@
+/**
+ * pty-driven regression tests for issue #100: exit code `CANCELLED` (4) was
+ * documented (by #98) as reachable by declining a confirmation prompt or by
+ * Ctrl-C, but neither path actually produced it.
+ *
+ * These tests attach the real, built CLI to a genuine pseudo-terminal via
+ * `node-pty` so `process.stdin.isTTY` is really `true` inside the CLI
+ * process and real keystrokes/signals drive the exact interactive-prompt
+ * and raw-SIGINT code paths the bug was in -- a piped/non-TTY stdin (as
+ * used by the CLI's other integration tests) never reaches either path, so
+ * mocking or piping stdin here would not have caught the original bug.
+ *
+ * - "declining a seal prompt exits CANCELLED, not SUCCESS" reproduces the
+ *   exact repro from the issue: typing `n` at "Create seal for gate 'x'?"
+ *   previously logged "Seal creation skipped" and fell through to the
+ *   caller's normal success path (implicit exit 0).
+ * - "Ctrl-C during a seal prompt exits CANCELLED" reproduces a real SIGINT
+ *   (not `@inquirer/core`'s internal force-close detection, which only
+ *   fires in the specific terminal mode a prompt puts the tty in) --
+ *   previously this fell through to Node's default, uncaught-signal
+ *   termination.
+ *
+ * @see ../../src/commands/run.ts
+ * @see ../../src/index.ts
+ * @see ../helpers/pty.ts
+ * @see ../helpers/pty-fixture.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnPty, waitForOutput, waitForPtyExit } from '../helpers/pty.js'
+import { setupSealPromptFixture, CLI_PATH, type SealPromptFixture } from '../helpers/pty-fixture.js'
+
+const PTY_TEST_TIMEOUT_MS = 30000
+
+describe('run --suite: seal prompt cancellation exits CANCELLED (issue #100)', () => {
+  let fixture: SealPromptFixture
+
+  beforeEach(async () => {
+    fixture = await setupSealPromptFixture()
+  }, PTY_TEST_TIMEOUT_MS)
+
+  afterEach(async () => {
+    await fixture.cleanup()
+  })
+
+  it(
+    'declining the seal prompt (typing "n") exits CANCELLED (4), not SUCCESS (0)',
+    async () => {
+      const term = spawnPty('node', [CLI_PATH, 'run', '--suite', fixture.suiteName], {
+        cwd: fixture.projectDir,
+        env: fixture.env,
+      })
+
+      await waitForOutput(term, (acc) => acc.includes(`Create seal for gate '${fixture.gateId}'`))
+
+      term.write('n\r')
+
+      const exitCode = await waitForPtyExit(term)
+
+      // Pre-fix: this was 0 (SUCCESS) -- the decline logged "Seal creation
+      // skipped" and fell through to "Suite completed!" as if nothing had
+      // gone wrong, which is exactly what let a CI script read a declined
+      // seal as a passing attestation.
+      expect(exitCode).not.toBe(0)
+      expect(exitCode).toBe(4) // ExitCode.CANCELLED
+    },
+    PTY_TEST_TIMEOUT_MS,
+  )
+
+  it(
+    'Ctrl-C (SIGINT) during the seal prompt exits CANCELLED (4), not the shell-conventional 130',
+    async () => {
+      const term = spawnPty('node', [CLI_PATH, 'run', '--suite', fixture.suiteName], {
+        cwd: fixture.projectDir,
+        env: fixture.env,
+      })
+
+      await waitForOutput(term, (acc) => acc.includes(`Create seal for gate '${fixture.gateId}'`))
+
+      // Send a real Ctrl-C keystroke through the pty -- this is what a real
+      // terminal delivers for Ctrl-C, exercising the same raw-SIGINT path a
+      // human would trigger (as opposed to calling `child.kill('SIGINT')`
+      // on a plain piped child, which does not reproduce the terminal-mode
+      // nuance the original bug lived in).
+      term.write('\x03')
+
+      const exitCode = await waitForPtyExit(term)
+
+      // Pre-fix: there was no `process.on('SIGINT', ...)` handler anywhere
+      // in the CLI, so Node's default action for an uncaught SIGINT ran
+      // instead of a clean `process.exit(4)` -- the process was killed by
+      // the signal (a parent shell would typically report this as 130).
+      expect(exitCode).toBe(4) // ExitCode.CANCELLED
+    },
+    PTY_TEST_TIMEOUT_MS,
+  )
+})

--- a/packages/cli/test/run-missing-yes-headless.integration.test.ts
+++ b/packages/cli/test/run-missing-yes-headless.integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression/coverage test for issue #100's third scenario: `run --suite`
+ * on non-interactive stdin (no TTY) without `--yes`.
+ *
+ * Prior to #100, `AI_ASSISTANT_GUIDE.md` and `docs/configuration.md`
+ * documented every "cancelled/interrupted prompt" case -- including this one
+ * -- as `CANCELLED` (4). This case never actually starts a prompt (the
+ * missing-flag check runs *before* any prompt could), so there is nothing to
+ * cancel; the real, correct, and unchanged behavior is `CONFIG_ERROR` (3),
+ * the same code any other missing-required-input usage error gets. #100's
+ * fix is the docs no longer implying this reaches `CANCELLED` -- see
+ * `test/exit-codes.test.ts`'s pin of that prose. This test locks the
+ * runtime behavior itself in place so a future change can't silently drift
+ * it away from what the docs now say.
+ *
+ * @see ../src/commands/run.ts
+ * @see ./exit-codes.test.ts
+ * @see ./helpers/pty-fixture.ts
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import { setupSealPromptFixture, CLI_PATH, type SealPromptFixture } from './helpers/pty-fixture.js'
+import { ExitCode } from '../src/utils/exit-codes.js'
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/** Run the built CLI as a real subprocess with stdin closed (`< /dev/null`) and a hard timeout. */
+function runCliWithClosedStdin(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs = 15000,
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(timeoutMs)}ms -- likely hanging on an ` +
+            `undocumented prompt with no TTY available: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, timeoutMs)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+describe('run --suite with no --yes and no TTY exits CONFIG_ERROR, not CANCELLED (issue #100)', () => {
+  let fixture: SealPromptFixture
+
+  beforeEach(async () => {
+    fixture = await setupSealPromptFixture()
+  }, 30000)
+
+  afterEach(async () => {
+    await fixture.cleanup()
+  })
+
+  it('exits CONFIG_ERROR (3) and names the missing --yes flag, without hanging', async () => {
+    const result = await runCliWithClosedStdin(
+      ['run', '--suite', fixture.suiteName],
+      fixture.projectDir,
+      fixture.env,
+    )
+
+    expect(result.exitCode).toBe(ExitCode.CONFIG_ERROR)
+    expect(result.exitCode).not.toBe(ExitCode.CANCELLED)
+    expect(result.stderr).toContain('--yes')
+  }, 30000)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       ink-testing-library:
         specifier: ^4.0.0
         version: 4.0.0(@types/react@18.3.27)
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.19.3))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
@@ -3521,8 +3524,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-machine-id@1.1.12:
     resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -8236,7 +8245,13 @@ snapshots:
       split2: 3.2.2
       through2: 4.0.2
 
+  node-addon-api@7.1.1: {}
+
   node-machine-id@1.1.12: {}
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   node-releases@2.0.27: {}
 


### PR DESCRIPTION
## Summary

#98 documented `CANCELLED` (4) as reachable by declining a confirmation prompt or by Ctrl-C,
but neither path actually produced it -- `handlePromptableError` only caught `@inquirer/core`'s
`ExitPromptError` (the force-close path); a *declined* prompt and a raw `SIGINT` were never
wired to it.

**Semantics decision (each criterion picked one option and made code + docs agree):**

1. **Declining a confirmation prompt exits `CANCELLED` (4), not `SUCCESS` (0).** `run`'s
   `promptForSeal` logged "Seal creation skipped" and returned, falling through to the
   caller's normal "Suite completed!" success path with an implicit exit `0` -- a CI script
   reading the exit code could not tell a declined seal apart from a successful one. Fixed in
   `packages/cli/src/commands/run.ts`: a decline now logs `Cancelled` and
   `process.exit(ExitCode.CANCELLED)`, matching the existing (already-correct) pattern in
   `identity remove` and `team remove`.
2. **Ctrl-C (`SIGINT`) exits `CANCELLED` (4), everywhere in the CLI -- not the shell's
   conventional 130.** `@inquirer/core`'s prompts install their own `SIGINT` handling on the
   readline interface and convert it to `ExitPromptError` (already mapped to `CANCELLED`), but
   that only fires while the terminal is in the specific raw/keypress mode a prompt puts it in.
   A real SIGINT outside that window fell through to Node's default, uncaught-signal
   termination. Fixed by installing a process-wide `process.on('SIGINT', ...)` handler for the
   CLI's entire lifetime (`registerSigintHandler` in `packages/cli/src/index.ts`), closing the
   gap unconditionally rather than trying to track "is a prompt currently active" at every one
   of the ~9 call sites across the codebase that invoke `@inquirer/prompts` directly.
3. **Missing a required flag with no interactive terminal available stays `CONFIG_ERROR` (3) --
   docs no longer imply it's `CANCELLED`.** This path (e.g. `run --suite x < /dev/null` without
   `--yes`) fails fast *before* any prompt starts (`resolveConfirmation`/`confirmOverwrite`
   throw before ever invoking `@inquirer/prompts`), so there's nothing to cancel -- it's a usage
   error like any other missing-required-input mistake. Code was already correct; only the docs
   claimed otherwise. No code change for this case, only doc updates.

Docs (`AI_ASSISTANT_GUIDE.md`, `docs/configuration.md`) updated to describe only this reachable
behavior, and the #81/#98 exit-code docs-pin test (`packages/cli/test/exit-codes.test.ts`) is
extended to pin the prose itself (not just the table), so it can't silently drift from reachable
behavior again.

## Acceptance criteria mapping

- **Declined prompt -> `CANCELLED`, not `SUCCESS`** -- covered by
  `packages/cli/test/pty/run-cancellation.pty.test.ts`'s `"declining the seal prompt (typing
  \"n\") exits CANCELLED (4), not SUCCESS (0)"` test. This is a **pty-driven** test: it attaches
  the real built CLI to a genuine pseudo-terminal via `node-pty` so `process.stdin.isTTY` is
  really `true`, waits for the real `"Create seal for gate 'smoke'?"` prompt text, types `n\r`,
  and asserts the process exit code. Confirmed to **fail against pre-fix code** (exits `0`) and
  pass with the fix (manually verified by reverting `run.ts`/`index.ts`, rebuilding, and
  re-running -- see commit history for the exact repro).
- **Ctrl-C during a prompt -> the documented code** -- covered by the same file's `"Ctrl-C
  (SIGINT) during the seal prompt exits CANCELLED (4), not the shell-conventional 130"` test,
  which sends a real `\x03` keystroke through the pty (not `child.kill('SIGINT')`, which
  bypasses the terminal-mode nuance the original bug lived in). Confirmed to fail pre-fix (exits
  `0` -- `node-pty`'s own exit-code reporting for a signal-killed child, not literally `130`,
  but unambiguously not the documented `4` either) and pass post-fix.
- **Missing-flag-headless -> its documented code** -- covered by
  `packages/cli/test/run-missing-yes-headless.integration.test.ts`, which spawns the real CLI
  with stdin closed (`< /dev/null` equivalent) and asserts `CONFIG_ERROR` (3), not `CANCELLED`.
  This locks the already-correct runtime behavior in place; it does not fail pre-fix (the code
  path was never wrong, only the docs) but guards against future drift, and pairs with the
  docs-pin extension below to prove the *documented* claim now matches reality.
- **Docs-pin test extension so the exit-code table (and prose) can't drift again** -- covered by
  the two new `it.each` cases added to `packages/cli/test/exit-codes.test.ts`, asserting both
  `AI_ASSISTANT_GUIDE.md` and `docs/configuration.md` document a declined prompt / Ctrl-C as
  `CANCELLED` and the missing-flag/non-TTY case as `CONFIG_ERROR`. Confirmed to fail against the
  pre-fix docs (manually verified by stashing the doc changes and re-running) and pass with the
  fix.

A fast unit test (`packages/cli/test/index.test.ts`) also covers `registerSigintHandler` in
isolation, complementing (not replacing) the pty-driven integration coverage above.

## Test plan

- [x] `packages/cli/test/pty/run-cancellation.pty.test.ts` (new, mandatory pty regression):
      decline -> `CANCELLED`; Ctrl-C -> `CANCELLED`. Both confirmed to fail pre-fix.
- [x] `packages/cli/test/run-missing-yes-headless.integration.test.ts` (new): missing `--yes`
      with closed stdin -> `CONFIG_ERROR`, not `CANCELLED`.
- [x] `packages/cli/test/exit-codes.test.ts` (extended): docs-pin assertions on the new prose,
      confirmed to fail against pre-fix docs.
- [x] `packages/cli/test/index.test.ts` (new): unit coverage for `registerSigintHandler`.
- [x] Full `pnpm run build && pnpm run check && pnpm run test` green across all packages
      (core, cli, attest-it, github-action) -- 774 CLI tests + 539 core tests + github-action
      tests all passing.
- [x] `prettier --check .` clean.
- [x] `syncpack lint` clean (new `node-pty` devDependency, cli-only).

## Notes for reviewers

- `node-pty` is added as a `packages/cli` devDependency (test-only) to drive the real
  interactive-prompt/raw-SIGINT input contract; `pnpm-workspace.yaml`'s
  `onlyBuiltDependencies` is updated to allow its native prebuild install script.
  `packages/cli/test/helpers/pty.ts` re-asserts the executable bit on `node-pty`'s bundled
  `spawn-helper` binary before every spawn, because pnpm's content-addressable store does not
  restore the original executable bit for files outside a package's declared `bin` field --
  without this, `pty.spawn` fails with `posix_spawnp failed` after a plain `pnpm install`
  (this is very likely why the previous implementer's pty-based repro attempt stalled).
- The global `SIGINT` handler intentionally covers the whole CLI process lifetime, not just
  "while a prompt is active." A real terminal delivers Ctrl-C as a kernel signal to the whole
  foreground process group, so `run`'s spawned test-command child (`stdio: 'inherit'`) already
  receives its own SIGINT directly regardless of what the parent does -- this change only
  affects how the *parent* `attest-it` process reports its own exit code, and treats any
  user-initiated Ctrl-C the same way every other cancellation is reported.

Refs #100
