### PR TITLE
fix: repoint dogfood policy.yaml gate fingerprints off deleted key-provider files

### DIFF
--- a/.attest-it/policy.yaml
+++ b/.attest-it/policy.yaml
@@ -20,7 +20,10 @@ gates:
     fingerprint:
       paths:
         - packages/cli/test/manual/scripts/1password-integration.ts
-        - packages/core/src/key-provider/one-password-provider.ts
+        - packages/core/src/key-provider/discovery.ts
+        - packages/core/src/key-provider/vault-key-provider.ts
+        - packages/core/src/key-provider/registry.ts
+        - packages/core/src/key-provider/store.ts
         - packages/core/src/seal/**/*.ts
         - packages/core/src/crypto.ts
     maxAge: 90d
@@ -33,7 +36,10 @@ gates:
     fingerprint:
       paths:
         - packages/cli/test/manual/scripts/keychain-integration.ts
-        - packages/core/src/key-provider/macos-keychain-provider.ts
+        - packages/core/src/key-provider/discovery.ts
+        - packages/core/src/key-provider/vault-key-provider.ts
+        - packages/core/src/key-provider/registry.ts
+        - packages/core/src/key-provider/store.ts
         - packages/core/src/seal/**/*.ts
         - packages/core/src/crypto.ts
     maxAge: 90d
@@ -45,7 +51,10 @@ gates:
     fingerprint:
       paths:
         - packages/cli/test/manual/scripts/yubikey-integration.ts
-        - packages/core/src/key-provider/yubikey-provider.ts
+        - packages/core/src/key-provider/discovery.ts
+        - packages/core/src/key-provider/vault-key-provider.ts
+        - packages/core/src/key-provider/registry.ts
+        - packages/core/src/key-provider/store.ts
         - packages/core/src/seal/**/*.ts
         - packages/core/src/crypto.ts
     maxAge: 90d

--- a/docs/manual-testing-guide.md
+++ b/docs/manual-testing-guide.md
@@ -126,7 +126,7 @@ Error: Gate 'yubikey-integration' verification failed
   Actual: def456...
 
   Files changed since last seal:
