### PR TITLE
fix: make dogfood attestation check non-blocking on PRs

### DIFF
--- a/.github/workflows/verify-manual-attestations.yml
+++ b/.github/workflows/verify-manual-attestations.yml
@@ -18,11 +18,24 @@ name: Verify Manual Test Attestations
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Daily freshness check, independent of PR/push activity, so seal
+    # expiry (maxAge) is caught even during quiet periods.
+    - cron: '0 6 * * *'
 
 jobs:
   verify-attestations:
     name: Verify manual test attestations
     runs-on: ubuntu-latest
+    # Dogfood seals require the repo owner's physical hardware (YubiKey,
+    # 1Password, Keychain) to refresh — see issue #82. Until re-sealed, this
+    # job can legitimately fail. On pull_request it stays informational
+    # (non-blocking) so unrelated PRs aren't gated on an owner-only manual
+    # step; on push to main and on the schedule it stays blocking so the
+    # freshness signal itself is never silently ignored.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Makes the `Verify manual test attestations` CI job **non-blocking on `pull_request` events**, while keeping it **blocking on `push` to `main` and on a new daily `schedule` run**. This is Option 3 from #82, confirmed by the repo owner's PM decision in the issue thread ("Change `verify-manual-attestations.yml` so the dogfood attestation check is NON-blocking on pull_request events ... and remains blocking on push to main and on its schedule").

## Why now

Even after #113 repoints the stale `policy.yaml` fingerprint paths (landing in parallel), the seals themselves remain **expired** until the repo owner physically re-runs the four manual suites (YubiKey, 1Password, Keychain, interactive CLI) and re-seals — that re-seal step is owner-gated hardware work, not something the fleet can automate. So `Verify manual test attestations` will keep failing on every PR regardless of #113's fix, and a permanently red required-looking check trains reviewers to ignore CI. Making it non-blocking on PRs is what actually unblocks clean merges fleet-wide, while keeping it strict on `main` push and the daily schedule preserves the freshness signal so staleness is never silently ignored.

## What changed

Only `.github/workflows/verify-manual-attestations.yml` — no changes to `.attest-it/policy.yaml`, seals, or the verification logic itself. (#113, running in parallel, owns `.attest-it/policy.yaml` — different file, no overlap.)

### Trigger: added `push` (main) and `schedule`

```yaml
on:
  pull_request:
    branches: [main]
  push:
    branches: [main]
  schedule:
    # Daily freshness check, independent of PR/push activity, so seal
    # expiry (maxAge) is caught even during quiet periods.
    - cron: '0 6 * * *'
```

The workflow previously only ran on `pull_request`, so there was no periodic freshness signal outside of PR activity. Added a daily 06:00 UTC cron.

### Job: gated `continue-on-error` by event type

```yaml
jobs:
  verify-attestations:
    name: Verify manual test attestations
    runs-on: ubuntu-latest
    # Dogfood seals require the repo owner's physical hardware (YubiKey,
    # 1Password, Keychain) to refresh — see issue #82. Until re-sealed, this
    # job can legitimately fail. On pull_request it stays informational
    # (non-blocking) so unrelated PRs aren't gated on an owner-only manual
    # step; on push to main and on the schedule it stays blocking so the
    # freshness signal itself is never silently ignored.
    continue-on-error: ${{ github.event_name == 'pull_request' }}
```

Reasoning per event type:
- **`pull_request` → non-blocking.** `continue-on-error` evaluates `true`, so the job still runs and reports its real pass/fail result in the Checks UI, but a failure no longer marks the overall run (or any required status built on top of the job) as failed. The `build` job (in `ci.yml`) remains the sole required check, so unrelated PRs merge clean while this job's red/green state stays visible as a warning.
- **`push` to `main` → blocking.** `continue-on-error` evaluates `false`; a stale/missing seal fails the run on `main`, same as before this change.
- **`schedule` → blocking.** Same as `push` — `continue-on-error` evaluates `false`, so the daily run fails loudly if seals have gone stale, independent of PR/push cadence.

### Before/after summary

| Event | Before | After |
|---|---|---|
| `pull_request` → main | job failure blocks (was the root cause of #82) | job still runs and reports; failure does **not** block (`continue-on-error: true`) |
| `push` → main | job failure blocks | unchanged: job failure blocks (`continue-on-error: false`) |
| `schedule` (daily) | did not exist | new: job failure blocks (`continue-on-error: false`) |

## Acceptance criteria mapping

Per the PM's acceptance criterion in the issue: "PR CI on an unrelated change goes green while the dogfood check still reports the expiry as a visible warning."

- Covered by this PR's own CI run on this branch: the `Verify manual test attestations` job is expected to still report its real (currently failing, due to expired dogfood seals) result, but because `continue-on-error` evaluates to `true` for this `pull_request` event, it will surface as a yellow/warning "Successful (with warnings)" style check rather than a hard failure, and will not block the required `build` check from going green.

## Regression testing

This is a CI/workflow-config change with no unit-testable code path (per the bugfix-regression-tests exception for configuration/infrastructure changes with no testable code path). Verification instead consists of:
1. The before/after event-conditional table above, reasoned through for each of the three trigger types.
2. Live confirmation on this PR's own Checks tab (see CI status below) that the manual-attestation job is non-blocking here.
3. `node scripts/check-policy-ref-guard.mjs --self-test` and `node scripts/check-policy-ref-guard.mjs` both pass — this change does not introduce or alter any `policy-ref` override, preserving the real-policy-gate guarantee documented at the top of the workflow file.

## Verification run locally

- `pnpm install --frozen-lockfile`
- `pnpm run build` — green (reverted an incidental, unrelated bundler-output diff in `packages/github-action/dist/*` produced by a fresh build; not part of this change's scope)
- `pnpm run check` — green (only pre-existing `security/detect-object-injection` warnings, unrelated to this PR)
- `pnpm run test` — 779/779 tests passed across 42 files
- `npx prettier --check .github/workflows/verify-manual-attestations.yml` — passed

No actionlint step exists in this repo's check suite, so none was run.

Refs #82
