### PR TITLE
test: isolate all VaultKeeper file-backend tests from the real config dir

### DIFF
--- a/packages/cli/test/README.md
+++ b/packages/cli/test/README.md
@@ -305,6 +305,29 @@ console.log('Project at:', project.baseDir)
 // Don't call dispose() to keep it around
 ```
 
+## VaultKeeper Test Isolation
+
+Any test that exercises the VaultKeeper `file` backend (e.g. `identity create --storage file`,
+directly or via a spawned CLI subprocess) **must** redirect VaultKeeper's config directory to an
+isolated per-test temp directory by setting `VAULTKEEPER_CONFIG_DIR` (in `process.env` for
+in-process calls, or in the `env` passed to a spawned subprocess) -- never rely on the default
+`~/.config/vaultkeeper/`. A global test-setup guard
+(`test/setup/vaultkeeper-isolation-guard.setup.ts`, wired in via `vitest.config.ts`'s
+`setupFiles`) fails any test that writes to the real directory instead, so a missing override is
+caught immediately rather than silently polluting the developer's or CI runner's real keystore
+(issue #114).
+
+If you're setting up a fixture that already redirects `ATTEST_IT_HOME` to an isolated temp
+directory, set `VAULTKEEPER_CONFIG_DIR` to that same directory alongside it -- see
+`helpers/pty-fixture.ts` and `test/integration/non-interactive-setup.integration.test.ts` for the
+established pattern.
+
+**Note:** if your machine already has stray `.enc` files under `~/.config/vaultkeeper/file/` from
+before this guard existed (pre-#114 test runs leaked real secrets there), they are not cleaned up
+automatically -- the guard only prevents new leaks. It's safe to delete any `.enc` file there that
+doesn't correspond to a real identity you intentionally created with `attest-it identity create
+--storage file`.
+
 ## Contributing New Tests
 
 When adding new test scenarios:

--- a/packages/cli/test/helpers/pty-fixture.ts
+++ b/packages/cli/test/helpers/pty-fixture.ts
@@ -94,7 +94,10 @@ export interface SealPromptFixture {
   projectDir: string
   /** Directory used as this fixture's isolated `ATTEST_IT_HOME`. */
   homeDir: string
-  /** Env vars (`ATTEST_IT_HOME`) to pass to any CLI invocation against this fixture. */
+  /**
+   * Env vars (`ATTEST_IT_HOME`, `VAULTKEEPER_CONFIG_DIR`) to pass to any CLI
+   * invocation against this fixture.
+   */
   env: NodeJS.ProcessEnv
   /** Name of the suite/gate configured, authorized for the fixture's identity. */
   suiteName: string
@@ -110,7 +113,10 @@ export interface SealPromptFixture {
 export async function setupSealPromptFixture(): Promise<SealPromptFixture> {
   const projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-pty-project-'))
   const homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-pty-home-'))
-  const env = { ATTEST_IT_HOME: homeDir, NO_COLOR: '1' }
+  // Issue #114: also redirect VaultKeeper's `file` backend to this same
+  // isolated temp home, so `identity create --storage file` below never
+  // touches the real `~/.config/vaultkeeper/file/`.
+  const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir, NO_COLOR: '1' }
   const suiteName = 'smoke'
   const gateId = 'smoke'
 

--- a/packages/cli/test/identity-create.test.ts
+++ b/packages/cli/test/identity-create.test.ts
@@ -128,12 +128,18 @@ function withFakeStdin<T>(content: string, fn: () => Promise<T>): Promise<T> {
 describe('runCreate (non-interactive)', () => {
   let tempHome: string
   const originalIsTTY = process.stdin.isTTY
+  // Issue #114: `--storage file` stores real key material via VaultKeeper's
+  // `file` backend, which -- unless redirected -- writes to the developer's/
+  // CI runner's real `~/.config/vaultkeeper/file/` directory. Redirect it to
+  // the same isolated temp dir used for ATTEST_IT_HOME.
+  const originalVaultKeeperConfigDir = process.env.VAULTKEEPER_CONFIG_DIR
   let mockProcessExit: ReturnType<typeof vi.spyOn>
   let mockConsoleError: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-it-identity-create-'))
     setAttestItHomeDir(tempHome)
+    process.env.VAULTKEEPER_CONFIG_DIR = tempHome
 
     // Simulate a bare CI machine: only the filesystem backend is usable.
     vi.mocked(isOnePasswordInstalled).mockResolvedValue(false)
@@ -152,6 +158,11 @@ describe('runCreate (non-interactive)', () => {
 
   afterEach(() => {
     setAttestItHomeDir(null)
+    if (originalVaultKeeperConfigDir === undefined) {
+      delete process.env.VAULTKEEPER_CONFIG_DIR
+    } else {
+      process.env.VAULTKEEPER_CONFIG_DIR = originalVaultKeeperConfigDir
+    }
     fs.rmSync(tempHome, { recursive: true, force: true })
     Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
     vi.restoreAllMocks()

--- a/packages/cli/test/integration/getting-started.integration.test.ts
+++ b/packages/cli/test/integration/getting-started.integration.test.ts
@@ -129,7 +129,10 @@ describe('documented getting-started flow end-to-end (issue #84)', () => {
   it(
     'AC: init succeeds on the exact package.json npm install leaves behind (no name/version)',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend (used by the
+      // `identity create --storage file` step below) to this same isolated
+      // temp home, so the real `~/.config/vaultkeeper/file/` is never touched.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
       // This is exactly what `npm install <pkg>` produces in a directory with
       // no prior package.json (README Quick Start step 1) -- verified by
@@ -160,7 +163,10 @@ describe('documented getting-started flow end-to-end (issue #84)', () => {
       'define a gate -> seal -> status -> verify) succeeds with no undocumented ' +
       'manual YAML editing beyond the documented gate/suite step, and no undocumented prompts',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend (used by the
+      // `identity create --storage file` step below) to this same isolated
+      // temp home, so the real `~/.config/vaultkeeper/file/` is never touched.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
       // Mirror the README's own first command: a bare package.json with no
       // name/version, as `npm install attest-it` leaves behind.
@@ -310,7 +316,10 @@ describe('documented getting-started flow end-to-end (issue #84)', () => {
   it(
     'AC: identity export never guides users to the nonexistent team-config.yaml/members schema',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend (used by the
+      // `identity create --storage file` step below) to this same isolated
+      // temp home, so the real `~/.config/vaultkeeper/file/` is never touched.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
       const createResult = await runCliNonInteractive(
         ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],

--- a/packages/cli/test/integration/non-interactive-setup.integration.test.ts
+++ b/packages/cli/test/integration/non-interactive-setup.integration.test.ts
@@ -256,7 +256,10 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
   it(
     'runs identity create -> init -> run (seal) -> verify with zero TTY prompts and stdin closed throughout',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend to this same
+      // isolated temp home, so `identity create --storage file` never
+      // touches the real `~/.config/vaultkeeper/file/`.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
       // 1. identity create: the very first onboarding step. This is the
       // exact hang this issue reports -- it must complete with no prompt.
@@ -347,7 +350,10 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
   it(
     'fails fast (never hangs) when identity create is missing required flags with no TTY',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend to this same
+      // isolated temp home, so `identity create --storage file` never
+      // touches the real `~/.config/vaultkeeper/file/`.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
       const result = await runCliNonInteractive(['identity', 'create'], projectDir, env)
 
@@ -360,7 +366,10 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
   it(
     'fails fast (never hangs) when init would overwrite existing config without --force, with no TTY',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend to this same
+      // isolated temp home, so `identity create --storage file` never
+      // touches the real `~/.config/vaultkeeper/file/`.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
       const first = await runCliNonInteractive(['init'], projectDir, env)
       expect(first.exitCode).toBe(0)
@@ -375,7 +384,10 @@ describe('non-interactive setup end-to-end (issue #80)', () => {
   it(
     'fails fast (never hangs) when run has pending suites but neither --suite nor --all is given, with no TTY',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend to this same
+      // isolated temp home, so `identity create --storage file` never
+      // touches the real `~/.config/vaultkeeper/file/`.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
 
       const initResult = await runCliNonInteractive(['init'], projectDir, env)
       expect(initResult.exitCode).toBe(0)

--- a/packages/cli/test/integration/policy-comment-preservation.integration.test.ts
+++ b/packages/cli/test/integration/policy-comment-preservation.integration.test.ts
@@ -114,7 +114,10 @@ describe('policy.yaml comment preservation across mutating commands (issue #102)
   it(
     'keeps the schema directive and header/example comments after `team join` mutates a freshly-scaffolded policy.yaml',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend (used by the
+      // `identity create --storage file` step below) to this same isolated
+      // temp home, so the real `~/.config/vaultkeeper/file/` is never touched.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
       const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
 
       // 1. init: scaffolds policy.yaml with the schema directive, trust-model
@@ -168,7 +171,10 @@ describe('policy.yaml comment preservation across mutating commands (issue #102)
   it(
     'keeps preserving comments across a second mutating command (`team add`) on the same file',
     async () => {
-      const env = { ATTEST_IT_HOME: homeDir }
+      // Issue #114: also redirect VaultKeeper's `file` backend (used by the
+      // `identity create --storage file` step below) to this same isolated
+      // temp home, so the real `~/.config/vaultkeeper/file/` is never touched.
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
       const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
 
       await runCliNonInteractive(['init'], projectDir, env)

--- a/packages/cli/test/setup/vaultkeeper-isolation-guard.setup.ts
+++ b/packages/cli/test/setup/vaultkeeper-isolation-guard.setup.ts
@@ -1,0 +1,38 @@
+/**
+ * Global vitest wiring for the VaultKeeper test-isolation guard (issue #114).
+ *
+ * Registered via `test.setupFiles` in `vitest.config.ts` so it runs for
+ * every test in this package. Snapshots the REAL VaultKeeper config
+ * directory before the suite and after every test, failing the offending
+ * test loudly if any new file appeared there -- the signal that some test
+ * exercised the `file` backend without redirecting it to an isolated
+ * `VAULTKEEPER_CONFIG_DIR` temp directory.
+ *
+ * @see vaultkeeper-isolation-guard.ts for the pure, unit-tested logic.
+ * @packageDocumentation
+ */
+import { afterEach, beforeAll } from 'vitest'
+import {
+  assertNoNewEntries,
+  collectFilesRecursive,
+  resolveRealVaultKeeperConfigDir,
+} from './vaultkeeper-isolation-guard.js'
+
+const REAL_VAULTKEEPER_CONFIG_DIR = resolveRealVaultKeeperConfigDir()
+let baseline: string[] = []
+
+beforeAll(() => {
+  baseline = collectFilesRecursive(REAL_VAULTKEEPER_CONFIG_DIR)
+})
+
+afterEach(() => {
+  const current = collectFilesRecursive(REAL_VAULTKEEPER_CONFIG_DIR)
+  try {
+    assertNoNewEntries(REAL_VAULTKEEPER_CONFIG_DIR, baseline, current)
+  } finally {
+    // Re-baseline regardless of outcome so a single leak is reported once,
+    // on the test that caused it, rather than on every subsequent test in
+    // the same file/worker.
+    baseline = current
+  }
+})

--- a/packages/cli/test/setup/vaultkeeper-isolation-guard.test.ts
+++ b/packages/cli/test/setup/vaultkeeper-isolation-guard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression coverage for issue #114: several integration/UAT tests
+ * exercised the VaultKeeper `file` backend without an isolated
+ * `VAULTKEEPER_CONFIG_DIR`, silently writing into the developer's/CI
+ * runner's real `~/.config/vaultkeeper/file/` directory.
+ *
+ * These tests exercise the guard's pure logic (never the real
+ * `~/.config/vaultkeeper` directory -- everything here operates on
+ * disposable scratch directories under `os.tmpdir()`) to prove it actually
+ * detects a leak: `assertNoNewEntries` must throw when a new file appears
+ * between two {@link collectFilesRecursive} snapshots of the same
+ * directory, and must not throw when nothing changed. Against a guard that
+ * never compared snapshots at all (or compared them incorrectly), the
+ * "detects a new file" case below would fail to throw.
+ */
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  assertNoNewEntries,
+  collectFilesRecursive,
+  resolveRealVaultKeeperConfigDir,
+} from './vaultkeeper-isolation-guard.js'
+
+describe('resolveRealVaultKeeperConfigDir', () => {
+  it('resolves to a stable, platform-appropriate path under the home directory', () => {
+    const dir = resolveRealVaultKeeperConfigDir()
+    expect(dir).toContain('vaultkeeper')
+    expect(path.isAbsolute(dir)).toBe(true)
+  })
+
+  it('never reads VAULTKEEPER_CONFIG_DIR (must reflect the real, unoverridden location)', () => {
+    const original = process.env.VAULTKEEPER_CONFIG_DIR
+    process.env.VAULTKEEPER_CONFIG_DIR = '/some/isolated/test/temp/dir'
+    try {
+      const dir = resolveRealVaultKeeperConfigDir()
+      expect(dir).not.toBe('/some/isolated/test/temp/dir')
+    } finally {
+      if (original === undefined) {
+        delete process.env.VAULTKEEPER_CONFIG_DIR
+      } else {
+        process.env.VAULTKEEPER_CONFIG_DIR = original
+      }
+    }
+  })
+})
+
+describe('collectFilesRecursive', () => {
+  let scratchDir: string
+
+  afterEach(async () => {
+    if (scratchDir) {
+      await fs.rm(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns an empty list for a directory that does not exist', () => {
+    const missing = path.join(os.tmpdir(), 'attest-it-guard-test-does-not-exist')
+    expect(collectFilesRecursive(missing)).toEqual([])
+  })
+
+  it('lists nested files (mirroring <configDir>/file/<id>.enc) but not directories', async () => {
+    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-guard-scan-'))
+    await fs.mkdir(path.join(scratchDir, 'file'), { recursive: true })
+    await fs.writeFile(path.join(scratchDir, 'file', 'abc123.enc'), 'secret')
+    await fs.writeFile(path.join(scratchDir, 'config.yaml'), 'version: 1')
+
+    const files = collectFilesRecursive(scratchDir)
+
+    expect(files).toEqual(
+      [path.join(scratchDir, 'config.yaml'), path.join(scratchDir, 'file', 'abc123.enc')].sort(),
+    )
+    // Directories themselves must never appear in the listing.
+    expect(files).not.toContain(path.join(scratchDir, 'file'))
+  })
+})
+
+describe('assertNoNewEntries', () => {
+  it('does not throw when nothing changed between snapshots', () => {
+    const before = ['/tmp/vk/config.yaml']
+    const after = ['/tmp/vk/config.yaml']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).not.toThrow()
+  })
+
+  it('does not throw when files were only removed (never a false positive on cleanup)', () => {
+    const before = ['/tmp/vk/config.yaml', '/tmp/vk/file/stale.enc']
+    const after = ['/tmp/vk/config.yaml']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).not.toThrow()
+  })
+
+  // This is the core regression case: a leaking test would cause a new
+  // `.enc` file to appear under the real VaultKeeper directory between the
+  // "before" and "after" snapshots. Against a no-op or miswired guard, this
+  // would silently pass instead of throwing.
+  it('throws naming the new file when a leak writes into the guarded directory', () => {
+    const before = ['/tmp/vk/config.yaml']
+    const after = ['/tmp/vk/config.yaml', '/tmp/vk/file/leaked-secret.enc']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/leaked-secret\.enc/)
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/VAULTKEEPER_CONFIG_DIR/)
+  })
+
+  it('names every new file when a leak writes more than one', () => {
+    const before: string[] = []
+    const after = ['/tmp/vk/file/one.enc', '/tmp/vk/file/two.enc']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/one\.enc.*two\.enc|two\.enc.*one\.enc/)
+  })
+})

--- a/packages/cli/test/setup/vaultkeeper-isolation-guard.ts
+++ b/packages/cli/test/setup/vaultkeeper-isolation-guard.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure logic for the VaultKeeper test-isolation guard (issue #114).
+ *
+ * @remarks
+ * Several integration/UAT tests exercise the VaultKeeper `file` backend
+ * without redirecting it (via `VAULTKEEPER_CONFIG_DIR`) to an isolated temp
+ * directory, so they silently read/write the developer's or CI runner's
+ * REAL `~/.config/vaultkeeper/file/` directory -- accumulating stray
+ * `.enc` secret files there (300+ observed on at least one machine).
+ *
+ * This module contains the guard's pure, unit-testable logic: resolving
+ * the real (non-test-overridden) VaultKeeper config directory the same way
+ * VaultKeeper itself does, recursively snapshotting its contents, and
+ * asserting that no new files appeared between two snapshots. The vitest
+ * wiring (`beforeAll`/`afterEach`) that actually runs this against the real
+ * directory during a test run lives in `vaultkeeper-isolation-guard.setup.ts`,
+ * which is registered as a global `setupFiles` entry so it applies to every
+ * test in this package without each test file needing to opt in.
+ *
+ * @see vaultkeeper-isolation-guard.setup.ts
+ * @see vaultkeeper-isolation-guard.test.ts
+ * @packageDocumentation
+ */
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * Resolve the REAL VaultKeeper config directory -- i.e. where VaultKeeper's
+ * own `getPlatformDefaultConfigDir()` resolves to when `VAULTKEEPER_CONFIG_DIR`
+ * is unset. This intentionally does NOT read `process.env.VAULTKEEPER_CONFIG_DIR`
+ * -- the guard needs the real machine location regardless of whatever a test
+ * has (or hasn't) overridden the env var to, so it can detect writes that
+ * land there instead of an isolated temp directory.
+ */
+export function resolveRealVaultKeeperConfigDir(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA
+    if (appData !== undefined && appData !== '') {
+      return path.join(appData, 'vaultkeeper')
+    }
+    return path.join(os.homedir(), 'AppData', 'Roaming', 'vaultkeeper')
+  }
+  return path.join(os.homedir(), '.config', 'vaultkeeper')
+}
+
+/**
+ * Recursively list every file (not directory) under `dir`, as absolute
+ * paths, sorted for stable comparison. Returns an empty list if `dir`
+ * doesn't exist -- a missing directory is the common, expected case on a
+ * clean CI runner.
+ */
+export function collectFilesRecursive(dir: string): string[] {
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const results: string[] = []
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      results.push(...collectFilesRecursive(full))
+    } else {
+      results.push(full)
+    }
+  }
+  return results.sort()
+}
+
+/**
+ * Assert that `after` introduces no files beyond what was present in
+ * `before`. Throws a descriptive error naming the offending directory and
+ * the new file(s) if it does.
+ *
+ * @param dir - The directory being guarded (used only for the error message)
+ * @param before - A prior {@link collectFilesRecursive} snapshot
+ * @param after - A later {@link collectFilesRecursive} snapshot
+ */
+export function assertNoNewEntries(
+  dir: string,
+  before: readonly string[],
+  after: readonly string[],
+): void {
+  const beforeSet = new Set(before)
+  const newEntries = after.filter((entry) => !beforeSet.has(entry))
+  if (newEntries.length > 0) {
+    throw new Error(
+      `VaultKeeper test-isolation guard (issue #114): a test wrote to the REAL ` +
+        `VaultKeeper config directory (${dir}) instead of an isolated temp directory. ` +
+        `New file(s): ${newEntries.join(', ')}. Set process.env.VAULTKEEPER_CONFIG_DIR ` +
+        `(and pass it through to any spawned CLI subprocess's env) to a per-test temp ` +
+        `directory before invoking anything that stores or deletes keys via the ` +
+        `VaultKeeper file backend.`,
+    )
+  }
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/fixtures/**', 'test/docker/**'],
     environment: 'node',
+    // Fails any test that writes to the developer's/CI runner's real
+    // VaultKeeper config directory instead of an isolated
+    // VAULTKEEPER_CONFIG_DIR temp dir (issue #114).
+    setupFiles: ['./test/setup/vaultkeeper-isolation-guard.setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/core/test/setup/vaultkeeper-isolation-guard.setup.ts
+++ b/packages/core/test/setup/vaultkeeper-isolation-guard.setup.ts
@@ -1,0 +1,38 @@
+/**
+ * Global vitest wiring for the VaultKeeper test-isolation guard (issue #114).
+ *
+ * Registered via `test.setupFiles` in `vitest.config.ts` so it runs for
+ * every test in this package. Snapshots the REAL VaultKeeper config
+ * directory before the suite and after every test, failing the offending
+ * test loudly if any new file appeared there -- the signal that some test
+ * exercised the `file` backend without redirecting it to an isolated
+ * `VAULTKEEPER_CONFIG_DIR` temp directory.
+ *
+ * @see vaultkeeper-isolation-guard.ts for the pure, unit-tested logic.
+ * @packageDocumentation
+ */
+import { afterEach, beforeAll } from 'vitest'
+import {
+  assertNoNewEntries,
+  collectFilesRecursive,
+  resolveRealVaultKeeperConfigDir,
+} from './vaultkeeper-isolation-guard.js'
+
+const REAL_VAULTKEEPER_CONFIG_DIR = resolveRealVaultKeeperConfigDir()
+let baseline: string[] = []
+
+beforeAll(() => {
+  baseline = collectFilesRecursive(REAL_VAULTKEEPER_CONFIG_DIR)
+})
+
+afterEach(() => {
+  const current = collectFilesRecursive(REAL_VAULTKEEPER_CONFIG_DIR)
+  try {
+    assertNoNewEntries(REAL_VAULTKEEPER_CONFIG_DIR, baseline, current)
+  } finally {
+    // Re-baseline regardless of outcome so a single leak is reported once,
+    // on the test that caused it, rather than on every subsequent test in
+    // the same file/worker.
+    baseline = current
+  }
+})

