### PR TITLE
feat(core): adopt VaultKeeper delegated signing and presence capability

### DIFF
--- a/.changeset/vaultkeeper-delegated-signing.md
+++ b/.changeset/vaultkeeper-delegated-signing.md
@@ -1,0 +1,13 @@
+---
+'@attest-it/core': minor
+'@attest-it/cli': minor
+---
+
+Adopt VaultKeeper's delegated-signing (`SigningBackend`) and presence-capability surface.
+
+- **Delegated signing for signing-capable backends.** `VaultKeyProvider` now uses VaultKeeper's `SigningBackend` contract (`generateSigningKey` / `getPublicKey` / `signWithKey`) when the underlying backend implements it (guarded by `isSigningBackend`). For such backends the private key is generated and held inside the backend and signing is delegated — the raw key never reaches attest-it's process memory as a file, let alone disk. Backends that only implement the base `SecretBackend` contract keep the existing `getPrivateKey()` temp-file path unchanged (additive, not a removal).
+- **`KeyProvider` interface extension (additive, optional).** Three optional members were added: `signDirectly?(keyRef, data)`, `supportsDelegatedSigning?(keyRef)`, and `getPresenceCapability?()`. Existing implementers and callers are unaffected — hence a **minor** bump, not major.
+- **Presence capability surfaced.** `attest-it identity show` now reports whether the active identity's backend enforces a fresh per-use human-presence check, fail-closed for backends that cannot prove it. New helper `getIdentityPresenceCapability()` is exported from `@attest-it/core`.
+- **New seal-signing helpers.** `createSealWithProvider()` (prefers delegated signing, falls back to the temp-file PEM path) and `createSealWithSigner()` are exported; the `seal`/`run` commands and the embeddable `seal()` API route through them.
+- **Root gate anchors with delegated keys too.** `createRootSealWithProvider()` lets a root signer whose key lives in a signing backend anchor `policy.yaml` without ever materializing the raw key; `seal --root` and `init`'s bootstrap ceremony use it, so a delegated-key identity can be a root signer.
+- **`@1password/sdk` is now an explicit dependency of `@attest-it/core`.** VaultKeeper 0.7.0 made it an optional peer for the 1Password backend (replacing the `op` CLI); declaring it keeps the VaultKeeper-backed 1Password path resolvable. Documented in the README and `docs/configuration.md`.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Keys are stored in your login keychain, protected by your system password. Avail
 
 ### 1Password
 
-Keys are stored as secure documents in your 1Password vault. Requires the 1Password CLI (`op`) to be installed and signed in.
+Keys are stored as secure documents in your 1Password vault via VaultKeeper's 1Password backend, which uses the 1Password SDK (`@1password/sdk`, installed as a dependency of attest-it) — the legacy 1Password CLI (`op`) is no longer required. Authenticate the SDK with a 1Password service account token (`OP_SERVICE_ACCOUNT_TOKEN`). See [configuration](docs/configuration.md#1password) for details.
 
 ### YubiKey (Hardware Security)
 
@@ -323,7 +323,7 @@ Keys are stored as secure documents in your 1Password vault. Requires the 1Passw
 
 **Optional** (for key storage):
 
-- 1Password CLI (`op`) for 1Password key storage
+- A 1Password service account token (`OP_SERVICE_ACCOUNT_TOKEN`) for 1Password key storage — the 1Password SDK (`@1password/sdk`) ships with attest-it, so the `op` CLI is not required
 - macOS for Keychain key storage
 - YubiKey with `ykman` CLI for hardware-protected key storage
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -520,7 +520,13 @@ privateKey:
 | `id`    | string      | Yes      | Opaque VaultKeeper secret ID for the key |
 | `vault` | string      | No       | 1Password vault name, for display/lookup |
 