-    - packages/core/src/key-provider/yubikey-provider.ts
+    - packages/core/src/key-provider/vault-key-provider.ts
 ```
 
 ## Troubleshooting

--- a/packages/core/test/config/dogfood-policy-fingerprint-paths.test.ts
+++ b/packages/core/test/config/dogfood-policy-fingerprint-paths.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for the repo's own `.attest-it/policy.yaml` gate
+ * fingerprint paths (issue #113).
+ *
+ * @remarks
+ * The "Verify manual test attestations" CI job (`.github/workflows/verify-manual-attestations.yml`)
+ * resolves every gate's `fingerprint.paths` entries against the repo checkout
+ * via {@link computeFingerprintSync} (see `packages/core/src/fingerprint.ts`,
+ * which throws `Path does not exist: <resolved>` for any non-glob path that
+ * is missing). After the VaultKeeper key-provider consolidation (#63), three
+ * gates in `.attest-it/policy.yaml` still pointed at deleted files
+ * (`one-password-provider.ts`, `macos-keychain-provider.ts`,
+ * `yubikey-provider.ts`), so this job failed identically on every PR.
+ *
+ * This test parses the repo's real policy file with the same
+ * {@link parsePolicyContent} used by the trust-model loader, then computes
+ * the fingerprint for every gate exactly as the CI job would. It fails
+ * pre-fix with "Path does not exist" and guards against future renames
+ * silently breaking the dogfood gate again.
+ */
+
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parsePolicyContent } from '../../src/config/policy-schema.js'
+import { computeFingerprintSync } from '../../src/fingerprint.js'
+
+// This test file lives at <repo-root>/packages/core/test/config/, so the
+// repo root is four directories up.
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+const POLICY_PATH = path.join(REPO_ROOT, '.attest-it', 'policy.yaml')
+
+function loadRepoPolicy() {
+  const content = fs.readFileSync(POLICY_PATH, 'utf-8')
+  return parsePolicyContent(content, 'yaml')
+}
+
+describe('dogfood: .attest-it/policy.yaml gate fingerprint paths', () => {
+  it('policy file exists at the expected repo-root location', () => {
+    expect(fs.existsSync(POLICY_PATH)).toBe(true)
+  })
+
+  const policy = loadRepoPolicy()
+  const gateIds = Object.keys(policy.gates)
+
+  it('has at least one gate to check', () => {
+    expect(gateIds.length).toBeGreaterThan(0)
+  })
+
+  it.each(gateIds)('gate "%s" fingerprint paths all resolve to real files', (gateId) => {
+    const gate = policy.gates[gateId]
+    if (!gate) {
+      throw new Error(`Gate "${gateId}" unexpectedly missing from parsed policy`)
+    }
+
+    // This mirrors exactly what the "Verify manual test attestations" CI job
+    // does when it computes the current fingerprint for a gate: non-glob
+    // paths that don't exist throw `Path does not exist: <resolved path>`.
+    expect(() =>
+      computeFingerprintSync({
+        paths: gate.fingerprint.paths,
+        exclude: gate.fingerprint.exclude,
+        baseDir: REPO_ROOT,
+      }),
+    ).not.toThrow()
+
+    const result = computeFingerprintSync({
+      paths: gate.fingerprint.paths,
+      exclude: gate.fingerprint.exclude,
+      baseDir: REPO_ROOT,
+    })
+    // A gate whose fingerprint paths silently resolve to zero files would
+    // still "pass" this test's not-toThrow assertion above while providing
+    // no real attestation coverage, so require at least one matched file.
+    expect(result.fileCount).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

The repo's own `.attest-it/policy.yaml` had three manual-test gate fingerprints pointing at
key-provider source files that were deleted when #63 consolidated all key-provider backends
behind VaultKeeper. This made the **"Verify manual test attestations"** CI job fail identically
on every PR with `Path does not exist: .../one-password-provider.ts`, training reviewers to
ignore a red check on a trust/attestation tool.

This PR is a **path-repoint only**. It does **not** re-anchor the policy seal — that requires the
repo owner's Ed25519 key. After this merges, `.attest-it/seals.json` will still contain
seals computed against the *old* fingerprint paths, so the "Verify manual test attestations" job
will still fail (now with `FINGERPRINT_MISMATCH`/`EXPIRED` instead of `Path does not exist`) until
the owner re-seals the three affected gates. That's expected, and is exactly why #82 (making this
job non-blocking on PRs) exists in parallel.

## What changed

For each of the three stale gates, I investigated where each backend's implementation actually
lives post-#63 (`registry.ts`, `discovery.ts`, `vault-key-provider.ts`, `store.ts`) and repointed
the fingerprint at the files that now represent that backend's real code surface:

| Gate | Old (deleted) path | New paths |
|---|---|---|
| `1password-integration` | `packages/core/src/key-provider/one-password-provider.ts` | `discovery.ts`, `vault-key-provider.ts`, `registry.ts`, `store.ts` |
| `keychain-integration` | `packages/core/src/key-provider/macos-keychain-provider.ts` | `discovery.ts`, `vault-key-provider.ts`, `registry.ts`, `store.ts` |
| `yubikey-integration` | `packages/core/src/key-provider/yubikey-provider.ts` | `discovery.ts`, `vault-key-provider.ts`, `registry.ts`, `store.ts` |

Reasoning for the "combined files" mapping: the VaultKeeper consolidation didn't leave one
file per backend. Instead:
- `discovery.ts` still has backend-specific enumeration/availability functions
  (`isOnePasswordInstalled`/`listOnePasswordAccounts`/`listOnePasswordVaults`,
  `isMacOSKeychainAvailable`/`listMacOSKeychains`,
  `isYubiKeyInstalled`/`listYubiKeyDevices`/`isYubiKeyChallengeResponseConfigured`) — each
  manual test script (`1password-integration.ts`, `keychain-integration.ts`,
  `yubikey-integration.ts`) imports its backend's functions from this one file.
- `vault-key-provider.ts` is the generic `VaultKeyProvider` adapter every manual script
  instantiates (wrapping a `vaultkeeper` `SecretBackend`) to actually generate/store/retrieve
  the key.
- `registry.ts` registers the `1password`/`macos-keychain`/`yubikey` factory functions that
  `identity create --storage <backend>` uses in production.
- `store.ts` is the high-level `storePrivateKey`/`deletePrivateKey` helper `identity create`
  and `identity remove` use per backend type.

All three backends now share these four files rather than having dedicated provider modules, so
all three gates legitimately point at the same set of files — that's an accurate reflection of
the current code structure, not an accident of my repoint.

I also audited the rest of `.attest-it/policy.yaml` (the `cli-interactive` gate and all
`packages/core/src/seal/**/*.ts` / `packages/core/src/crypto.ts` globs) — every other path
already resolves. Additionally fixed one stale illustrative path
(`packages/core/src/key-provider/yubikey-provider.ts`) in `docs/manual-testing-guide.md`'s
"Example CI Failure Output" section to match the current file layout.

## Acceptance criteria mapping

- **AC1** ("Repoint the gate fingerprint path... from `one-password-provider.ts` to the current
  `vault-key-provider.ts` (and audit for any other stale paths)"): covered by the
  `.attest-it/policy.yaml` changes above, and by
  `packages/core/test/config/dogfood-policy-fingerprint-paths.test.ts`, which parses the real
  policy file and asserts every gate's fingerprint paths resolve to real files (fails pre-fix
  with the exact `Path does not exist` error CI reports).
- **AC2** ("'Verify manual test attestations' passes on a fresh PR"): **not fully satisfied by
  this PR** — see the seal-is-owner-gated note above. The path-resolution failure is fixed (this
  PR's regression test proves it), but the job as a whole will still fail on
  `FINGERPRINT_MISMATCH`/`EXPIRED` until the owner re-seals. This matches the issue's own scope
  note ("the accompanying re-seal is owner-gated and must be performed by the owner").

## Regression test

`packages/core/test/config/dogfood-policy-fingerprint-paths.test.ts` — parses the repo's real
`.attest-it/policy.yaml` with the same `parsePolicyContent` the trust-model loader uses, then
calls `computeFingerprintSync` for every gate exactly as the CI job does. Verified failing
pre-fix (reproduces `Error: Path does not exist: .../one-password-provider.ts` etc. for the three
affected gates) and passing post-fix. Also asserts every gate resolves at least one file (guards
against a fingerprint that "passes" by matching zero files).

## Changeset

No changeset added. This PR only changes repo-internal dogfood configuration
(`.attest-it/policy.yaml`, not shipped in any published package) and adds an internal test
(`@attest-it/core`'s `files` field is `["dist"]`, so `test/` is never published). No published
package's runtime behavior or public API changes.

## Verification

- `pnpm run build` — green
- `pnpm check:packages` (lint + typecheck + api-report for all packages) — green, only
  pre-existing `security/detect-object-injection` warnings, no new errors
- `pnpm check:workspace` (knip, syncpack, prettier) — green
- `pnpm run test` — 42 test files / 779 tests passing across the workspace, including the new
  regression test and all 558 `@attest-it/core` tests

## Known CI expectations on this PR

- `test-action` / `test-docker` are known-flaky in this repo, unrelated to this change.
- **"Verify manual test attestations" will still be red on this PR.** The path-resolution bug
  this PR fixes is gone, but the seal itself is stale/expired (owner-gated re-seal, tracked in
  #82) — see the summary above. The required check for this PR is `build`.

Refs #113