--- a/packages/core/test/setup/vaultkeeper-isolation-guard.test.ts
+++ b/packages/core/test/setup/vaultkeeper-isolation-guard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression coverage for issue #114: several integration/UAT tests
+ * exercised the VaultKeeper `file` backend without an isolated
+ * `VAULTKEEPER_CONFIG_DIR`, silently writing into the developer's/CI
+ * runner's real `~/.config/vaultkeeper/file/` directory.
+ *
+ * These tests exercise the guard's pure logic (never the real
+ * `~/.config/vaultkeeper` directory -- everything here operates on
+ * disposable scratch directories under `os.tmpdir()`) to prove it actually
+ * detects a leak: `assertNoNewEntries` must throw when a new file appears
+ * between two {@link collectFilesRecursive} snapshots of the same
+ * directory, and must not throw when nothing changed. Against a guard that
+ * never compared snapshots at all (or compared them incorrectly), the
+ * "detects a new file" case below would fail to throw.
+ */
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  assertNoNewEntries,
+  collectFilesRecursive,
+  resolveRealVaultKeeperConfigDir,
+} from './vaultkeeper-isolation-guard.js'
+
+describe('resolveRealVaultKeeperConfigDir', () => {
+  it('resolves to a stable, platform-appropriate path under the home directory', () => {
+    const dir = resolveRealVaultKeeperConfigDir()
+    expect(dir).toContain('vaultkeeper')
+    expect(path.isAbsolute(dir)).toBe(true)
+  })
+
+  it('never reads VAULTKEEPER_CONFIG_DIR (must reflect the real, unoverridden location)', () => {
+    const original = process.env.VAULTKEEPER_CONFIG_DIR
+    process.env.VAULTKEEPER_CONFIG_DIR = '/some/isolated/test/temp/dir'
+    try {
+      const dir = resolveRealVaultKeeperConfigDir()
+      expect(dir).not.toBe('/some/isolated/test/temp/dir')
+    } finally {
+      if (original === undefined) {
+        delete process.env.VAULTKEEPER_CONFIG_DIR
+      } else {
+        process.env.VAULTKEEPER_CONFIG_DIR = original
+      }
+    }
+  })
+})
+
+describe('collectFilesRecursive', () => {
+  let scratchDir: string
+
+  afterEach(async () => {
+    if (scratchDir) {
+      await fs.rm(scratchDir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns an empty list for a directory that does not exist', () => {
+    const missing = path.join(os.tmpdir(), 'attest-it-guard-test-does-not-exist')
+    expect(collectFilesRecursive(missing)).toEqual([])
+  })
+
+  it('lists nested files (mirroring <configDir>/file/<id>.enc) but not directories', async () => {
+    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-guard-scan-'))
+    await fs.mkdir(path.join(scratchDir, 'file'), { recursive: true })
+    await fs.writeFile(path.join(scratchDir, 'file', 'abc123.enc'), 'secret')
+    await fs.writeFile(path.join(scratchDir, 'config.yaml'), 'version: 1')
+
+    const files = collectFilesRecursive(scratchDir)
+
+    expect(files).toEqual(
+      [path.join(scratchDir, 'config.yaml'), path.join(scratchDir, 'file', 'abc123.enc')].sort(),
+    )
+    // Directories themselves must never appear in the listing.
+    expect(files).not.toContain(path.join(scratchDir, 'file'))
+  })
+})
+
+describe('assertNoNewEntries', () => {
+  it('does not throw when nothing changed between snapshots', () => {
+    const before = ['/tmp/vk/config.yaml']
+    const after = ['/tmp/vk/config.yaml']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).not.toThrow()
+  })
+
+  it('does not throw when files were only removed (never a false positive on cleanup)', () => {
+    const before = ['/tmp/vk/config.yaml', '/tmp/vk/file/stale.enc']
+    const after = ['/tmp/vk/config.yaml']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).not.toThrow()
+  })
+
+  // This is the core regression case: a leaking test would cause a new
+  // `.enc` file to appear under the real VaultKeeper directory between the
+  // "before" and "after" snapshots. Against a no-op or miswired guard, this
+  // would silently pass instead of throwing.
+  it('throws naming the new file when a leak writes into the guarded directory', () => {
+    const before = ['/tmp/vk/config.yaml']
+    const after = ['/tmp/vk/config.yaml', '/tmp/vk/file/leaked-secret.enc']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/leaked-secret\.enc/)
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/VAULTKEEPER_CONFIG_DIR/)
+  })
+
+  it('names every new file when a leak writes more than one', () => {
+    const before: string[] = []
+    const after = ['/tmp/vk/file/one.enc', '/tmp/vk/file/two.enc']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/one\.enc.*two\.enc|two\.enc.*one\.enc/)
+  })
+})