-**Requirements:** 1Password CLI (`op`) must be installed
+**Requirements:** The VaultKeeper-backed 1Password backend uses the 1Password
+SDK ([`@1password/sdk`](https://www.npmjs.com/package/@1password/sdk)) — a
+`vaultkeeper` optional peer dependency that attest-it installs on your behalf
+(it ships as a dependency of `@attest-it/core`). The legacy 1Password CLI (`op`)
+is **no longer required** for this path. Authenticate the SDK with a 1Password
+[service account token](https://developer.1password.com/docs/service-accounts/)
+(`OP_SERVICE_ACCOUNT_TOKEN`) as documented by VaultKeeper.
 
 ---
 

--- a/packages/cli/src/commands/identity/show.ts
+++ b/packages/cli/src/commands/identity/show.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { loadLocalConfig } from '@attest-it/core'
+import { loadLocalConfig, getIdentityPresenceCapability } from '@attest-it/core'
 import { log, error } from '../../utils/output.js'
 import { ExitCode } from '../../utils/exit-codes.js'
 import { getTheme } from '../../components/theme.js'
@@ -84,6 +84,21 @@ async function runShow(slug?: string): Promise<void> {
         log(`    Type: File (legacy — not managed by VaultKeeper)`)
         log(`    Path: ${identity.privateKey.path}`)
         break
+    }
+    log('')
+
+    // Report whether the backend enforces a fresh per-use human presence check
+    // (e.g. a hardware touch or per-use biometric). Fail-closed: a backend that
+    // cannot prove per-use presence is reported as not enforcing it.
+    const presence = await getIdentityPresenceCapability(identity)
+    log('  Per-Use Presence:')
+    if (presence.presencePerUse) {
+      const scope = presence.presenceEnforcedOperations
+        ? presence.presenceEnforcedOperations.join(', ')
+        : 'all operations'
+      log(`    ${theme.green('Enforced')} (${scope})`)
+    } else {
+      log(`    Not enforced`)
     }
     log('')
   } catch (err) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,7 +9,6 @@ import {
   loadLocalConfigSync,
   getActiveIdentity,
   computePolicyFingerprintSync,
-  createRootSeal,
   findPolicyPath,
   readSealsSync,
   writeSealsSync,
@@ -21,7 +20,7 @@ import { confirmAction, isInteractiveTTY, handlePromptableError } from '../utils
 import { ExitCode } from '../utils/exit-codes.js'
 import { offerCompletionInstall } from '../utils/completion-offer.js'
 import { getPackageVersion } from '../utils/version.js'
-import { loadIdentitySigningKey } from '../utils/identity-key.js'
+import { createRootSealForIdentity } from '../utils/identity-key.js'
 
 export const initCommand = new Command('init')
   .description('Initialize attest-it split configuration (policy.yaml + config.yaml)')
@@ -442,13 +441,7 @@ async function bootstrapRootGate(
   const resolvedPolicyPath = findPolicyPath(projectRoot) ?? policyPath
   const policyFingerprint = computePolicyFingerprintSync(projectRoot, resolvedPolicyPath)
 
-  const { privateKeyPem, passphrase } = await loadIdentitySigningKey(identity)
-  const seal = createRootSeal({
-    policyFingerprint,
-    sealedBy: identitySlug,
-    privateKey: privateKeyPem,
-    ...(passphrase !== undefined && { passphrase }),
-  })
+  const seal = await createRootSealForIdentity(identity, policyFingerprint, identitySlug)
 
   const sealsFile = readSealsSync(projectRoot, sealsPath)
   // eslint-disable-next-line security/detect-object-injection -- ROOT_GATE_ID is a fixed reserved constant

--- a/packages/cli/src/commands/run-interactive.tsx
+++ b/packages/cli/src/commands/run-interactive.tsx
@@ -24,7 +24,7 @@ import {
   getActiveIdentity,
   getIdentityConfigDir,
   isAuthorizedSigner,
-  createSeal,
+  createSealWithProvider,
   readSealsSync,
   writeSealsSync,
   type AttestItConfig,
@@ -291,23 +291,15 @@ async function createSealForGate(
   const keyProvider = createKeyProviderFromIdentity(identity)
   const keyRef = getKeyRefFromIdentity(identity)
 
-  // Get private key from provider
-  const keyResult = await keyProvider.getPrivateKey(keyRef)
-
-  // Read the key file content
-  const fs = await import('node:fs/promises')
-  const privateKeyPem = await fs.readFile(keyResult.keyPath, 'utf8')
-
-  // Clean up after reading
-  await keyResult.cleanup()
-
-  // Create seal using identity slug (not display name) for verification lookup
+  // Sign the seal via the identity's backend. Delegated-signing backends sign
+  // without ever exposing the raw key; other backends fall back to a temp PEM.
   const identitySlug = localConfig.activeIdentity
-  const seal = createSeal({
+  const seal = await createSealWithProvider({
     gateId,
     fingerprint: fingerprintResult.fingerprint,
     sealedBy: identitySlug,
-    privateKey: privateKeyPem,
+    keyProvider,
+    keyRef,
   })
 
   // Read existing seals

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -13,10 +13,9 @@ import {
   loadLocalConfigSync,
   getActiveIdentity,
   isAuthorizedSigner,
-  createSeal,
+  createSealWithProvider,
   readSealsSync,
   writeSealsSync,
-  isEncryptedPrivateKeyPem,
   type AttestItConfig,
   type Identity,
 } from '@attest-it/core'
@@ -495,31 +494,19 @@ async function promptForSeal(
     const keyProvider = createKeyProviderFromIdentity(identity)
     const keyRef = getKeyRefFromIdentity(identity)
 
-    // Get private key from provider
-    const keyResult = await keyProvider.getPrivateKey(keyRef)
-
-    // Read the key file content
-    const fs = await import('node:fs/promises')
-    const privateKeyPem = await fs.readFile(keyResult.keyPath, 'utf8')
-
-    // Clean up after reading
-    await keyResult.cleanup()
-
-    // A file-backed key created with `identity create --passphrase-stdin` is
-    // encrypted; resolve the passphrase needed to sign with it from the
-    // environment, an interactive prompt, or fail fast. See issue #80.
-    const passphrase = isEncryptedPrivateKeyPem(privateKeyPem)
-      ? await resolveKeyPassphrase()
-      : undefined
-
-    // Create seal using identity slug (not display name) for verification lookup
+    // Sign the seal via the identity's backend. Delegated-signing backends sign
+    // without ever exposing the raw key; the fallback retrieves the PEM and, when
+    // it is passphrase-encrypted (e.g. `identity create --passphrase-stdin`),
+    // resolves the passphrase from the environment, a prompt, or fails fast
+    // (see issue #80).
     const identitySlug = localConfig.activeIdentity
-    const seal = createSeal({
+    const seal = await createSealWithProvider({
       gateId,
       fingerprint: gateFingerprint.fingerprint,
       sealedBy: identitySlug,
-      privateKey: privateKeyPem,
-      ...(passphrase !== undefined && { passphrase }),
+      keyProvider,
+      keyRef,
+      resolvePassphrase: resolveKeyPassphrase,
     })
 
     // Read existing seals

--- a/packages/cli/src/commands/seal.ts
+++ b/packages/cli/src/commands/seal.ts
@@ -10,15 +10,13 @@ import {
   getActiveIdentity,
   computeFingerprintSync,
   computePolicyFingerprintSync,
-  createRootSeal,
   findPolicyPath,
   isAuthorizedSigner,
   getGate,
-  createSeal,
+  createSealWithProvider,
   readSealsSync,
   writeSealsSync,
   verifyGateSeal,
-  isEncryptedPrivateKeyPem,
   KeyProviderRegistry,
   ROOT_GATE_ID,
   API_SCHEMA_VERSION,
@@ -31,7 +29,7 @@ import {
 import { log, success, error, warn, verbose, outputJson } from '../utils/output.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { resolveKeyPassphrase } from '../utils/passphrase.js'
-import { loadIdentitySigningKey } from '../utils/identity-key.js'
+import { createRootSealForIdentity } from '../utils/identity-key.js'
 
 export const sealCommand = new Command('seal')
   .description('Create seals for gates')
@@ -296,14 +294,7 @@ async function runSealRoot(options: SealOptions): Promise<void> {
       process.exit(ExitCode.SUCCESS)
     }
 
-    const { privateKeyPem, passphrase } = await loadIdentitySigningKey(identity)
-
-    const seal = createRootSeal({
-      policyFingerprint,
-      sealedBy: identitySlug,
-      privateKey: privateKeyPem,
-      ...(passphrase !== undefined && { passphrase }),
-    })
+    const seal = await createRootSealForIdentity(identity, policyFingerprint, identitySlug)
 
     const sealsFile = readSealsSync(projectRoot, config.settings.sealsPath)
     // eslint-disable-next-line security/detect-object-injection -- ROOT_GATE_ID is a fixed reserved constant
@@ -421,33 +412,20 @@ async function processSingleGate(
 
   // Create key provider from identity's private key reference
   const keyProvider = createKeyProviderFromIdentity(identity)
-
-  // Get private key from provider
   const keyRef = getKeyRefFromIdentity(identity)
-  const keyResult = await keyProvider.getPrivateKey(keyRef)
 
-  // Read the key file content
-  const fs = await import('node:fs/promises')
-  const privateKeyPem = await fs.readFile(keyResult.keyPath, 'utf8')
-
-  // Clean up after reading
-  await keyResult.cleanup()
-
-  // A file-backed key created with `identity create --passphrase-stdin` is
-  // encrypted; resolve the passphrase needed to sign with it from the
-  // environment, an interactive prompt, or fail fast. Shared with `run`'s
-  // seal-creation path -- see issue #94.
-  const passphrase = isEncryptedPrivateKeyPem(privateKeyPem)
-    ? await resolveKeyPassphrase()
-    : undefined
-
-  // Create seal using identity slug (not display name) for verification lookup
-  const seal = createSeal({
+  // Sign the seal via the identity's backend. Delegated-signing backends sign
+  // without ever exposing the raw key; the fallback retrieves the PEM and, when
+  // it is passphrase-encrypted (e.g. `identity create --passphrase-stdin`),
+  // resolves the passphrase from the environment, a prompt, or fails fast
+  // (shared with `run`'s seal-creation path -- see issue #94).
+  const seal = await createSealWithProvider({
     gateId,
     fingerprint: fingerprintResult.fingerprint,
     sealedBy: identitySlug,
-    privateKey: privateKeyPem,
-    ...(passphrase !== undefined && { passphrase }),
+    keyProvider,
+    keyRef,
+    resolvePassphrase: resolveKeyPassphrase,
   })
 
   // Add seal to seals file

--- a/packages/cli/src/utils/identity-key.ts
+++ b/packages/cli/src/utils/identity-key.ts
@@ -9,8 +9,12 @@
  * @module
  */
 
-import { readFile } from 'node:fs/promises'
-import { KeyProviderRegistry, isEncryptedPrivateKeyPem, type Identity } from '@attest-it/core'
+import {
+  KeyProviderRegistry,
+  createRootSealWithProvider,
+  type Identity,
+  type Seal,
+} from '@attest-it/core'
 import { resolveKeyPassphrase } from './passphrase.js'
 
 /**
@@ -64,38 +68,33 @@ function getKeyRefFromIdentity(identity: Identity): string {
 }
 
 /**
- * The material needed to sign with an identity: the PEM private key and, when it
- * is passphrase-encrypted, the resolved passphrase.
- */
-export interface IdentitySigningKey {
-  /** PEM-encoded private key. */
-  privateKeyPem: string
-  /** Passphrase for the key, if it is encrypted. */
-  passphrase?: string
-}
-
-/**
- * Load the PEM private key behind an identity through its key-provider backend
- * and resolve a passphrase if the key is encrypted.
+ * Create the root-gate seal over the policy file for an identity, through its
+ * key-provider backend.
+ *
+ * @remarks
+ * Prefers delegated signing (the raw key never leaves the backend) and falls
+ * back to the temp-file PEM path for non-signing backends, resolving a
+ * passphrase when the key is encrypted. This is the single audited signing path
+ * shared by `seal --root` and `init`'s bootstrap ceremony.
  *
  * @param identity - The active identity to sign with.
- * @returns The signing key material.
+ * @param policyFingerprint - Fingerprint of the policy file being anchored.
+ * @param sealedBy - Team member slug creating the root seal.
+ * @returns The created root seal.
  */
-export async function loadIdentitySigningKey(identity: Identity): Promise<IdentitySigningKey> {
+export async function createRootSealForIdentity(
+  identity: Identity,
+  policyFingerprint: string,
+  sealedBy: string,
+): Promise<Seal> {
   const keyProvider = createKeyProviderFromIdentity(identity)
   const keyRef = getKeyRefFromIdentity(identity)
 
-  const keyResult = await keyProvider.getPrivateKey(keyRef)
-  let privateKeyPem: string
-  try {
-    privateKeyPem = await readFile(keyResult.keyPath, 'utf8')
-  } finally {
-    await keyResult.cleanup()
-  }
-
-  if (isEncryptedPrivateKeyPem(privateKeyPem)) {
-    const passphrase = await resolveKeyPassphrase()
-    return { privateKeyPem, passphrase }
-  }
-  return { privateKeyPem }
+  return createRootSealWithProvider({
+    policyFingerprint,
+    sealedBy,
+    keyProvider,
+    keyRef,
+    resolvePassphrase: resolveKeyPassphrase,
+  })
 }

--- a/packages/cli/test/passphrase.test.ts
+++ b/packages/cli/test/passphrase.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for `resolveKeyPassphrase` — the non-interactive-safe passphrase
+ * resolution shared by `seal` and `run` for encrypted file-backed keys.
+ *
+ * @see issue #94 (seal passphrase handling), issue #80/#87 (fail-fast policy)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@inquirer/prompts', () => ({ password: vi.fn() }))
+vi.mock('../src/utils/prompts.js', () => ({ isInteractiveTTY: vi.fn(() => false) }))
+
+const { password } = await import('@inquirer/prompts')
+const { isInteractiveTTY } = await import('../src/utils/prompts.js')
+const { resolveKeyPassphrase } = await import('../src/utils/passphrase.js')
+
+const PASSPHRASE_ENV = 'ATTEST_IT_KEY_PASSPHRASE'
+const originalEnvValue = process.env[PASSPHRASE_ENV]
+
+describe('resolveKeyPassphrase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env[PASSPHRASE_ENV]
+    vi.mocked(isInteractiveTTY).mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    if (originalEnvValue === undefined) {
+      delete process.env[PASSPHRASE_ENV]
+    } else {
+      process.env[PASSPHRASE_ENV] = originalEnvValue
+    }
+  })
+
+  it('returns the env var value without prompting', async () => {
+    process.env[PASSPHRASE_ENV] = 'env-secret'
+    await expect(resolveKeyPassphrase()).resolves.toBe('env-secret')
+    expect(password).not.toHaveBeenCalled()
+  })
+
+  it('prompts interactively when the env var is unset and stdin is a TTY', async () => {
+    vi.mocked(isInteractiveTTY).mockReturnValue(true)
+    vi.mocked(password).mockResolvedValue('prompted-secret')
+
+    await expect(resolveKeyPassphrase()).resolves.toBe('prompted-secret')
+    expect(password).toHaveBeenCalledOnce()
+  })
+
+  it('fails fast naming the env var when non-interactive and the env var is unset', async () => {
+    await expect(resolveKeyPassphrase()).rejects.toThrow(PASSPHRASE_ENV)
+    expect(password).not.toHaveBeenCalled()
+  })
+
+  it('ignores an empty env var and falls through to the fail-fast path', async () => {
+    process.env[PASSPHRASE_ENV] = ''
+    await expect(resolveKeyPassphrase()).rejects.toThrow(PASSPHRASE_ENV)
+    expect(password).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/test/seal.test.ts
+++ b/packages/cli/test/seal.test.ts
@@ -20,18 +20,10 @@ vi.mock('@attest-it/core', async () => {
     readSealsSync: vi.fn(),
     writeSealsSync: vi.fn(),
     verifyGateSeal: vi.fn(),
-    isEncryptedPrivateKeyPem: vi.fn(),
-    createSeal: vi.fn(),
+    createSealWithProvider: vi.fn(),
     KeyProviderRegistry: { create: vi.fn() },
   }
 })
-
-// node:fs/promises.readFile is used to read the resolved key file's PEM
-// content before signing -- mocked so the encrypted-key passphrase tests
-// don't need a real file on disk.
-vi.mock('node:fs/promises', () => ({
-  readFile: vi.fn(),
-}))
 
 // @inquirer/prompts' password() -- used to prompt for an encrypted identity
 // key's passphrase interactively (shared with `run`, issue #94).
@@ -65,11 +57,9 @@ const {
   readSealsSync,
   writeSealsSync,
   verifyGateSeal,
-  isEncryptedPrivateKeyPem,
-  createSeal,
+  createSealWithProvider,
   KeyProviderRegistry,
 } = await import('@attest-it/core')
-const { readFile } = await import('node:fs/promises')
 const { password } = await import('@inquirer/prompts')
 const { isInteractiveTTY } = await import('../src/utils/prompts.js')
 const { runSeal } = await import('../src/commands/seal.js')
@@ -255,10 +245,11 @@ describe('seal --json', () => {
 // Regression coverage for issue #94: `seal` read a private key's raw PEM and
 // signed with it directly, with no passphrase handling at all -- so a
 // passphrase-encrypted file-backed key (created via `identity create
-// --passphrase-stdin`) simply failed to sign. `run`'s seal-creation path
-// already resolved this in #87; `seal` now shares that same
-// non-interactive-safe resolution (env var -> interactive prompt -> fail
-// fast) via `resolveKeyPassphrase`.
+// --passphrase-stdin`) simply failed to sign. Passphrase resolution now lives
+// in core's `createSealWithProvider` (which invokes the CLI's
+// `resolveKeyPassphrase` only when the retrieved key is encrypted); these tests
+// verify `seal` wires that resolver and surfaces its outcomes. The resolver's
+// own env -> prompt -> fail-fast policy is covered in `passphrase.test.ts`.
 describe('seal — encrypted private key passphrase (issue #94)', () => {
   const PASSPHRASE_ENV = 'ATTEST_IT_KEY_PASSPHRASE'
   const originalEnvValue = process.env[PASSPHRASE_ENV]
@@ -296,9 +287,6 @@ describe('seal — encrypted private key passphrase (issue #94)', () => {
       getPrivateKey: vi.fn().mockResolvedValue({ keyPath: '/tmp/key.pem', cleanup: vi.fn() }),
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal test double
     } as unknown as ReturnType<typeof KeyProviderRegistry.create>)
-    vi.mocked(readFile).mockResolvedValue(
-      '-----BEGIN ENCRYPTED PRIVATE KEY-----\nfake\n-----END ENCRYPTED PRIVATE KEY-----\n',
-    )
     return config
   }
 
@@ -312,30 +300,24 @@ describe('seal — encrypted private key passphrase (issue #94)', () => {
     }
   }
 
-  it('resolves the passphrase from ATTEST_IT_KEY_PASSPHRASE and signs without prompting', async () => {
+  it('signs using the env-var passphrase (via the resolver) without prompting', async () => {
     setupSigningMocks()
     process.env[PASSPHRASE_ENV] = 'env-secret'
-    vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(true)
-    vi.mocked(createSeal).mockReturnValue(fakeSeal())
+    // Simulate an encrypted key: createSealWithProvider invokes the resolver.
+    let resolved: string | undefined
+    vi.mocked(createSealWithProvider).mockImplementation(async (opts) => {
+      resolved = await opts.resolvePassphrase?.()
+      return fakeSeal()
+    })
 
     await runSeal(['test-gate'], { json: true })
 
-    expect(createSeal).toHaveBeenCalledWith(expect.objectContaining({ passphrase: 'env-secret' }))
+    expect(resolved).toBe('env-secret')
     expect(password).not.toHaveBeenCalled()
+    expect(vi.mocked(createSealWithProvider)).toHaveBeenCalledWith(
+      expect.objectContaining({ resolvePassphrase: expect.any(Function) as unknown }),
+    )
     expect(mockProcessExit).toHaveBeenCalledWith(0)
-  })
-
-  it('does not resolve or pass a passphrase for an unencrypted key', async () => {
-    setupSigningMocks()
-    vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(false)
-    vi.mocked(createSeal).mockReturnValue(fakeSeal())
-
-    await runSeal(['test-gate'], { json: true })
-
-    expect(createSeal).toHaveBeenCalledTimes(1)
-    const [options] = vi.mocked(createSeal).mock.calls[0] ?? []
-    expect(options).not.toHaveProperty('passphrase')
-    expect(password).not.toHaveBeenCalled()
   })
 
   it(
@@ -343,19 +325,21 @@ describe('seal — encrypted private key passphrase (issue #94)', () => {
       'and stdin is not a TTY',
     async () => {
       setupSigningMocks()
-      vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(true)
+      // Encrypted key + no env + non-TTY: the resolver fails fast and the error
+      // must surface as a per-gate failure, not a hang.
+      vi.mocked(createSealWithProvider).mockImplementation(async (opts) => {
+        await opts.resolvePassphrase?.()
+        return fakeSeal()
+      })
 
       await runSeal(['test-gate'], { json: true })
 
-      // Never invokes the prompt library, and never signs.
       expect(password).not.toHaveBeenCalled()
-      expect(createSeal).not.toHaveBeenCalled()
 
       const printed = mockConsoleLog.mock.calls.map((c) => String(c[0])).join('\n')
       expect(printed).toContain('passphrase-encrypted')
       expect(printed).toContain(PASSPHRASE_ENV)
-      // The failure is scoped to this gate (summary.failed), not a hang and
-      // not CONFIG_ERROR -- it surfaces as FAILURE (1).
+      // Scoped to this gate (summary.failed) -- surfaces as FAILURE (1).
       expect(mockProcessExit).toHaveBeenCalledWith(1)
     },
   )
@@ -363,15 +347,17 @@ describe('seal — encrypted private key passphrase (issue #94)', () => {
   it('prompts interactively for the passphrase when the env var is unset and stdin is a TTY', async () => {
     setupSigningMocks()
     vi.mocked(isInteractiveTTY).mockReturnValue(true)
-    vi.mocked(isEncryptedPrivateKeyPem).mockReturnValue(true)
     vi.mocked(password).mockResolvedValue('prompted-secret')
-    vi.mocked(createSeal).mockReturnValue(fakeSeal())
+    let resolved: string | undefined
+    vi.mocked(createSealWithProvider).mockImplementation(async (opts) => {
+      resolved = await opts.resolvePassphrase?.()
+      return fakeSeal()
+    })
 
     await runSeal(['test-gate'], { json: true })
 
     expect(password).toHaveBeenCalledTimes(1)
-    expect(createSeal).toHaveBeenCalledWith(
-      expect.objectContaining({ passphrase: 'prompted-secret' }),
-    )
+    expect(resolved).toBe('prompted-secret')
+    expect(mockProcessExit).toHaveBeenCalledWith(0)
   })
 })

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Buffer as Buffer_2 } from 'node:buffer';
 import { Document } from 'yaml';
 import { SecretBackend } from 'vaultkeeper';
 import { z } from 'zod';
@@ -63,6 +64,9 @@ export interface AttestItSettings {
 }
 
 // @public
+export type CanonicalSigner = (canonicalString: string) => Promise<string>;
+
+// @public
 export function checkOpenSSL(): Promise<string>;
 
 // @public
@@ -94,6 +98,15 @@ export function createRootSeal(params: {
 }): Seal;
 
 // @public
+export function createRootSealWithProvider(params: {
+    keyProvider: KeyProvider;
+    keyRef: string;
+    policyFingerprint: string;
+    resolvePassphrase?: () => Promise<string | undefined>;
+    sealedBy: string;
+}): Promise<Seal>;
+
+// @public
 export function createSeal(options: CreateSealOptions): Seal;
 
 // @public
@@ -103,6 +116,30 @@ export interface CreateSealOptions {
     passphrase?: string;
     privateKey: string;
     sealedBy: string;
+}
+
+// @public
+export function createSealWithProvider(options: CreateSealWithProviderOptions): Promise<Seal>;
+
+// @public
+export interface CreateSealWithProviderOptions {
+    fingerprint: string;
+    gateId: string;
+    keyProvider: KeyProvider;
+    keyRef: string;
+    resolvePassphrase?: () => Promise<string | undefined>;
+    sealedBy: string;
+}
+
+// @public
+export function createSealWithSigner(options: CreateSealWithSignerOptions): Promise<Seal>;
+
+// @public
+export interface CreateSealWithSignerOptions {
+    fingerprint: string;
+    gateId: string;
+    sealedBy: string;
+    sign: CanonicalSigner;
 }
 
 // @public
@@ -249,6 +286,9 @@ export function getHomePublicKeysDir(homeDir?: string): string;
 export function getIdentityConfigDir(homeDir?: string): string;
 
 // @public
+export function getIdentityPresenceCapability(identity: Identity): Promise<KeyPresenceCapability>;
+
+// @public
 export function getLocalConfigPath(homeDir?: string): string;
 
 // @public
@@ -333,13 +373,25 @@ export interface KeyPaths {
 }
 
 // @public
+export interface KeyPresenceCapability {
+    presenceEnforcedOperations?: readonly KeyPresenceOperation[];
+    presencePerUse: boolean;
+}
+
+// @public
+export type KeyPresenceOperation = 'delete' | 'read' | 'sign' | 'store';
+
+// @public
 export interface KeyProvider {
     readonly displayName: string;
     generateKeyPair(options: KeygenProviderOptions): Promise<KeyGenerationResult>;
     getConfig(): KeyProviderConfig;
+    getPresenceCapability?(): Promise<KeyPresenceCapability>;
     getPrivateKey(keyRef: string): Promise<KeyRetrievalResult>;
     isAvailable(): Promise<boolean>;
     keyExists(keyRef: string): Promise<boolean>;
+    signDirectly?(keyRef: string, data: Buffer | string): Promise<string>;
+    supportsDelegatedSigning?(keyRef: string): Promise<boolean>;
     readonly type: string;
 }
 
@@ -1067,9 +1119,12 @@ export class VaultKeyProvider implements KeyProvider {
     readonly displayName: string;
     generateKeyPair(options: KeygenProviderOptions): Promise<KeyGenerationResult>;
     getConfig(): KeyProviderConfig;
+    getPresenceCapability(): Promise<KeyPresenceCapability>;
     getPrivateKey(keyRef: string): Promise<KeyRetrievalResult>;
     isAvailable(): Promise<boolean>;
     keyExists(keyRef: string): Promise<boolean>;
+    readonly signDirectly?: (keyRef: string, data: Buffer_2 | string) => Promise<string>;
+    supportsDelegatedSigning(keyRef: string): Promise<boolean>;
     // (undocumented)
     readonly type: string;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "version": "0.10.1",
   "author": "Mike North <michael.l.north@gmail.com>",
   "dependencies": {
+    "@1password/sdk": "^0.4.0",
     "@migrex/core": "0.2.0-alpha.1",
     "@migrex/zod": "1.0.0-alpha.1",
     "ms": "^2.1.3",

--- a/packages/core/src/api/internal.ts
+++ b/packages/core/src/api/internal.ts
@@ -12,6 +12,7 @@ import type { AttestItConfig } from '../types.js'
 import type { Identity } from '../identity/index.js'
 import { listPackageFiles } from '../fingerprint.js'
 import { KeyProviderRegistry } from '../key-provider/index.js'
+import type { KeyPresenceCapability } from '../key-provider/index.js'
 import type { VerificationState } from '../seal/verification.js'
 import type { ApiFailure, FailureClass } from './types.js'
 import { API_SCHEMA_VERSION } from './types.js'
@@ -232,5 +233,41 @@ export function keyRefForIdentity(identity: Identity): string {
       const _exhaustive: never = privateKey
       throw new Error(`Unsupported private key type: ${String(_exhaustive)}`)
     }
+  }
+}
+
+/**
+ * Report whether an {@link Identity}'s signing backend enforces a fresh per-use
+ * human presence check (e.g. a hardware touch or per-use biometric approval).
+ *
+ * @remarks
+ * Fail-closed: any provider that does not implement capability reporting — or a
+ * backend that cannot be constructed or probed — is reported as
+ * `{ presencePerUse: false }`. Capability probing never triggers a presence
+ * prompt (per VaultKeeper's contract), so this is safe to call from read-only
+ * commands like `attest-it identity show`.
+ *
+ * @param identity - The identity whose backend capabilities to report.
+ * @returns The identity backend's presence capability, defaulting safely.
+ * @public
+ */
+export async function getIdentityPresenceCapability(
+  identity: Identity,
+): Promise<KeyPresenceCapability> {
+  let provider
+  try {
+    provider = keyProviderForIdentity(identity)
+  } catch {
+    return { presencePerUse: false }
+  }
+
+  if (!provider.getPresenceCapability) {
+    return { presencePerUse: false }
+  }
+
+  try {
+    return await provider.getPresenceCapability()
+  } catch {
+    return { presencePerUse: false }
   }
 }

--- a/packages/core/src/api/operations.ts
+++ b/packages/core/src/api/operations.ts
@@ -13,13 +13,19 @@
  * @packageDocumentation
  */
 
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import * as path from 'node:path'
 import type { AttestItConfig } from '../types.js'
 import { loadSplitConfig } from '../config/index.js'
 import { computeFingerprint, listPackageFiles } from '../fingerprint.js'
 import { loadLocalConfigSync } from '../identity/index.js'
-import { createSeal, readSeals, writeSeals, verifyGateSeal, type SealsFile } from '../seal/index.js'
+import {
+  createSealWithProvider,
+  readSeals,
+  writeSeals,
+  verifyGateSeal,
+  type SealsFile,
+} from '../seal/index.js'
 import {
   evaluateConfigTrust,
   fail,
@@ -368,21 +374,15 @@ export async function seal(
     baseDir,
   })
 
-  // Resolve the private key via the identity's backend. The unlock happens here.
+  // Sign the seal via the identity's backend. Delegated signing keeps the raw
+  // private key inside the backend; otherwise the key is unlocked to a temp PEM.
   const keyProvider = keyProviderForIdentity(identity)
-  const keyResult = await keyProvider.getPrivateKey(keyRefForIdentity(identity))
-  let privateKeyPem: string
-  try {
-    privateKeyPem = await readFile(keyResult.keyPath, 'utf8')
-  } finally {
-    await keyResult.cleanup()
-  }
-
-  const newSeal = createSeal({
+  const newSeal = await createSealWithProvider({
     gateId: gate,
     fingerprint: fingerprintResult.fingerprint,
     sealedBy: params.identity,
-    privateKey: privateKeyPem,
+    keyProvider,
+    keyRef: keyRefForIdentity(identity),
   })
 
   let existing: SealsFile

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -69,6 +69,7 @@ export {
   RootGateVerificationError,
   verifyRootGate,
   createRootSeal,
+  createRootSealWithProvider,
   synthesizeRootGate,
   computePolicyFingerprint,
   computePolicyFingerprintSync,

--- a/packages/core/src/config/root-gate.ts
+++ b/packages/core/src/config/root-gate.ts
@@ -24,7 +24,8 @@
 import { relative, resolve } from 'node:path'
 import { computeFingerprint, computeFingerprintSync } from '../fingerprint.js'
 import type { AttestItConfig, GateConfig, RootGateConfig } from '../types.js'
-import { createSeal } from '../seal/operations.js'
+import { createSeal, createSealWithProvider } from '../seal/operations.js'
+import type { KeyProvider } from '../key-provider/types.js'
 import { verifyGateSeal, type SealVerificationResult } from '../seal/verification.js'
 import type { Seal, SealsFile } from '../seal/types.js'
 import { ROOT_GATE_ID } from './migrations/policy-graph.js'
@@ -168,6 +169,43 @@ export function createRootSeal(params: {
     sealedBy: params.sealedBy,
     privateKey: params.privateKey,
     ...(params.passphrase !== undefined && { passphrase: params.passphrase }),
+  })
+}
+
+/**
+ * Create a root-gate seal over the policy file using a {@link KeyProvider},
+ * preferring delegated signing.
+ *
+ * @remarks
+ * The root seal is byte-for-byte the same shape as any other gate seal, so this
+ * delegates to {@link createSealWithProvider} with the reserved
+ * {@link ROOT_GATE_ID}. That means a delegated-signing backend (whose key lives
+ * in the signing namespace and is not retrievable as a PEM) can anchor the root
+ * gate too — the raw key never leaves the backend. Backends without delegated
+ * signing fall back to the temp-file PEM path, resolving a passphrase via
+ * `resolvePassphrase` when the key is encrypted.
+ *
+ * @public
+ */
+export async function createRootSealWithProvider(params: {
+  /** Fingerprint of the policy file (from {@link computePolicyFingerprintSync}). */
+  policyFingerprint: string
+  /** Team member slug creating the root seal. */
+  sealedBy: string
+  /** The key provider that holds (or can delegate signing for) the root key. */
+  keyProvider: KeyProvider
+  /** Provider-specific key reference. */
+  keyRef: string
+  /** Resolve a passphrase for the fallback PEM path when the key is encrypted. */
+  resolvePassphrase?: () => Promise<string | undefined>
+}): Promise<Seal> {
+  return createSealWithProvider({
+    gateId: ROOT_GATE_ID,
+    fingerprint: params.policyFingerprint,
+    sealedBy: params.sealedBy,
+    keyProvider: params.keyProvider,
+    keyRef: params.keyRef,
+    ...(params.resolvePassphrase && { resolvePassphrase: params.resolvePassphrase }),
   })
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,7 @@ export {
   RootGateVerificationError,
   verifyRootGate,
   createRootSeal,
+  createRootSealWithProvider,
   synthesizeRootGate,
   computePolicyFingerprint,
   computePolicyFingerprintSync,
@@ -139,6 +140,8 @@ export {
   type KeyRetrievalResult,
   type KeyGenerationResult,
   type KeygenProviderOptions,
+  type KeyPresenceCapability,
+  type KeyPresenceOperation,
   type OnePasswordAccount,
   type OnePasswordVault,
   type InaccessibleAccount,
@@ -223,9 +226,14 @@ export {
   type VerifyAllParams,
 } from './api/index.js'
 
+// Identity backend capability reporting
+export { getIdentityPresenceCapability } from './api/internal.js'
+
 // Seal System
 export {
   createSeal,
+  createSealWithSigner,
+  createSealWithProvider,
   verifySeal,
   readSeals,
   readSealsSync,
@@ -236,6 +244,9 @@ export {
   type Seal,
   type SealsFile,
   type CreateSealOptions,
+  type CreateSealWithSignerOptions,
+  type CreateSealWithProviderOptions,
+  type CanonicalSigner,
   type SignatureVerificationResult,
   type VerificationState,
   type SealVerificationResult,

--- a/packages/core/src/key-provider/index.ts
+++ b/packages/core/src/key-provider/index.ts
@@ -16,6 +16,8 @@ export type {
   KeyGenerationResult,
   KeygenProviderOptions,
   KeyProvider,
+  KeyPresenceCapability,
+  KeyPresenceOperation,
 } from './types.js'
 
 // VaultKeeper provider

--- a/packages/core/src/key-provider/types.ts
+++ b/packages/core/src/key-provider/types.ts
@@ -54,6 +54,44 @@ export interface KeyGenerationResult {
 }
 
 /**
+ * A keyed backend operation that a per-use presence requirement can gate.
+ *
+ * @remarks
+ * Mirrors VaultKeeper's `PresenceOperation`: `'read'` is the secret read behind
+ * a signing/retrieval unlock; `'store'`, `'delete'`, and `'sign'` are the write,
+ * removal, and signing paths.
+ *
+ * @public
+ */
+export type KeyPresenceOperation = 'read' | 'store' | 'delete' | 'sign'
+
+/**
+ * Whether a provider's underlying backend enforces a fresh per-use human
+ * presence check (e.g. a hardware touch or per-use biometric approval).
+ *
+ * @remarks
+ * Reported fail-closed: a provider whose backend cannot prove per-use presence
+ * reports `{ presencePerUse: false }` rather than silently claiming a guarantee
+ * it cannot enforce.
+ *
+ * @public
+ */
+export interface KeyPresenceCapability {
+  /**
+   * `true` when the active key's backend forces a distinct, fresh physical human
+   * action for the operations in {@link KeyPresenceCapability.presenceEnforcedOperations}
+   * (all keyed operations when that field is omitted).
+   */
+  presencePerUse: boolean
+  /**
+   * The keyed operations for which a fresh per-use action is actually forced.
+   * Omitted when presence is enforced for all keyed operations. Ignored when
+   * {@link KeyPresenceCapability.presencePerUse} is `false`.
+   */
+  presenceEnforcedOperations?: readonly KeyPresenceOperation[]
+}
+
+/**
  * Options for key generation via provider.
  * @public
  */
@@ -92,8 +130,50 @@ export interface KeyProvider {
    * Retrieve the private key for signing.
    * Returns a temporary file path that can be passed to OpenSSL.
    * Caller MUST call cleanup() after signing is complete.
+   *
+   * @remarks
+   * This is the fallback signing path used when delegated signing is not
+   * available for the key (see {@link KeyProvider.signDirectly}). It exposes the
+   * raw private key to the current process as a temporary file.
    */
   getPrivateKey(keyRef: string): Promise<KeyRetrievalResult>
+
+  /**
+   * Sign `data` for `keyRef` entirely inside the provider's backend, returning a
+   * base64-encoded signature — the raw private key never leaves the backend and
+   * never touches this process's memory as a file or disk.
+   *
+   * @remarks
+   * Optional and additive: present only for providers whose backend implements
+   * delegated signing. Callers MUST prefer this over {@link KeyProvider.getPrivateKey}
+   * when both it and {@link KeyProvider.supportsDelegatedSigning} indicate the key
+   * is signable this way. Its per-provider presence does not by itself guarantee a
+   * given `keyRef` is delegated-signable — gate on
+   * {@link KeyProvider.supportsDelegatedSigning}.
+   *
+   * @param keyRef - Provider-specific key reference.
+   * @param data - The exact bytes to sign (strings are UTF-8-encoded).
+   */
+  signDirectly?(keyRef: string, data: string | Buffer): Promise<string>
+
+  /**
+   * Report whether `keyRef` can be signed via {@link KeyProvider.signDirectly}
+   * without ever exposing the raw private key.
+   *
+   * @remarks
+   * Per-key (not merely per-provider): a backend may hold some keys as delegated
+   * signing keys and others as plain retrievable secrets. Returns `false`
+   * (fail-closed) for providers or keys that do not support delegated signing, so
+   * callers safely fall back to {@link KeyProvider.getPrivateKey}.
+   */
+  supportsDelegatedSigning?(keyRef: string): Promise<boolean>
+
+  /**
+   * Report whether this provider's backend enforces a fresh per-use human
+   * presence check. Optional and fail-closed: absence is treated as
+   * `{ presencePerUse: false }`.
+   */
+  getPresenceCapability?(): Promise<KeyPresenceCapability>
 
   /**
    * Generate a new keypair and store the private key.

--- a/packages/core/src/key-provider/vault-key-provider.ts
+++ b/packages/core/src/key-provider/vault-key-provider.ts
@@ -7,20 +7,38 @@
  *
  */
 
+import { Buffer } from 'node:buffer'
 import * as crypto from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import type { SecretBackend } from 'vaultkeeper'
+import type { SecretBackend, SigningBackend } from 'vaultkeeper'
+import { getBackendCapabilities, isSigningBackend, SigningKeyNotFoundError } from 'vaultkeeper'
 import { generateKeyPair as ed25519GenerateKeyPair } from '../crypto/ed25519.js'
 import { setKeyPermissions } from '../crypto.js'
 import type {
   KeyProvider,
   KeyProviderConfig,
+  KeyPresenceCapability,
   KeyRetrievalResult,
   KeyGenerationResult,
   KeygenProviderOptions,
 } from './types.js'
+
+/**
+ * The JOSE signing algorithm attest-it enrolls in delegated signing backends.
+ * attest-it signs seals with Ed25519, whose JOSE `alg` identifier is `EdDSA`.
+ */
+const DELEGATED_SIGNING_ALGORITHM = 'EdDSA' as const
+
+/**
+ * Convert an SPKI-PEM Ed25519 public key to attest-it's compact wire format:
+ * the base64 of the raw 32-byte key (SPKI DER minus its 12-byte header).
+ */
+function spkiPemToRawBase64(publicKeyPem: string): string {
+  const der = crypto.createPublicKey(publicKeyPem).export({ type: 'spki', format: 'der' })
+  return Buffer.from(der).subarray(12).toString('base64')
+}
 
 /**
  * Options for creating a VaultKeyProvider.
@@ -51,6 +69,20 @@ export class VaultKeyProvider implements KeyProvider {
   private readonly backend: SecretBackend
 
   /**
+   * Delegated signing entry point, present only when the underlying backend
+   * implements VaultKeeper's `SigningBackend` contract.
+   *
+   * @remarks
+   * Assigned in the constructor so `signDirectly` is absent for non-signing
+   * backends — callers detect delegated-signing support via its presence
+   * combined with {@link VaultKeyProvider.supportsDelegatedSigning}. When
+   * delegated signing is used the raw private key never leaves the backend, so
+   * no PEM is written to disk (resolves the former `getPrivateKey` temp-file
+   * TODO for signing-capable backends).
+   */
+  readonly signDirectly?: (keyRef: string, data: string | Buffer) => Promise<string>
+
+  /**
    * Create a new VaultKeyProvider.
    * @param options - Provider options including the VaultKeeper backend
    */
@@ -58,6 +90,15 @@ export class VaultKeyProvider implements KeyProvider {
     this.backend = options.backend
     this.type = options.backend.type
     this.displayName = options.displayName
+
+    if (isSigningBackend(this.backend)) {
+      const signingBackend: SigningBackend = this.backend
+      this.signDirectly = async (keyRef, data) => {
+        const dataBuffer = typeof data === 'string' ? Buffer.from(data, 'utf8') : data
+        const signature = await signingBackend.signWithKey(keyRef, dataBuffer)
+        return signature.toString('base64')
+      }
+    }
   }
 
   /**
@@ -69,10 +110,74 @@ export class VaultKeyProvider implements KeyProvider {
 
   /**
    * Check if a key exists in the VaultKeeper backend.
+   *
+   * @remarks
+   * For a signing-capable backend a key may live in the delegated signing-key
+   * namespace rather than the plain secret store, so both are checked.
+   *
    * @param keyRef - Secret identifier in the backend
    */
   async keyExists(keyRef: string): Promise<boolean> {
+    if (isSigningBackend(this.backend) && (await this.signingKeyExists(this.backend, keyRef))) {
+      return true
+    }
     return this.backend.exists(keyRef)
+  }
+
+  /**
+   * Whether a delegated signing key is enrolled under `keyRef`.
+   *
+   * @remarks
+   * VaultKeeper exposes no direct existence check for signing keys, so this
+   * probes `getPublicKey` (which never triggers a presence prompt). A
+   * `SigningKeyNotFoundError` means "not enrolled" — the correct fail-closed
+   * result (`false`). Any other error (backend unavailable, a transient
+   * 1Password/network blip, a decrypt failure) is re-thrown so it surfaces as a
+   * backend failure rather than being silently misreported as "no delegated
+   * key" (which would then confusingly fall back and fail with "Secret not
+   * found").
+   */
+  private async signingKeyExists(backend: SigningBackend, keyRef: string): Promise<boolean> {
+    try {
+      await backend.getPublicKey(keyRef)
+      return true
+    } catch (error) {
+      if (error instanceof SigningKeyNotFoundError) {
+        return false
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Report whether `keyRef` can be signed via delegated backend signing, so
+   * callers can prefer {@link VaultKeyProvider.signDirectly} and avoid ever
+   * materializing the raw private key. Fail-closed: `false` when the backend is
+   * not signing-capable or no signing key is enrolled under `keyRef`.
+   *
+   * @param keyRef - Secret identifier in the backend
+   */
+  async supportsDelegatedSigning(keyRef: string): Promise<boolean> {
+    if (!isSigningBackend(this.backend)) {
+      return false
+    }
+    return this.signingKeyExists(this.backend, keyRef)
+  }
+
+  /**
+   * Report whether the underlying backend enforces a fresh per-use human
+   * presence check. Fail-closed via VaultKeeper's `getBackendCapabilities`: a
+   * backend that does not implement the capability contract reports
+   * `{ presencePerUse: false }`.
+   */
+  async getPresenceCapability(): Promise<KeyPresenceCapability> {
+    const capabilities = await getBackendCapabilities(this.backend)
+    return {
+      presencePerUse: capabilities.presencePerUse,
+      ...(capabilities.presenceEnforcedOperations && {
+        presenceEnforcedOperations: capabilities.presenceEnforcedOperations,
+      }),
+    }
   }
 
   /**
@@ -157,17 +262,33 @@ export class VaultKeyProvider implements KeyProvider {
       }
     }
 
-    // Generate Ed25519 keypair
-    const keyPair = ed25519GenerateKeyPair()
+    // Generate a unique ID for the key material in VaultKeeper
+    const secretId = `attest-it-${crypto.randomUUID()}`
 
     // Ensure public key directory exists
     await fs.mkdir(path.dirname(publicKeyPath), { recursive: true })
 
+    // Delegated signing path: the backend generates and holds the private key
+    // itself. attest-it never sees the raw key — it only receives the public
+    // half. This keeps signing-capable keys off attest-it's disk entirely.
+    if (isSigningBackend(this.backend)) {
+      await this.backend.generateSigningKey(secretId, DELEGATED_SIGNING_ALGORITHM)
+      const { publicKeyPem } = await this.backend.getPublicKey(secretId)
+      await fs.writeFile(publicKeyPath, spkiPemToRawBase64(publicKeyPem), 'utf-8')
+
+      return {
+        privateKeyRef: secretId,
+        publicKeyPath,
+        storageDescription: `VaultKeeper (${this.backend.displayName}, delegated signing): ${secretId}`,
+      }
+    }
+
+    // Secret-store fallback: attest-it generates the keypair locally and stores
+    // the PEM as an ordinary secret for backends without delegated signing.
+    const keyPair = ed25519GenerateKeyPair()
+
     // Write public key to filesystem
     await fs.writeFile(publicKeyPath, keyPair.publicKey, 'utf-8')
-
-    // Generate a unique ID for the secret in VaultKeeper
-    const secretId = `attest-it-${crypto.randomUUID()}`
 
     // Store private key in VaultKeeper backend
     await this.backend.store(secretId, keyPair.privateKey)

--- a/packages/core/src/seal/index.ts
+++ b/packages/core/src/seal/index.ts
@@ -9,12 +9,17 @@ export type { Seal, SealsFile } from './types.js'
 // Operations
 export {
   createSeal,
+  createSealWithSigner,
+  createSealWithProvider,
   verifySeal,
   readSeals,
   readSealsSync,
   writeSeals,
   writeSealsSync,
   type CreateSealOptions,
+  type CreateSealWithSignerOptions,
+  type CreateSealWithProviderOptions,
+  type CanonicalSigner,
   type SignatureVerificationResult,
 } from './operations.js'
 

--- a/packages/core/src/seal/operations.ts
+++ b/packages/core/src/seal/operations.ts
@@ -4,11 +4,13 @@
  */
 
 import * as fs from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import * as path from 'node:path'
 
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
 import * as ed25519 from '../crypto/ed25519.js'
 import type { AttestItConfig } from '../types.js'
+import type { KeyProvider } from '../key-provider/types.js'
 import type { Seal, SealsFile } from './types.js'
 import { sealsFileSchemaV1 } from '../config/migrations/index.js'
 
@@ -93,6 +95,132 @@ export function createSeal(options: CreateSealOptions): Seal {
     timestamp,
     sealedBy,
     signature,
+  }
+}
+
+/**
+ * Signs the canonical seal string, returning a base64-encoded signature.
+ * @public
+ */
+export type CanonicalSigner = (canonicalString: string) => Promise<string>
+
+/**
+ * Options for creating a seal from an external signer.
+ * @public
+ */
+export interface CreateSealWithSignerOptions {
+  /** Gate identifier (slug) */
+  gateId: string
+  /** SHA-256 fingerprint of the gate's content */
+  fingerprint: string
+  /** Team member slug creating the seal */
+  sealedBy: string
+  /** Produces the base64 signature over the canonical string. */
+  sign: CanonicalSigner
+}
+
+/**
+ * Create a seal whose signature is produced by an external signer over the
+ * canonical string `gateId:fingerprint:timestamp`.
+ *
+ * @remarks
+ * This is the delegated-signing counterpart to {@link createSeal}: the caller
+ * supplies a {@link CanonicalSigner} (e.g. a VaultKeeper `SigningBackend`) that
+ * signs without exposing the raw private key. The timestamp is generated here so
+ * the signer signs the exact canonical string embedded in the seal.
+ *
+ * @param options - Seal creation options with an external signer
+ * @returns The created seal
+ * @public
+ */
+export async function createSealWithSigner(options: CreateSealWithSignerOptions): Promise<Seal> {
+  const { gateId, fingerprint, sealedBy, sign } = options
+
+  const timestamp = new Date().toISOString()
+  const canonicalString = `${gateId}:${fingerprint}:${timestamp}`
+  const signature = await sign(canonicalString)
+
+  return {
+    gateId,
+    fingerprint,
+    timestamp,
+    sealedBy,
+    signature,
+  }
+}
+
+/**
+ * Options for creating a seal via a {@link KeyProvider}.
+ * @public
+ */
+export interface CreateSealWithProviderOptions {
+  /** Gate identifier (slug) */
+  gateId: string
+  /** SHA-256 fingerprint of the gate's content */
+  fingerprint: string
+  /** Team member slug creating the seal */
+  sealedBy: string
+  /** The key provider that holds (or can delegate signing for) the private key */
+  keyProvider: KeyProvider
+  /** Provider-specific key reference */
+  keyRef: string
+  /**
+   * Resolve a passphrase for the fallback path when the retrieved PEM is
+   * encrypted. Only invoked on the {@link KeyProvider.getPrivateKey} fallback,
+   * never for delegated signing.
+   */
+  resolvePassphrase?: () => Promise<string | undefined>
+}
+
+/**
+ * Create a seal using a {@link KeyProvider}, preferring delegated signing.
+ *
+ * @remarks
+ * When the provider reports that `keyRef` is delegated-signable
+ * ({@link KeyProvider.supportsDelegatedSigning}), the seal is signed via
+ * {@link KeyProvider.signDirectly} and the raw private key never leaves the
+ * backend — no PEM is written to disk. Otherwise this falls back to
+ * {@link KeyProvider.getPrivateKey} + a temporary PEM file, preserving existing
+ * behavior for non-signing backends and legacy keys.
+ *
+ * @param options - Seal creation options
+ * @returns The created seal
+ * @public
+ */
+export async function createSealWithProvider(
+  options: CreateSealWithProviderOptions,
+): Promise<Seal> {
+  const { gateId, fingerprint, sealedBy, keyProvider, keyRef, resolvePassphrase } = options
+
+  if (
+    keyProvider.signDirectly &&
+    keyProvider.supportsDelegatedSigning &&
+    (await keyProvider.supportsDelegatedSigning(keyRef))
+  ) {
+    const signDirectly = keyProvider.signDirectly.bind(keyProvider)
+    return createSealWithSigner({
+      gateId,
+      fingerprint,
+      sealedBy,
+      sign: (canonicalString) => signDirectly(keyRef, canonicalString),
+    })
+  }
+
+  const keyResult = await keyProvider.getPrivateKey(keyRef)
+  try {
+    const privateKey = await readFile(keyResult.keyPath, 'utf8')
+    const passphrase = ed25519.isEncryptedPrivateKeyPem(privateKey)
+      ? await resolvePassphrase?.()
+      : undefined
+    return createSeal({
+      gateId,
+      fingerprint,
+      sealedBy,
+      privateKey,
+      ...(passphrase !== undefined && { passphrase }),
+    })
+  } finally {
+    await keyResult.cleanup()
   }
 }
 

--- a/packages/core/test/helpers/mock-backends.ts
+++ b/packages/core/test/helpers/mock-backends.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared mock VaultKeeper backends for tests.
+ *
+ * @see https://github.com/mike-north/vaultkeeper (SecretBackend / SigningBackend / PresenceCapableBackend)
+ */
+
+import * as nodeCrypto from 'node:crypto'
+import { vi } from 'vitest'
+import { SigningKeyNotFoundError } from 'vaultkeeper'
+import type {
+  BackendCapabilities,
+  SecretBackend,
+  SigningAlgorithm,
+  SigningBackend,
+  SigningPublicKey,
+} from 'vaultkeeper'
+
+/**
+ * Create a mock SecretBackend, returning both the backend and individual mock
+ * function references for assertion.
+ */
+export function createMockBackend(overrides: Partial<SecretBackend> = {}) {
+  const secretStore = new Map<string, string>()
+
+  const isAvailableFn = vi.fn<() => Promise<boolean>>().mockResolvedValue(true)
+  const storeFn = vi.fn<(id: string, secret: string) => Promise<void>>((id, secret) => {
+    secretStore.set(id, secret)
+    return Promise.resolve()
+  })
+  const retrieveFn = vi.fn<(id: string) => Promise<string>>((id) => {
+    const val = secretStore.get(id)
+    if (val === undefined) {
+      return Promise.reject(new Error(`Secret not found: ${id}`))
+    }
+    return Promise.resolve(val)
+  })
+  const deleteFn = vi.fn<(id: string) => Promise<void>>((id) => {
+    if (!secretStore.has(id)) {
+      return Promise.reject(new Error(`Secret not found: ${id}`))
+    }
+    secretStore.delete(id)
+    return Promise.resolve()
+  })
+  const existsFn = vi.fn<(id: string) => Promise<boolean>>((id) =>
+    Promise.resolve(secretStore.has(id)),
+  )
+
+  const backend: SecretBackend = {
+    type: 'mock',
+    displayName: 'Mock Backend',
+    isAvailable: isAvailableFn,
+    store: storeFn,
+    retrieve: retrieveFn,
+    delete: deleteFn,
+    exists: existsFn,
+    ...overrides,
+  }
+
+  return { backend, secretStore, isAvailableFn, storeFn, retrieveFn, deleteFn, existsFn }
+}
+
+/**
+ * Create a mock VaultKeeper SigningBackend that holds real Ed25519 signing keys
+ * in memory, mirroring the file backend's contract: signing keys live in a
+ * namespace separate from ordinary secrets, and the private key never leaves the
+ * backend (only signatures and the public half are exposed).
+ *
+ * @param capabilities - When provided, the backend also implements
+ *   PresenceCapableBackend and reports these capabilities.
+ */
+const SUPPORTED_SIGNING_ALGORITHMS: readonly SigningAlgorithm[] = ['EdDSA']
+
+export function createSigningMockBackend(capabilities?: Partial<BackendCapabilities>) {
+  const base = createMockBackend()
+  const signingKeys = new Map<string, nodeCrypto.KeyObject>()
+
+  const generateSigningKeyFn = vi.fn<(id: string, algorithm: SigningAlgorithm) => Promise<void>>(
+    (id, algorithm) => {
+      if (!SUPPORTED_SIGNING_ALGORITHMS.includes(algorithm)) {
+        return Promise.reject(new Error(`Unsupported signing algorithm '${algorithm}'`))
+      }
+      if (signingKeys.has(id)) {
+        return Promise.reject(new Error(`Signing key already exists: ${id}`))
+      }
+      const { privateKey } = nodeCrypto.generateKeyPairSync('ed25519')
+      signingKeys.set(id, privateKey)
+      return Promise.resolve()
+    },
+  )
+
+  const getPublicKeyFn = vi.fn<(id: string) => Promise<SigningPublicKey>>((id) => {
+    const priv = signingKeys.get(id)
+    if (!priv) {
+      return Promise.reject(new SigningKeyNotFoundError(`Signing key not found: ${id}`, id))
+    }
+    const pub = nodeCrypto.createPublicKey(priv)
+    const publicKeyPem = pub.export({ type: 'spki', format: 'pem' }).toString()
+    const der = pub.export({ type: 'spki', format: 'der' })
+    const kid = nodeCrypto.createHash('sha256').update(der).digest('base64url')
+    return Promise.resolve({ publicKeyPem, algorithm: 'EdDSA', kid })
+  })
+
+  const signWithKeyFn = vi.fn<(id: string, data: Buffer) => Promise<Buffer>>((id, data) => {
+    const priv = signingKeys.get(id)
+    if (!priv) {
+      return Promise.reject(new SigningKeyNotFoundError(`Signing key not found: ${id}`, id))
+    }
+    return Promise.resolve(nodeCrypto.sign(null, data, priv))
+  })
+
+  const backend: SigningBackend = {
+    ...base.backend,
+    generateSigningKey: generateSigningKeyFn,
+    getPublicKey: getPublicKeyFn,
+    signWithKey: signWithKeyFn,
+    ...(capabilities && {
+      getCapabilities: (): Promise<BackendCapabilities> =>
+        Promise.resolve({ presencePerUse: false, ...capabilities }),
+    }),
+  }
+
+  return {
+    ...base,
+    backend,
+    signingKeys,
+    generateSigningKeyFn,
+    getPublicKeyFn,
+    signWithKeyFn,
+  }
+}
+
+/**
+ * Recover attest-it's compact public-key form (base64 of the raw 32-byte Ed25519
+ * key) from an SPKI PEM, for use in seal verification assertions.
+ */
+export function spkiPemToRawBase64(publicKeyPem: string): string {
+  return Buffer.from(
+    nodeCrypto.createPublicKey(publicKeyPem).export({ type: 'spki', format: 'der' }),
+  )
+    .subarray(12)
+    .toString('base64')
+}

--- a/packages/core/test/key-provider/one-password-resolution.test.ts
+++ b/packages/core/test/key-provider/one-password-resolution.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test: the VaultKeeper-backed 1Password path stays resolvable.
+ *
+ * VaultKeeper 0.7.0 made `@1password/sdk` an optional peer dependency for its
+ * 1Password backend (replacing the `op` CLI). attest-it declares `@1password/sdk`
+ * as an explicit dependency so the VaultKeeper 1Password backend resolves and
+ * constructs. This guards against the dependency being dropped.
+ *
+ * @see https://github.com/mike-north/attest-it/issues/76
+ */
+
+import { describe, expect, it } from 'vitest'
+import { BackendRegistry } from 'vaultkeeper'
+import { KeyProviderRegistry } from '../../src/key-provider/registry.js'
+
+describe('VaultKeeper 1Password backend resolution', () => {
+  it('resolves the @1password/sdk optional peer dependency', async () => {
+    // Import (not just require.resolve) so a broken/missing install fails here.
+    await expect(import('@1password/sdk')).resolves.toBeDefined()
+  })
+
+  it('constructs the VaultKeeper 1Password backend without a resolution error', () => {
+    expect(() => BackendRegistry.create('1password')).not.toThrow()
+  })
+
+  it('creates the 1Password key provider backed by VaultKeeper', () => {
+    const provider = KeyProviderRegistry.create({ type: '1password', options: {} })
+    expect(provider.type).toBe('1password')
+  })
+})

--- a/packages/core/test/key-provider/registry.test.ts
+++ b/packages/core/test/key-provider/registry.test.ts
@@ -40,6 +40,11 @@ vi.mock('vaultkeeper', () => {
         return makeMockBackend(type)
       },
     },
+    // These mock backends implement only the base SecretBackend contract, so
+    // the capability/signing guards report false.
+    isSigningBackend: () => false,
+    isPresenceCapableBackend: () => false,
+    getBackendCapabilities: () => Promise.resolve({ presencePerUse: false }),
   }
 })
 

--- a/packages/core/test/key-provider/vault-key-provider.test.ts
+++ b/packages/core/test/key-provider/vault-key-provider.test.ts
@@ -4,56 +4,16 @@
  * @see https://github.com/mike-north/vaultkeeper (SecretBackend interface)
  */
 
+import * as nodeCrypto from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { SecretBackend } from 'vaultkeeper'
+import { SigningKeyNotFoundError } from 'vaultkeeper'
+import * as ed25519 from '../../src/crypto/ed25519.js'
 import { VaultKeyProvider } from '../../src/key-provider/vault-key-provider.js'
-
-/**
- * Create a mock SecretBackend for testing, returning both the backend
- * and individual mock function references for assertion.
- */
-function createMockBackend(overrides: Partial<SecretBackend> = {}) {
-  const secretStore = new Map<string, string>()
-
-  const isAvailableFn = vi.fn<() => Promise<boolean>>().mockResolvedValue(true)
-  const storeFn = vi.fn<(id: string, secret: string) => Promise<void>>((id, secret) => {
-    secretStore.set(id, secret)
-    return Promise.resolve()
-  })
-  const retrieveFn = vi.fn<(id: string) => Promise<string>>((id) => {
-    const val = secretStore.get(id)
-    if (val === undefined) {
-      return Promise.reject(new Error(`Secret not found: ${id}`))
-    }
-    return Promise.resolve(val)
-  })
-  const deleteFn = vi.fn<(id: string) => Promise<void>>((id) => {
-    if (!secretStore.has(id)) {
-      return Promise.reject(new Error(`Secret not found: ${id}`))
-    }
-    secretStore.delete(id)
-    return Promise.resolve()
-  })
-  const existsFn = vi.fn<(id: string) => Promise<boolean>>((id) =>
-    Promise.resolve(secretStore.has(id)),
-  )
-
-  const backend: SecretBackend = {
-    type: 'mock',
-    displayName: 'Mock Backend',
-    isAvailable: isAvailableFn,
-    store: storeFn,
-    retrieve: retrieveFn,
-    delete: deleteFn,
-    exists: existsFn,
-    ...overrides,
-  }
-
-  return { backend, isAvailableFn, storeFn, retrieveFn, deleteFn, existsFn }
-}
+import { createMockBackend, createSigningMockBackend } from '../helpers/mock-backends.js'
 
 /** A sample Ed25519 PEM private key for testing. */
 const SAMPLE_PEM = `-----BEGIN PRIVATE KEY-----
@@ -203,6 +163,140 @@ describe('VaultKeyProvider', () => {
       const config = provider.getConfig()
       expect(config.type).toBe('mock')
       expect(config.options).toEqual({ backendType: 'mock' })
+    })
+  })
+
+  describe('delegated signing (SigningBackend)', () => {
+    it('exposes signDirectly only when the backend implements SigningBackend', () => {
+      // Plain SecretBackend: no delegated signing.
+      expect(provider.signDirectly).toBeUndefined()
+
+      // SigningBackend: signDirectly is available.
+      const signing = createSigningMockBackend()
+      const signingProvider = new VaultKeyProvider({
+        backend: signing.backend,
+        displayName: 'Signing Mock',
+      })
+      expect(signingProvider.signDirectly).toBeTypeOf('function')
+    })
+
+    it('supportsDelegatedSigning is false for a non-signing backend', async () => {
+      await expect(provider.supportsDelegatedSigning('any-ref')).resolves.toBe(false)
+    })
+
+    it('supportsDelegatedSigning is true only once a signing key is enrolled', async () => {
+      const signing = createSigningMockBackend()
+      const signingProvider = new VaultKeyProvider({
+        backend: signing.backend,
+        displayName: 'Signing Mock',
+      })
+
+      // Not yet enrolled: fail-closed so callers fall back to getPrivateKey.
+      await expect(signingProvider.supportsDelegatedSigning('key-1')).resolves.toBe(false)
+
+      await signing.backend.generateSigningKey('key-1', 'EdDSA')
+      await expect(signingProvider.supportsDelegatedSigning('key-1')).resolves.toBe(true)
+    })
+
+    it('supportsDelegatedSigning propagates non-not-found backend errors instead of masking them', async () => {
+      const signing = createSigningMockBackend()
+      const signingProvider = new VaultKeyProvider({
+        backend: signing.backend,
+        displayName: 'Signing Mock',
+      })
+
+      // A genuine "not found" is the fail-closed path -> false.
+      signing.getPublicKeyFn.mockRejectedValueOnce(
+        new SigningKeyNotFoundError('signing key not found', 'key-1'),
+      )
+      await expect(signingProvider.supportsDelegatedSigning('key-1')).resolves.toBe(false)
+
+      // A transient backend failure (e.g. 1Password/network blip) must surface,
+      // not be misreported as "no delegated key".
+      signing.getPublicKeyFn.mockRejectedValueOnce(new Error('backend unavailable'))
+      await expect(signingProvider.supportsDelegatedSigning('key-1')).rejects.toThrow(
+        'backend unavailable',
+      )
+    })
+
+    it('signDirectly produces a signature the backend key verifies', async () => {
+      const signing = createSigningMockBackend()
+      const signingProvider = new VaultKeyProvider({
+        backend: signing.backend,
+        displayName: 'Signing Mock',
+      })
+      await signing.backend.generateSigningKey('key-1', 'EdDSA')
+      const { publicKeyPem } = await signing.getPublicKeyFn('key-1')
+      const rawPublicKeyBase64 = nodeCrypto
+        .createPublicKey(publicKeyPem)
+        .export({ type: 'spki', format: 'der' })
+        .subarray(12)
+        .toString('base64')
+
+      const message = 'gate-a:fingerprint:2026-07-17T00:00:00.000Z'
+      const { signDirectly } = signingProvider
+      if (!signDirectly) {
+        throw new Error('expected signDirectly to be available for a SigningBackend')
+      }
+      const signature = await signDirectly('key-1', message)
+
+      expect(signing.signWithKeyFn).toHaveBeenCalledWith('key-1', Buffer.from(message, 'utf8'))
+      expect(ed25519.verify(message, signature, rawPublicKeyBase64)).toBe(true)
+    })
+  })
+
+  describe('generateKeyPair with a SigningBackend', () => {
+    it('enrolls a delegated signing key and never stores raw PEM as a secret', async () => {
+      const signing = createSigningMockBackend()
+      const signingProvider = new VaultKeyProvider({
+        backend: signing.backend,
+        displayName: 'Signing Mock',
+      })
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-test-'))
+      const publicKeyPath = `${tmpDir}/public.pem`
+
+      try {
+        const result = await signingProvider.generateKeyPair({ publicKeyPath })
+
+        // Enrolled via the signing contract, not the secret store.
+        expect(signing.generateSigningKeyFn).toHaveBeenCalledWith(result.privateKeyRef, 'EdDSA')
+        expect(signing.storeFn).not.toHaveBeenCalled()
+        expect(result.storageDescription).toContain('delegated signing')
+
+        // Public key written as base64 raw 32-byte form (44 chars for Ed25519).
+        const publicKey = (await fs.readFile(publicKeyPath, 'utf-8')).trim()
+        expect(Buffer.from(publicKey, 'base64')).toHaveLength(32)
+
+        // keyExists reports true via the signing namespace, and delegated
+        // signing is available for the freshly enrolled key.
+        await expect(signingProvider.keyExists(result.privateKeyRef)).resolves.toBe(true)
+        await expect(signingProvider.supportsDelegatedSigning(result.privateKeyRef)).resolves.toBe(
+          true,
+        )
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe('getPresenceCapability', () => {
+    it('reports not-enforced (fail-closed) for a backend without capabilities', async () => {
+      await expect(provider.getPresenceCapability()).resolves.toEqual({ presencePerUse: false })
+    })
+
+    it('surfaces presencePerUse and enforced operations from a capable backend', async () => {
+      const signing = createSigningMockBackend({
+        presencePerUse: true,
+        presenceEnforcedOperations: ['sign'],
+      })
+      const signingProvider = new VaultKeyProvider({
+        backend: signing.backend,
+        displayName: 'Presence Mock',
+      })
+      await expect(signingProvider.getPresenceCapability()).resolves.toEqual({
+        presencePerUse: true,
+        presenceEnforcedOperations: ['sign'],
+      })
     })
   })
 })

--- a/packages/core/test/root-gate.test.ts
+++ b/packages/core/test/root-gate.test.ts
@@ -21,12 +21,15 @@ import type { AttestItConfig, TeamMember } from '../src/types.js'
 import {
   ROOT_GATE_ID,
   createRootSeal,
+  createRootSealWithProvider,
   computePolicyFingerprintSync,
   verifyRootGate,
   isBlockingRootGateState,
 } from '../src/config/root-gate.js'
 import { parsePolicyContent, PolicyValidationError } from '../src/config/policy-schema.js'
 import { policyMigrationGraph } from '../src/config/migrations/policy-graph.js'
+import { VaultKeyProvider } from '../src/key-provider/vault-key-provider.js'
+import { createSigningMockBackend, spkiPemToRawBase64 } from './helpers/mock-backends.js'
 
 interface Signer {
   slug: string
@@ -500,5 +503,74 @@ gates:
       },
     })
     expect(ok.success).toBe(true)
+  })
+})
+
+// Integration between #110's root gate and delegated signing (#76): a root
+// signer whose key lives in a VaultKeeper SigningBackend must be able to anchor
+// the policy without the raw key ever being materialized, and the resulting root
+// seal must verify through the same verifyRootGate path as a PEM-signed one.
+describe('root gate — delegated signing (SigningBackend)', () => {
+  const POLICY_FINGERPRINT = 'sha256:' + 'a'.repeat(64)
+
+  /** A root signer whose Ed25519 key is held in a delegated signing backend. */
+  async function makeDelegatedRootSigner(slug: string, name: string) {
+    const signing = createSigningMockBackend()
+    const provider = new VaultKeyProvider({ backend: signing.backend, displayName: 'Signing' })
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-it-root-delegated-'))
+    try {
+      const gen = await provider.generateKeyPair({ publicKeyPath: path.join(tmpDir, 'pub.pem') })
+      const { publicKeyPem } = await signing.getPublicKeyFn(gen.privateKeyRef)
+      const publicKey = spkiPemToRawBase64(publicKeyPem)
+      return {
+        slug,
+        member: { name, publicKey } satisfies TeamMember,
+        provider,
+        keyRef: gen.privateKeyRef,
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  }
+
+  it('anchors the root gate with a delegated key and verifies VALID', async () => {
+    const owner = await makeDelegatedRootSigner('owner', 'Owner')
+    const config = makeConfig({ rootSigners: ['owner'], team: { owner: owner.member } })
+
+    const rootSeal = await createRootSealWithProvider({
+      policyFingerprint: POLICY_FINGERPRINT,
+      sealedBy: owner.slug,
+      keyProvider: owner.provider,
+      keyRef: owner.keyRef,
+    })
+
+    const result = verifyRootGate({
+      config,
+      policyFingerprint: POLICY_FINGERPRINT,
+      seals: sealsWith(rootSeal),
+    })
+    expect(result.state).toBe('VALID')
+    expect(isBlockingRootGateState(result.state)).toBe(false)
+  })
+
+  it('rejects a delegated root seal against a different policy fingerprint', async () => {
+    const owner = await makeDelegatedRootSigner('owner', 'Owner')
+    const config = makeConfig({ rootSigners: ['owner'], team: { owner: owner.member } })
+
+    const rootSeal = await createRootSealWithProvider({
+      policyFingerprint: POLICY_FINGERPRINT,
+      sealedBy: owner.slug,
+      keyProvider: owner.provider,
+      keyRef: owner.keyRef,
+    })
+
+    const tampered = 'sha256:' + 'b'.repeat(64)
+    const result = verifyRootGate({
+      config,
+      policyFingerprint: tampered,
+      seals: sealsWith(rootSeal),
+    })
+    expect(result.state).toBe('FINGERPRINT_MISMATCH')
+    expect(isBlockingRootGateState(result.state)).toBe(true)
   })
 })

--- a/packages/core/test/seal/delegated-signing.test.ts
+++ b/packages/core/test/seal/delegated-signing.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Integration tests for delegated-signing seal creation.
+ *
+ * Verifies that when a VaultKeeper SigningBackend-capable key provider is used,
+ * seals are signed without the raw private key ever being written to disk, while
+ * non-signing backends still work via the temp-file PEM fallback.
+ *
+ * @see https://github.com/mike-north/vaultkeeper (SigningBackend contract)
+ * @see https://github.com/mike-north/attest-it/issues/76
+ */
+
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as ed25519 from '../../src/crypto/ed25519.js'
+import { createSealWithProvider } from '../../src/seal/operations.js'
+import { VaultKeyProvider } from '../../src/key-provider/vault-key-provider.js'
+import {
+  createMockBackend,
+  createSigningMockBackend,
+  spkiPemToRawBase64,
+} from '../helpers/mock-backends.js'
+
+// Wrap node:fs/promises so writes still hit disk (needed by the fallback path)
+// while `writeFile` calls are observable — the ESM namespace cannot be spied
+// directly, so a partial module mock is used instead.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, writeFile: vi.fn(actual.writeFile) }
+})
+
+const GATE_ID = 'ci'
+const FINGERPRINT = 'a'.repeat(64)
+const SEALED_BY = 'alice'
+
+/** Whether a written value looks like PEM private-key material. */
+function isPemPrivateKey(value: unknown): boolean {
+  const text = Buffer.isBuffer(value)
+    ? value.toString('utf8')
+    : typeof value === 'string'
+      ? value
+      : ''
+  return text.includes('PRIVATE KEY')
+}
+
+/** Reconstruct the canonical string a seal was signed over. */
+function canonicalFor(seal: { gateId: string; fingerprint: string; timestamp: string }): string {
+  return `${seal.gateId}:${seal.fingerprint}:${seal.timestamp}`
+}
+
+/** Whether any writeFile call so far received PEM private-key content. */
+function wrotePemToDisk(): boolean {
+  return vi.mocked(fs.writeFile).mock.calls.some(([, data]) => isPemPrivateKey(data))
+}
+
+describe('createSealWithProvider — delegated signing', () => {
+  afterEach(() => {
+    vi.mocked(fs.writeFile).mockClear()
+  })
+
+  it('signs via the backend without writing raw private-key bytes to disk', async () => {
+    const signing = createSigningMockBackend()
+    const provider = new VaultKeyProvider({ backend: signing.backend, displayName: 'Signing' })
+
+    // Enroll a delegated signing key (the provider uses generateSigningKey).
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-delegated-'))
+    const publicKeyPath = path.join(tmpDir, 'public.pem')
+    let keyRef: string
+    let rawPublicKeyBase64: string
+    try {
+      const gen = await provider.generateKeyPair({ publicKeyPath })
+      keyRef = gen.privateKeyRef
+      const { publicKeyPem } = await signing.getPublicKeyFn(keyRef)
+      rawPublicKeyBase64 = spkiPemToRawBase64(publicKeyPem)
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+
+    // Only inspect writes made during the signing operation itself.
+    vi.mocked(fs.writeFile).mockClear()
+
+    const seal = await createSealWithProvider({
+      gateId: GATE_ID,
+      fingerprint: FINGERPRINT,
+      sealedBy: SEALED_BY,
+      keyProvider: provider,
+      keyRef,
+    })
+
+    // Delegated path was taken: the backend signed and no PEM touched disk.
+    expect(signing.signWithKeyFn).toHaveBeenCalledOnce()
+    expect(signing.retrieveFn).not.toHaveBeenCalled()
+    expect(wrotePemToDisk()).toBe(false)
+
+    // The delegated signature verifies against the enrolled public key.
+    expect(ed25519.verify(canonicalFor(seal), seal.signature, rawPublicKeyBase64)).toBe(true)
+    expect(seal.sealedBy).toBe(SEALED_BY)
+  })
+
+  it('delegated-path tamper: verify fails when the signed canonical string or signature is altered', async () => {
+    const signing = createSigningMockBackend()
+    const provider = new VaultKeyProvider({ backend: signing.backend, displayName: 'Signing' })
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attest-it-delegated-tamper-'))
+    const publicKeyPath = path.join(tmpDir, 'public.pem')
+    let keyRef: string
+    let rawPublicKeyBase64: string
+    try {
+      const gen = await provider.generateKeyPair({ publicKeyPath })
+      keyRef = gen.privateKeyRef
+      const { publicKeyPem } = await signing.getPublicKeyFn(keyRef)
+      rawPublicKeyBase64 = spkiPemToRawBase64(publicKeyPem)
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    }
+
+    const seal = await createSealWithProvider({
+      gateId: GATE_ID,
+      fingerprint: FINGERPRINT,
+      sealedBy: SEALED_BY,
+      keyProvider: provider,
+      keyRef,
+    })
+
+    // Baseline: the untampered delegated signature verifies.
+    const canonical = canonicalFor(seal)
+    expect(ed25519.verify(canonical, seal.signature, rawPublicKeyBase64)).toBe(true)
+
+    // Tamper 1: flip a byte in the signed canonical string (as if the gate's
+    // fingerprint were swapped after signing) — verify must reject.
+    const tamperedCanonical = `${seal.gateId}:${'b' + FINGERPRINT.slice(1)}:${seal.timestamp}`
+    expect(tamperedCanonical).not.toBe(canonical)
+    expect(ed25519.verify(tamperedCanonical, seal.signature, rawPublicKeyBase64)).toBe(false)
+
+    // Tamper 2: flip a byte in the signature itself — verify must reject.
+    const sigBytes = Buffer.from(seal.signature, 'base64')
+    sigBytes[0] ^= 0xff
+    const tamperedSignature = sigBytes.toString('base64')
+    expect(tamperedSignature).not.toBe(seal.signature)
+    expect(ed25519.verify(canonical, tamperedSignature, rawPublicKeyBase64)).toBe(false)
+  })
+
+  it('falls back to the temp-file PEM path for a non-signing backend', async () => {
+    // Generate a real Ed25519 key and store its PEM as an ordinary secret.
+    const { publicKey, privateKey } = ed25519.generateKeyPair()
+    const plain = createMockBackend()
+    const provider = new VaultKeyProvider({ backend: plain.backend, displayName: 'Plain' })
+    await plain.backend.store('key-1', privateKey)
+
+    // Delegated signing is unavailable for a plain SecretBackend.
+    expect(provider.signDirectly).toBeUndefined()
+
+    vi.mocked(fs.writeFile).mockClear()
+
+    const seal = await createSealWithProvider({
+      gateId: GATE_ID,
+      fingerprint: FINGERPRINT,
+      sealedBy: SEALED_BY,
+      keyProvider: provider,
+      keyRef: 'key-1',
+    })
+
+    // Fallback path retrieved the PEM and wrote it to a temp file — proving the
+    // detector above would catch a raw-key disk write in the delegated case.
+    expect(plain.retrieveFn).toHaveBeenCalledWith('key-1')
+    expect(wrotePemToDisk()).toBe(true)
+
+    // The fallback signature verifies against the stored key's public half.
+    expect(ed25519.verify(canonicalFor(seal), seal.signature, publicKey)).toBe(true)
+  })
+})
+
+describe('createSealWithProvider — fallback passphrase handling', () => {
+  afterEach(() => {
+    vi.mocked(fs.writeFile).mockClear()
+  })
+
+  it('does not resolve a passphrase for an unencrypted key', async () => {
+    const { publicKey, privateKey } = ed25519.generateKeyPair()
+    const plain = createMockBackend()
+    const provider = new VaultKeyProvider({ backend: plain.backend, displayName: 'Plain' })
+    await plain.backend.store('key-1', privateKey)
+
+    const resolvePassphrase = vi.fn<() => Promise<string | undefined>>()
+
+    const seal = await createSealWithProvider({
+      gateId: GATE_ID,
+      fingerprint: FINGERPRINT,
+      sealedBy: SEALED_BY,
+      keyProvider: provider,
+      keyRef: 'key-1',
+      resolvePassphrase,
+    })
+
+    expect(resolvePassphrase).not.toHaveBeenCalled()
+    expect(ed25519.verify(canonicalFor(seal), seal.signature, publicKey)).toBe(true)
+  })
+
+  it('resolves and applies the passphrase for an encrypted key', async () => {
+    const { publicKey, privateKey } = ed25519.generateKeyPair({ passphrase: 'correct horse' })
+    const plain = createMockBackend()
+    const provider = new VaultKeyProvider({ backend: plain.backend, displayName: 'Plain' })
+    await plain.backend.store('key-1', privateKey)
+
+    const resolvePassphrase = vi
+      .fn<() => Promise<string | undefined>>()
+      .mockResolvedValue('correct horse')
+
+    const seal = await createSealWithProvider({
+      gateId: GATE_ID,
+      fingerprint: FINGERPRINT,
+      sealedBy: SEALED_BY,
+      keyProvider: provider,
+      keyRef: 'key-1',
+      resolvePassphrase,
+    })
+
+    expect(resolvePassphrase).toHaveBeenCalledOnce()
+    expect(ed25519.verify(canonicalFor(seal), seal.signature, publicKey)).toBe(true)
+  })
+
+  it('propagates a passphrase-resolution failure (fail-closed, no seal)', async () => {
+    const { privateKey } = ed25519.generateKeyPair({ passphrase: 'pw' })
+    const plain = createMockBackend()
+    const provider = new VaultKeyProvider({ backend: plain.backend, displayName: 'Plain' })
+    await plain.backend.store('key-1', privateKey)
+
+    const resolvePassphrase = vi
+      .fn<() => Promise<string | undefined>>()
+      .mockRejectedValue(new Error('no passphrase available'))
+
+    await expect(
+      createSealWithProvider({
+        gateId: GATE_ID,
+        fingerprint: FINGERPRINT,
+        sealedBy: SEALED_BY,
+        keyProvider: provider,
+        keyRef: 'key-1',
+        resolvePassphrase,
+      }),
+    ).rejects.toThrow('no passphrase available')
+  })
+})

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -44150,6 +44150,7 @@ async function glob(patternsOrOptions, options) {
 // ../core/dist/index.js
 var os2 = __toESM(require("os"), 1);
 var import_os = require("os");
+var import_buffer = require("buffer");
 
 // ../../node_modules/.pnpm/vaultkeeper@0.7.0_@1password+sdk@0.4.0_@types+node@22.19.3/node_modules/vaultkeeper/dist/index.js
 init_cjs_shims();
@@ -46091,6 +46092,18 @@ function registerBuiltinBackends() {
   );
 }
 registerBuiltinBackends();
+function isPresenceCapableBackend(backend) {
+  return "getCapabilities" in backend && typeof backend.getCapabilities === "function";
+}
+async function getBackendCapabilities(backend) {
+  if (isPresenceCapableBackend(backend)) {
+    return backend.getCapabilities();
+  }
+  return { presencePerUse: false };
+}
+function isSigningBackend(backend) {
+  return "generateSigningKey" in backend && typeof backend.generateSigningKey === "function" && "getPublicKey" in backend && typeof backend.getPublicKey === "function" && "signWithKey" in backend && typeof backend.signWithKey === "function";
+}
 var INSPECT_CUSTOM = /* @__PURE__ */ Symbol.for("nodejs.util.inspect.custom");
 var SecretAccessorTarget = class {
   read;
@@ -47406,10 +47419,28 @@ async function setKeyPermissions(keyPath) {
     await fs32.chmod(keyPath, 384);
   }
 }
+var DELEGATED_SIGNING_ALGORITHM = "EdDSA";
+function spkiPemToRawBase64(publicKeyPem) {
+  const der = crypto22.createPublicKey(publicKeyPem).export({ type: "spki", format: "der" });
+  return import_buffer.Buffer.from(der).subarray(12).toString("base64");
+}
 var VaultKeyProvider = class {
   type;
   displayName;
   backend;
+  /**
+   * Delegated signing entry point, present only when the underlying backend
+   * implements VaultKeeper's `SigningBackend` contract.
+   *
+   * @remarks
+   * Assigned in the constructor so `signDirectly` is absent for non-signing
+   * backends — callers detect delegated-signing support via its presence
+   * combined with {@link VaultKeyProvider.supportsDelegatedSigning}. When
+   * delegated signing is used the raw private key never leaves the backend, so
+   * no PEM is written to disk (resolves the former `getPrivateKey` temp-file
+   * TODO for signing-capable backends).
+   */
+  signDirectly;
   /**
    * Create a new VaultKeyProvider.
    * @param options - Provider options including the VaultKeeper backend
@@ -47418,6 +47449,14 @@ var VaultKeyProvider = class {
     this.backend = options.backend;
     this.type = options.backend.type;
     this.displayName = options.displayName;
+    if (isSigningBackend(this.backend)) {
+      const signingBackend = this.backend;
+      this.signDirectly = async (keyRef, data) => {
+        const dataBuffer = typeof data === "string" ? import_buffer.Buffer.from(data, "utf8") : data;
+        const signature = await signingBackend.signWithKey(keyRef, dataBuffer);
+        return signature.toString("base64");
+      };
+    }
   }
   /**
    * Check if the underlying VaultKeeper backend is available.
@@ -47427,10 +47466,71 @@ var VaultKeyProvider = class {
   }
   /**
    * Check if a key exists in the VaultKeeper backend.
+   *
+   * @remarks
+   * For a signing-capable backend a key may live in the delegated signing-key
+   * namespace rather than the plain secret store, so both are checked.
+   *
    * @param keyRef - Secret identifier in the backend
    */
   async keyExists(keyRef) {
+    if (isSigningBackend(this.backend) && await this.signingKeyExists(this.backend, keyRef)) {
+      return true;
+    }
     return this.backend.exists(keyRef);
+  }
+  /**
+   * Whether a delegated signing key is enrolled under `keyRef`.
+   *
+   * @remarks
+   * VaultKeeper exposes no direct existence check for signing keys, so this
+   * probes `getPublicKey` (which never triggers a presence prompt). A
+   * `SigningKeyNotFoundError` means "not enrolled" — the correct fail-closed
+   * result (`false`). Any other error (backend unavailable, a transient
+   * 1Password/network blip, a decrypt failure) is re-thrown so it surfaces as a
+   * backend failure rather than being silently misreported as "no delegated
+   * key" (which would then confusingly fall back and fail with "Secret not
+   * found").
+   */
+  async signingKeyExists(backend, keyRef) {
+    try {
+      await backend.getPublicKey(keyRef);
+      return true;
+    } catch (error2) {
+      if (error2 instanceof SigningKeyNotFoundError) {
+        return false;
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Report whether `keyRef` can be signed via delegated backend signing, so
+   * callers can prefer {@link VaultKeyProvider.signDirectly} and avoid ever
+   * materializing the raw private key. Fail-closed: `false` when the backend is
+   * not signing-capable or no signing key is enrolled under `keyRef`.
+   *
+   * @param keyRef - Secret identifier in the backend
+   */
+  async supportsDelegatedSigning(keyRef) {
+    if (!isSigningBackend(this.backend)) {
+      return false;
+    }
+    return this.signingKeyExists(this.backend, keyRef);
+  }
+  /**
+   * Report whether the underlying backend enforces a fresh per-use human
+   * presence check. Fail-closed via VaultKeeper's `getBackendCapabilities`: a
+   * backend that does not implement the capability contract reports
+   * `{ presencePerUse: false }`.
+   */
+  async getPresenceCapability() {
+    const capabilities = await getBackendCapabilities(this.backend);
+    return {
+      presencePerUse: capabilities.presencePerUse,
+      ...capabilities.presenceEnforcedOperations && {
+        presenceEnforcedOperations: capabilities.presenceEnforcedOperations
+      }
+    };
   }
   /**
    * Retrieve the private key from VaultKeeper for signing.
@@ -47499,10 +47599,20 @@ var VaultKeyProvider = class {
         }
       }
     }
-    const keyPair = generateKeyPair();
-    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
-    await fs32.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
     const secretId = `attest-it-${crypto22.randomUUID()}`;
+    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
+    if (isSigningBackend(this.backend)) {
+      await this.backend.generateSigningKey(secretId, DELEGATED_SIGNING_ALGORITHM);
+      const { publicKeyPem } = await this.backend.getPublicKey(secretId);
+      await fs32.writeFile(publicKeyPath, spkiPemToRawBase64(publicKeyPem), "utf-8");
+      return {
+        privateKeyRef: secretId,
+        publicKeyPath,
+        storageDescription: `VaultKeeper (${this.backend.displayName}, delegated signing): ${secretId}`
+      };
+    }
+    const keyPair = generateKeyPair();
+    await fs32.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
     await this.backend.store(secretId, keyPair.privateKey);
     return {
       privateKeyRef: secretId,

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -44153,6 +44153,7 @@ async function glob(patternsOrOptions, options) {
 // ../core/dist/index.js
 import * as os2 from "os";
 import { homedir as homedir3 } from "os";
+import { Buffer as Buffer$1 } from "buffer";
 
 // ../../node_modules/.pnpm/vaultkeeper@0.7.0_@1password+sdk@0.4.0_@types+node@22.19.3/node_modules/vaultkeeper/dist/index.js
 init_esm_shims();
@@ -46094,6 +46095,18 @@ function registerBuiltinBackends() {
   );
 }
 registerBuiltinBackends();
+function isPresenceCapableBackend(backend) {
+  return "getCapabilities" in backend && typeof backend.getCapabilities === "function";
+}
+async function getBackendCapabilities(backend) {
+  if (isPresenceCapableBackend(backend)) {
+    return backend.getCapabilities();
+  }
+  return { presencePerUse: false };
+}
+function isSigningBackend(backend) {
+  return "generateSigningKey" in backend && typeof backend.generateSigningKey === "function" && "getPublicKey" in backend && typeof backend.getPublicKey === "function" && "signWithKey" in backend && typeof backend.signWithKey === "function";
+}
 var INSPECT_CUSTOM = /* @__PURE__ */ Symbol.for("nodejs.util.inspect.custom");
 var SecretAccessorTarget = class {
   read;
@@ -47409,10 +47422,28 @@ async function setKeyPermissions(keyPath) {
     await fs32.chmod(keyPath, 384);
   }
 }
+var DELEGATED_SIGNING_ALGORITHM = "EdDSA";
+function spkiPemToRawBase64(publicKeyPem) {
+  const der = crypto22.createPublicKey(publicKeyPem).export({ type: "spki", format: "der" });
+  return Buffer$1.from(der).subarray(12).toString("base64");
+}
 var VaultKeyProvider = class {
   type;
   displayName;
   backend;
+  /**
+   * Delegated signing entry point, present only when the underlying backend
+   * implements VaultKeeper's `SigningBackend` contract.
+   *
+   * @remarks
+   * Assigned in the constructor so `signDirectly` is absent for non-signing
+   * backends — callers detect delegated-signing support via its presence
+   * combined with {@link VaultKeyProvider.supportsDelegatedSigning}. When
+   * delegated signing is used the raw private key never leaves the backend, so
+   * no PEM is written to disk (resolves the former `getPrivateKey` temp-file
+   * TODO for signing-capable backends).
+   */
+  signDirectly;
   /**
    * Create a new VaultKeyProvider.
    * @param options - Provider options including the VaultKeeper backend
@@ -47421,6 +47452,14 @@ var VaultKeyProvider = class {
     this.backend = options.backend;
     this.type = options.backend.type;
     this.displayName = options.displayName;
+    if (isSigningBackend(this.backend)) {
+      const signingBackend = this.backend;
+      this.signDirectly = async (keyRef, data) => {
+        const dataBuffer = typeof data === "string" ? Buffer$1.from(data, "utf8") : data;
+        const signature = await signingBackend.signWithKey(keyRef, dataBuffer);
+        return signature.toString("base64");
+      };
+    }
   }
   /**
    * Check if the underlying VaultKeeper backend is available.
@@ -47430,10 +47469,71 @@ var VaultKeyProvider = class {
   }
   /**
    * Check if a key exists in the VaultKeeper backend.
+   *
+   * @remarks
+   * For a signing-capable backend a key may live in the delegated signing-key
+   * namespace rather than the plain secret store, so both are checked.
+   *
    * @param keyRef - Secret identifier in the backend
    */
   async keyExists(keyRef) {
+    if (isSigningBackend(this.backend) && await this.signingKeyExists(this.backend, keyRef)) {
+      return true;
+    }
     return this.backend.exists(keyRef);
+  }
+  /**
+   * Whether a delegated signing key is enrolled under `keyRef`.
+   *
+   * @remarks
+   * VaultKeeper exposes no direct existence check for signing keys, so this
+   * probes `getPublicKey` (which never triggers a presence prompt). A
+   * `SigningKeyNotFoundError` means "not enrolled" — the correct fail-closed
+   * result (`false`). Any other error (backend unavailable, a transient
+   * 1Password/network blip, a decrypt failure) is re-thrown so it surfaces as a
+   * backend failure rather than being silently misreported as "no delegated
+   * key" (which would then confusingly fall back and fail with "Secret not
+   * found").
+   */
+  async signingKeyExists(backend, keyRef) {
+    try {
+      await backend.getPublicKey(keyRef);
+      return true;
+    } catch (error2) {
+      if (error2 instanceof SigningKeyNotFoundError) {
+        return false;
+      }
+      throw error2;
+    }
+  }
+  /**
+   * Report whether `keyRef` can be signed via delegated backend signing, so
+   * callers can prefer {@link VaultKeyProvider.signDirectly} and avoid ever
+   * materializing the raw private key. Fail-closed: `false` when the backend is
+   * not signing-capable or no signing key is enrolled under `keyRef`.
+   *
+   * @param keyRef - Secret identifier in the backend
+   */
+  async supportsDelegatedSigning(keyRef) {
+    if (!isSigningBackend(this.backend)) {
+      return false;
+    }
+    return this.signingKeyExists(this.backend, keyRef);
+  }
+  /**
+   * Report whether the underlying backend enforces a fresh per-use human
+   * presence check. Fail-closed via VaultKeeper's `getBackendCapabilities`: a
+   * backend that does not implement the capability contract reports
+   * `{ presencePerUse: false }`.
+   */
+  async getPresenceCapability() {
+    const capabilities = await getBackendCapabilities(this.backend);
+    return {
+      presencePerUse: capabilities.presencePerUse,
+      ...capabilities.presenceEnforcedOperations && {
+        presenceEnforcedOperations: capabilities.presenceEnforcedOperations
+      }
+    };
   }
   /**
    * Retrieve the private key from VaultKeeper for signing.
@@ -47502,10 +47602,20 @@ var VaultKeyProvider = class {
         }
       }
     }
-    const keyPair = generateKeyPair();
-    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
-    await fs32.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
     const secretId = `attest-it-${crypto22.randomUUID()}`;
+    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
+    if (isSigningBackend(this.backend)) {
+      await this.backend.generateSigningKey(secretId, DELEGATED_SIGNING_ALGORITHM);
+      const { publicKeyPem } = await this.backend.getPublicKey(secretId);
+      await fs32.writeFile(publicKeyPath, spkiPemToRawBase64(publicKeyPem), "utf-8");
+      return {
+        privateKeyRef: secretId,
+        publicKeyPath,
+        storageDescription: `VaultKeeper (${this.backend.displayName}, delegated signing): ${secretId}`
+      };
+    }
+    const keyPair = generateKeyPair();
+    await fs32.writeFile(publicKeyPath, keyPair.publicKey, "utf-8");
     await this.backend.store(secretId, keyPair.privateKey);
     return {
       privateKeyRef: secretId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@1password/sdk':
+        specifier: ^0.4.0
+        version: 0.4.0
       '@migrex/core':
         specifier: 0.2.0-alpha.1
         version: 0.2.0-alpha.1
@@ -4631,13 +4634,11 @@ packages:
 
 snapshots:
 
-  '@1password/sdk-core@0.4.0':
-    optional: true
+  '@1password/sdk-core@0.4.0': {}
 
   '@1password/sdk@0.4.0':
     dependencies:
       '@1password/sdk-core': 0.4.0
-    optional: true
 
   '@actions/core@1.11.1':
     dependencies:


### PR DESCRIPTION
## Summary

Adopts VaultKeeper 0.7.0's **`SigningBackend`** (delegated signing) and **`PresenceCapableBackend`** (per-use presence) surfaces in attest-it's `VaultKeyProvider`, resolving the long-standing `vault-key-provider.ts:93` TODO for signing-capable backends. When a backend supports delegated signing, the private key is generated and held **inside the backend** and signing is delegated — the raw key never reaches attest-it's process memory as a file, let alone disk. Backends that implement only the base `SecretBackend` contract keep the existing temp-file PEM path unchanged (additive fallback).

Refs #76

> **DO NOT MERGE — flagged for the PM's review of the signing-path change** (see the interface-extension callout below).

## VaultKeeper 0.7.0 signing API used (verified against `~/Development/vaultkeeper`)

Verified directly in `~/Development/vaultkeeper/packages/vaultkeeper/src/backend/types.ts` (local checkout on `main`, `package.json` version `0.7.0`). The issue text guessed `authorizeSigningKey()`/`createSigningKey()` with a JWS contract — the **actual** 0.7.0 surface is:

- `SigningBackend` (extends `SecretBackend`):
  - `generateSigningKey(id, algorithm: SigningAlgorithm): Promise<void>` — enroll a keypair; private half never leaves the backend
  - `getPublicKey(id): Promise<SigningPublicKey>` — returns `{ publicKeyPem, algorithm, kid }`
  - `signWithKey(id, data: Buffer): Promise<Buffer>` — returns raw signature bytes
- `isSigningBackend(backend)` — exported type guard (used; no duck-typing)
- `PresenceCapableBackend`: `getCapabilities(): Promise<BackendCapabilities>` where `BackendCapabilities = { presencePerUse: boolean; presenceEnforcedOperations?: readonly PresenceOperation[] }`
- `isPresenceCapableBackend(backend)` and the fail-closed helper `getBackendCapabilities(backend)` (used) — returns `{ presencePerUse: false }` for non-capable backends
- `SigningAlgorithm = 'EdDSA'` (attest-it enrolls Ed25519 → `'EdDSA'`)

Only VaultKeeper's **file** backend implements `SigningBackend` in 0.7.0 (`file-backend.ts`), and attest-it's `filesystem` provider uses it — so delegated signing is a real path here, not test-only. Signing keys live in a namespace separate from ordinary secrets, so the provider's `generateKeyPair` was also routed through `generateSigningKey` to keep the lifecycle coherent (a key stored as a plain secret is not reachable via `signWithKey`).

### `npm view vaultkeeper dist-tags` (Proof section)

```
{ latest: '0.7.0' }
```

`vaultkeeper` was already pinned to `^0.7.0` in `packages/core/package.json`; confirmed `latest` is `0.7.0` (the `1.0.0`/`1.0.1` line is superseded per the issue — not adopted).

## KeyProvider interface extension — FLAGGED FOR PM REVIEW

The `KeyProvider` interface (`packages/core/src/key-provider/types.ts`) is built around `getPrivateKey()` returning a **file path** that gets fed to a local signer. Rather than force VaultKeeper's signing contract through that file-path shape, I **extended `KeyProvider` with three optional, additive members**:

- `signDirectly?(keyRef, data): Promise<string>` — sign via the backend, base64 result; the raw key never leaves the backend. Present on `VaultKeyProvider` only when the backend is signing-capable.
- `supportsDelegatedSigning?(keyRef): Promise<boolean>` — **per-key** (not just per-provider) probe, so a backend holding some keys as delegated signing keys and others as plain PEM secrets is handled correctly. Fail-closed.
- `getPresenceCapability?(): Promise<KeyPresenceCapability>` — per-use presence, fail-closed.

**Why additive/optional (and why this is a `minor`, not `major`, bump):** existing implementers (`LegacyFilesystemKeyProvider`) need no changes, and existing callers are unaffected. Nothing was removed or had its signature changed. Seal creation now goes through new `createSealWithProvider()` (prefers delegated signing, falls back to the temp-file PEM path) / `createSealWithSigner()` helpers, used by the `seal`/`run` commands and the embeddable `seal()` API. **Please confirm you're comfortable with this shape before merge** — it's the public `KeyProvider` contract.

### Migration note for the PM

Because attest-it's `filesystem` provider maps to the signing-capable file backend, **new** identities created after this change enroll their key via `generateSigningKey` (delegated). `supportsDelegatedSigning` is a per-key probe, so any pre-existing file-backend identity whose key was stored as a plain PEM secret still falls back to `getPrivateKey()` and keeps working — no silent breakage. Worth a conscious sign-off given #64–66 only just landed.

## Acceptance criteria → coverage

- **Delegated signing, key never on disk** — `VaultKeyProvider.signDirectly` (via `isSigningBackend` + `signWithKey`).
- **Fallback preserved for non-signing backends** — `getPrivateKey()` temp-file path unchanged; covered by existing + new fallback tests.
- **No-disk-write regression test** — `packages/core/test/seal/delegated-signing.test.ts`: partial-mocks `node:fs/promises` and asserts no `writeFile` call receives PEM-shaped content during a delegated signing operation, while the non-signing fallback **does** write a PEM temp file (proving the detector works). Plus a positive test that the delegated signature verifies against the enrolled public key, and passphrase-branch tests for the fallback.
- **Presence surfaced** — `attest-it identity show` reports per-use presence (`packages/cli/src/commands/identity/show.ts`) via new `getIdentityPresenceCapability()` (`@attest-it/core`), fail-closed.
- **`@1password/sdk` added + 1Password backend still resolves** — added as an explicit dependency of `@attest-it/core`; regression test `packages/core/test/key-provider/one-password-resolution.test.ts` imports `@1password/sdk` and constructs the VaultKeeper 1Password backend + provider.
- **`OnePasswordKeyProvider unaffected` AC** — the standalone `OnePasswordKeyProvider` referenced by the issue no longer exists (removed in the #64–66 consolidation; current key-provider files are `discovery.ts`, `index.ts`, `legacy-filesystem-provider.ts`, `registry.ts`, `store.ts`, `types.ts`, `vault-key-provider.ts`). There is no separate non-VaultKeeper 1Password provider to affect.
- **Docs** — README + `docs/configuration.md` document the `@1password/sdk` requirement for the VaultKeeper-backed 1Password path.

## Where things live

- Provider: `packages/core/src/key-provider/vault-key-provider.ts` (delegated `generateKeyPair`/`signDirectly`/`supportsDelegatedSigning`/`getPresenceCapability`/`keyExists`)
- Interface + types: `packages/core/src/key-provider/types.ts` (`KeyPresenceCapability`, `KeyPresenceOperation`)
- Seal helpers: `packages/core/src/seal/operations.ts` (`createSealWithProvider`, `createSealWithSigner`)
- CLI wiring: `seal.ts`, `run.ts`, `run-interactive.tsx`, `identity/show.ts`
- Presence helper: `packages/core/src/api/internal.ts` (`getIdentityPresenceCapability`)

## Relationship to #75

For VaultKeeper-managed signing keys, delegated signing **sidesteps** #75 (OpenSSL passphrase piping) entirely — no local OpenSSL passphrase handling occurs on the delegated path. This is **not** a substitute fix for #75, which also covers the plain filesystem path VaultKeeper does not touch.

## Verification

`pnpm build`, `pnpm check`, and `pnpm test` all pass across the workspace (782 tests). Formatter (Prettier), ESLint (0 errors), API Extractor report, knip, and syncpack all green.