--- a/packages/core/test/setup/vaultkeeper-isolation-guard.ts
+++ b/packages/core/test/setup/vaultkeeper-isolation-guard.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure logic for the VaultKeeper test-isolation guard (issue #114).
+ *
+ * @remarks
+ * Several integration/UAT tests exercise the VaultKeeper `file` backend
+ * without redirecting it (via `VAULTKEEPER_CONFIG_DIR`) to an isolated temp
+ * directory, so they silently read/write the developer's or CI runner's
+ * REAL `~/.config/vaultkeeper/file/` directory -- accumulating stray
+ * `.enc` secret files there (300+ observed on at least one machine).
+ *
+ * This module contains the guard's pure, unit-testable logic: resolving
+ * the real (non-test-overridden) VaultKeeper config directory the same way
+ * VaultKeeper itself does, recursively snapshotting its contents, and
+ * asserting that no new files appeared between two snapshots. The vitest
+ * wiring (`beforeAll`/`afterEach`) that actually runs this against the real
+ * directory during a test run lives in `vaultkeeper-isolation-guard.setup.ts`,
+ * which is registered as a global `setupFiles` entry so it applies to every
+ * test in this package without each test file needing to opt in.
+ *
+ * @see vaultkeeper-isolation-guard.setup.ts
+ * @see vaultkeeper-isolation-guard.test.ts
+ * @packageDocumentation
+ */
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+/**
+ * Resolve the REAL VaultKeeper config directory -- i.e. where VaultKeeper's
+ * own `getPlatformDefaultConfigDir()` resolves to when `VAULTKEEPER_CONFIG_DIR`
+ * is unset. This intentionally does NOT read `process.env.VAULTKEEPER_CONFIG_DIR`
+ * -- the guard needs the real machine location regardless of whatever a test
+ * has (or hasn't) overridden the env var to, so it can detect writes that
+ * land there instead of an isolated temp directory.
+ */
+export function resolveRealVaultKeeperConfigDir(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA
+    if (appData !== undefined && appData !== '') {
+      return path.join(appData, 'vaultkeeper')
+    }
+    return path.join(os.homedir(), 'AppData', 'Roaming', 'vaultkeeper')
+  }
+  return path.join(os.homedir(), '.config', 'vaultkeeper')
+}
+
+/**
+ * Recursively list every file (not directory) under `dir`, as absolute
+ * paths, sorted for stable comparison. Returns an empty list if `dir`
+ * doesn't exist -- a missing directory is the common, expected case on a
+ * clean CI runner.
+ */
+export function collectFilesRecursive(dir: string): string[] {
+  let entries: fs.Dirent[]
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const results: string[] = []
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      results.push(...collectFilesRecursive(full))
+    } else {
+      results.push(full)
+    }
+  }
+  return results.sort()
+}
+
+/**
+ * Assert that `after` introduces no files beyond what was present in
+ * `before`. Throws a descriptive error naming the offending directory and
+ * the new file(s) if it does.
+ *
+ * @param dir - The directory being guarded (used only for the error message)
+ * @param before - A prior {@link collectFilesRecursive} snapshot
+ * @param after - A later {@link collectFilesRecursive} snapshot
+ */
+export function assertNoNewEntries(
+  dir: string,
+  before: readonly string[],
+  after: readonly string[],
+): void {
+  const beforeSet = new Set(before)
+  const newEntries = after.filter((entry) => !beforeSet.has(entry))
+  if (newEntries.length > 0) {
+    throw new Error(
+      `VaultKeeper test-isolation guard (issue #114): a test wrote to the REAL ` +
+        `VaultKeeper config directory (${dir}) instead of an isolated temp directory. ` +
+        `New file(s): ${newEntries.join(', ')}. Set process.env.VAULTKEEPER_CONFIG_DIR ` +
+        `(and pass it through to any spawned CLI subprocess's env) to a per-test temp ` +
+        `directory before invoking anything that stores or deletes keys via the ` +
+        `VaultKeeper file backend.`,
+    )
+  }
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     include: ['test/**/*.test.ts'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/fixtures/**'],
     environment: 'node',
+    // Fails any test that writes to the developer's/CI runner's real
+    // VaultKeeper config directory instead of an isolated
+    // VAULTKEEPER_CONFIG_DIR temp dir (issue #114).
+    setupFiles: ['./test/setup/vaultkeeper-isolation-guard.setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Several integration/UAT tests invoked the CLI with `--storage file` without redirecting
VaultKeeper's config directory, so they silently read/wrote the developer's/CI runner's real
`~/.config/vaultkeeper/file/` instead of an isolated temp dir (300+ stray `.enc` files observed on
at least one machine). This PR isolates every remaining offender found by a full sweep of the test
tree, and adds a global vitest setup guard (in both `@attest-it/cli` and `@attest-it/core`) that
fails any test writing to the real VaultKeeper directory, so this can't silently regress again.

Refs #114

## Test files/cases isolated

Full sweep method: grepped the whole test tree for `--storage file`, `'file'`/`"file"` private-key
references, `storePrivateKey`/`deletePrivateKey` calls, and any subprocess `spawn(...)` of the
built CLI, then manually traced each hit to determine whether it exercises the *real* VaultKeeper
`file` backend (as opposed to a fully-mocked `@attest-it/core`, where `type: 'file'` is just
literal test data with no real I/O).

**Newly isolated (were leaking, now fixed via `VAULTKEEPER_CONFIG_DIR`):**

- `packages/cli/test/identity-create.test.ts` — `runCreate` drives real `storePrivateKey` in-process;
  `beforeEach`/`afterEach` now set/restore `process.env.VAULTKEEPER_CONFIG_DIR` alongside the
  existing `setAttestItHomeDir` temp-home isolation.
- `packages/cli/test/integration/getting-started.integration.test.ts` — all 3 `env` objects passed
  to the spawned CLI subprocess now also set `VAULTKEEPER_CONFIG_DIR: homeDir`.
- `packages/cli/test/integration/non-interactive-setup.integration.test.ts` — the 4 `env` objects
  that were missing it (the 3 already using it, added in #109 for issue #101, are untouched).
- `packages/cli/test/integration/policy-comment-preservation.integration.test.ts` — both `env`
  objects.
- `packages/cli/test/helpers/pty-fixture.ts` (`setupSealPromptFixture`, shared by
  `test/pty/run-cancellation.pty.test.ts` and `test/run-missing-yes-headless.integration.test.ts`) —
  the fixture's `env` now also sets `VAULTKEEPER_CONFIG_DIR: homeDir`.

**Already isolated, left as-is (confirmed correct, not touched):**

- `packages/cli/test/identity-remove.test.ts` (issue #101 fix, PR #109) — its only real
  `storePrivateKey`/`deletePrivateKey` call is in the describe block that already redirects
  `VAULTKEEPER_CONFIG_DIR`; every other describe block in that file uses mocked
  `loadLocalConfig`/`saveLocalConfig` with `type: 'filesystem'`/`'1password'`/`'keychain'`
  references that never reach a real VaultKeeper backend.
- `packages/core/test/key-provider/store.test.ts` — already redirects `VAULTKEEPER_CONFIG_DIR`.

**Confirmed NOT leaking (no real backend I/O, just literal `'file'`-typed test fixtures behind a
fully-mocked `@attest-it/core` or `vaultkeeper`):** `identity-export.test.ts`, `seal.test.ts`,
`team-join.test.ts`, `packages/core/test/identity/config.test.ts`,
`packages/core/test/key-provider/registry.test.ts` (mocks `vaultkeeper`'s `BackendRegistry`
entirely), `packages/core/test/schemas/schema-contract.test.ts`,
`packages/github-action/test/fetch-policy.test.ts`. `packages/cli/test/docker/**` scripts run
inside a Docker container against the container's own `$HOME` (separate CI job, out of scope) and
`test/manual/**` scripts are human-run-only, not part of the automated suite.

## Guard implementation

`packages/{cli,core}/test/setup/vaultkeeper-isolation-guard.ts` — pure, unit-tested logic:
- `resolveRealVaultKeeperConfigDir()` resolves the REAL VaultKeeper config dir the same way
  VaultKeeper's own `getPlatformDefaultConfigDir()` does (`~/.config/vaultkeeper`, or the Windows
  equivalent) — deliberately ignoring `VAULTKEEPER_CONFIG_DIR` so it always points at the machine's
  actual location regardless of what a given test has overridden.
- `collectFilesRecursive(dir)` recursively lists every file under that directory.
- `assertNoNewEntries(dir, before, after)` throws, naming the new file(s) and pointing at
  `VAULTKEEPER_CONFIG_DIR`, if `after` contains anything `before` didn't.

`packages/{cli,core}/test/setup/vaultkeeper-isolation-guard.setup.ts` wires this into vitest via
`beforeAll`/`afterEach`, registered as a `test.setupFiles` entry in each package's
`vitest.config.ts` — so it runs for *every* test in the package, not just ones that opt in.
Snapshots the real directory before the suite, re-diffs after every single test, and fails the
offending test immediately, naming the leaked file(s).

**How it fails on a regression:** verified live during this PR by temporarily reverting the
`identity-create.test.ts` fix (removing its `VAULTKEEPER_CONFIG_DIR` override) and re-running —
the guard failed with:

```
VaultKeeper test-isolation guard (issue #114): a test wrote to the REAL VaultKeeper config
directory (/Users/mnorth/.config/vaultkeeper) instead of an isolated temp directory. New file(s):
/Users/mnorth/.config/vaultkeeper/file/<hex>.enc. Set process.env.VAULTKEEPER_CONFIG_DIR ...
```

The leaked file was deleted and the fix restored before committing. This guard **is** the
regression test for this issue's second acceptance criterion; `vaultkeeper-isolation-guard.test.ts`
additionally unit-tests the guard's pure comparison/collection logic against disposable scratch
directories (never the real one) so its detection logic itself is covered without ever writing
into a real developer/CI keystore during a normal test run.

`@attest-it/github-action` was deliberately left unguarded — confirmed by inspection that none of
its tests exercise a real VaultKeeper backend (every `type: 'file'` reference there is inert test
data behind full mocks), so there's nothing to catch there today.

## Docs

Added a "VaultKeeper Test Isolation" section to `packages/cli/test/README.md` explaining the
`VAULTKEEPER_CONFIG_DIR` convention, the guard, and a note that pre-existing stray `.enc` files
from before this guard existed aren't auto-cleaned (safe to manually delete anything not
corresponding to an identity you intentionally created).

## Changeset

None. This is a test-only / test-harness change with no changes under any package's `src/` and no
public API or runtime behavior change for consumers of `@attest-it/cli` or `@attest-it/core`.

## Acceptance criteria mapping

1. "Every integration/UAT test... points at an isolated temp config dir" — covered by the fixes
   listed above; verified with the existing full test suites (`packages/cli` 43 files / 787 tests,
   `packages/core` 26 files / 560 tests) run against this developer machine's real (~500-file)
   VaultKeeper directory, confirming zero new files appeared before and after the full run.
2. "Add a guard/lint that fails if a test writes to the real vaultkeeper directory" — covered by
   `vaultkeeper-isolation-guard.setup.ts` + `vaultkeeper-isolation-guard.ts`, unit-tested in
   `vaultkeeper-isolation-guard.test.ts`, and manually verified to fail (see above).
3. "(Optional) a note about accumulated stray `.enc` files" — covered in
   `packages/cli/test/README.md`.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm run check` (lint + typecheck + api-report, all 3 packages)
- [x] `pnpm run test` (43 + 26 + 3 test files, all green)
- [x] Manually confirmed `find ~/.config/vaultkeeper -type f | wc -l` is unchanged (504) before and
      after the full `packages/cli` + `packages/core` test runs
- [x] Manually confirmed the guard fails loudly (and names the leaked file) when isolation is
      removed, then restored the fix
