### PR TITLE
feat(cli): add identity migrate to import legacy filesystem identities into VaultKeeper

### DIFF
--- a/.changeset/identity-migrate-legacy.md
+++ b/.changeset/identity-migrate-legacy.md
@@ -1,0 +1,14 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Add `attest-it identity migrate` to import legacy `filesystem`-backed identities (from a v1-to-v2
+config migration) into VaultKeeper. It imports each legacy PEM into the configured VaultKeeper
+backend (default `file`), resolves a passphrase for encrypted keys the same way `run`/`seal` do,
+verifies a real sign/verify round-trip against the identity's recorded public key, and only then
+rewrites the identity's config record and deletes the original key file (`--keep-files` to skip
+deletion). Fail-closed: a verification failure rolls back the imported secret and leaves the
+legacy file and config untouched. Non-interactive capable via `--yes`. Idempotent: a second run
+with nothing left to migrate exits `0`. Once migrated, `identity list`/`identity show` no longer
+display the identity as "(legacy)".

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -528,6 +528,43 @@ is **no longer required** for this path. Authenticate the SDK with a 1Password
 [service account token](https://developer.1password.com/docs/service-accounts/)
 (`OP_SERVICE_ACCOUNT_TOKEN`) as documented by VaultKeeper.
 
+### Migrating Legacy Identities
+
+An identity whose `privateKey.type` is still the legacy `filesystem` shape (see
+[Path Resolution](#path-resolution)) reads its private key directly off disk instead of through
+VaultKeeper. Run `attest-it identity migrate` to import every legacy identity's key into
+VaultKeeper and rewrite its config record to the v2 `file`/`keychain`/`1password`/`yubikey` shape:
+
+```bash
+attest-it identity migrate            # migrate every legacy identity, prompting for confirmation
+attest-it identity migrate alice      # migrate only the "alice" identity
+attest-it identity migrate --yes      # non-interactive: skip the confirmation prompt
+attest-it identity migrate --storage keychain   # import into a backend other than the default `file`
+attest-it identity migrate --keep-files         # keep the original key file(s) after migrating
+```
+
+For each identity, `migrate`:
+
+1. Reads the legacy PEM file and, if it is passphrase-encrypted, resolves the passphrase the same
+   way `run`/`seal` do (`ATTEST_IT_KEY_PASSPHRASE` env var, or an interactive prompt when one flag
+   is missing and stdin is a TTY).
+2. Imports the exact PEM into the target VaultKeeper backend (default: `file`) — the identity's
+   public key never changes, since it's the same keypair, just relocated storage.
+3. **Verifies a real sign/verify round-trip** against the identity's already-recorded public key
+   using the newly-imported VaultKeeper-backed key.
+4. Only after that verification succeeds does it update `config.yaml`'s `privateKey` field and
+   delete the original legacy key file (unless `--keep-files` is passed).
+
+If verification fails for any reason, the just-imported VaultKeeper secret is rolled back, the
+legacy key file is left untouched, and `config.yaml` is not modified — migration is fail-closed. A
+second run with nothing left to migrate exits `0` and reports there is nothing to do.
+
+**Note:** the private key is imported via VaultKeeper's plain secret store (the same path
+`identity create` uses today), not VaultKeeper's delegated-signing key namespace — enrolling into
+that namespace (`generateSigningKey`) always mints a brand-new keypair, which would change the
+identity's public key. This does not affect signing: the imported key still signs through the
+same VaultKeeper-backed `getPrivateKey()` path used by every other non-delegated-signing key.
+
 ---
 
 ## Verification States

--- a/packages/cli/src/commands/identity/index.ts
+++ b/packages/cli/src/commands/identity/index.ts
@@ -5,6 +5,7 @@ import { useCommand } from './use.js'
 import { showCommand } from './show.js'
 import { removeCommand } from './remove.js'
 import { exportCommand } from './export.js'
+import { migrateCommand } from './migrate.js'
 
 export const identityCommand = new Command('identity')
   .description('Manage local identities and keypairs')
@@ -14,3 +15,4 @@ export const identityCommand = new Command('identity')
   .addCommand(showCommand)
   .addCommand(removeCommand)
   .addCommand(exportCommand)
+  .addCommand(migrateCommand)

--- a/packages/cli/src/commands/identity/migrate.ts
+++ b/packages/cli/src/commands/identity/migrate.ts
@@ -1,0 +1,371 @@
+import { Command } from 'commander'
+import { confirm } from '@inquirer/prompts'
+import { randomUUID } from 'node:crypto'
+import { readFile, unlink } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import * as path from 'node:path'
+import {
+  loadLocalConfig,
+  saveLocalConfig,
+  storePrivateKey,
+  deletePrivateKey,
+  KeyProviderRegistry,
+  signEd25519,
+  verifyEd25519,
+  isEncryptedPrivateKeyPem,
+  type Identity,
+  type LocalConfig,
+  type PrivateKeyRef,
+  type PrivateKeyBackendType,
+} from '@attest-it/core'
+import { log, success, error, info, warn, getTheme } from '../../utils/output.js'
+import { ExitCode } from '../../utils/exit-codes.js'
+import { resolveConfirmation, handlePromptableError } from '../../utils/prompts.js'
+import { resolveKeyPassphrase } from '../../utils/passphrase.js'
+
+/**
+ * Storage backend values accepted by `--storage`, mirroring `identity
+ * create`'s `--storage` (see `create.ts`).
+ */
+const STORAGE_TYPES = ['file', 'keychain', '1password', 'yubikey'] as const
+type StorageType = (typeof STORAGE_TYPES)[number]
+
+/** Maps a `--storage` value to the `KeyProviderRegistry` type it corresponds to. */
+const STORAGE_TYPE_TO_REGISTRY: Record<StorageType, string> = {
+  file: 'filesystem',
+  keychain: 'macos-keychain',
+  '1password': '1password',
+  yubikey: 'yubikey',
+}
+
+function isStorageType(value: string): value is StorageType {
+  return STORAGE_TYPES.some((storageType) => storageType === value)
+}
+
+/** Build the v2 `PrivateKeyRef` for a newly-imported key under `secretId`. */
+function buildPrivateKeyRef(storageType: StorageType, secretId: string): PrivateKeyRef {
+  switch (storageType) {
+    case 'file':
+      return { type: 'file', id: secretId }
+    case 'keychain':
+      return { type: 'keychain', id: secretId }
+    case '1password':
+      return { type: '1password', id: secretId }
+    case 'yubikey':
+      return { type: 'yubikey', id: secretId }
+  }
+}
+
+interface MigrateOptions {
+  yes?: boolean
+  storage?: string
+  keepFiles?: boolean
+}
+
+export const migrateCommand = new Command('migrate')
+  .description('Import legacy filesystem-backed identities into VaultKeeper')
+  .argument('[slug]', 'Migrate only this identity (defaults to every legacy identity)')
+  .option('-y, --yes', 'Skip the confirmation prompt and migrate non-interactively')
+  .option(
+    '--storage <backend>',
+    `Target VaultKeeper backend for the imported key: ${STORAGE_TYPES.join('|')}`,
+    'file',
+  )
+  .option(
+    '--keep-files',
+    'Do not delete the original legacy key file(s) after a verified migration',
+  )
+  .action(async (slug: string | undefined, options: MigrateOptions) => {
+    await runMigrate(slug, options)
+  })
+
+/** An identity slug paired with its (known-legacy) config entry. */
+interface LegacyIdentityEntry {
+  slug: string
+  identity: Identity
+  legacyPath: string
+}
+
+/**
+ * Find every identity in `config` whose private key is still the legacy
+ * `filesystem` shape (see `LegacyPrivateKeyRef`/`PrivateKeyRef` in
+ * `@attest-it/core`'s identity types), optionally narrowed to a single slug.
+ *
+ * @throws Error if `onlySlug` is given but does not name a legacy identity
+ * (either the slug does not exist, or it already migrated).
+ */
+function findLegacyIdentities(config: LocalConfig, onlySlug?: string): LegacyIdentityEntry[] {
+  const entries = Object.entries(config.identities)
+    .filter(([, identity]) => identity.privateKey.type === 'filesystem')
+    .map(([entrySlug, identity]) => ({
+      slug: entrySlug,
+      identity,
+      // Type narrowed by the filter above; TS can't see through Object.entries.
+      legacyPath: identity.privateKey.type === 'filesystem' ? identity.privateKey.path : '',
+    }))
+
+  if (onlySlug === undefined) {
+    return entries
+  }
+
+  const match = entries.find((entry) => entry.slug === onlySlug)
+  if (match) {
+    return [match]
+  }
+
+  // eslint-disable-next-line security/detect-object-injection -- onlySlug is the operator's own CLI argument, not attacker-controlled
+  if (config.identities[onlySlug]) {
+    // Exists, but isn't legacy -- not an error, just nothing to do for it.
+    return []
+  }
+
+  throw new Error(`Identity "${onlySlug}" not found`)
+}
+
+/**
+ * Result of successfully migrating a single legacy identity.
+ */
+interface MigratedIdentity {
+  slug: string
+  privateKeyRef: PrivateKeyRef
+  storageDescription: string
+  legacyPath: string
+}
+
+/**
+ * Import one legacy identity's private key into the target VaultKeeper
+ * backend, verify a real sign/verify round-trip against the identity's
+ * already-recorded public key, and return the new `PrivateKeyRef` to write
+ * into config.
+ *
+ * @remarks
+ * Fail-closed: if the round-trip verification throws for any reason, the
+ * just-stored VaultKeeper secret is deleted (best-effort) and the error is
+ * re-thrown -- the caller must not update config or delete the legacy file
+ * when this rejects. See issue #107.
+ *
+ * The private key is imported via the target backend's plain secret store
+ * (`storePrivateKey`), preserving the exact original PEM (and, if
+ * passphrase-encrypted, its exact encrypted form) so the identity's public
+ * key never changes. See the comment on VaultKeeper's `SigningBackend`
+ * contract in this PR's description for why a signing-namespace enrollment
+ * (`generateSigningKey`) is not used here.
+ */
+async function migrateOne(
+  entry: LegacyIdentityEntry,
+  storageType: StorageType,
+): Promise<MigratedIdentity> {
+  const { slug, identity, legacyPath } = entry
+
+  const legacyProvider = KeyProviderRegistry.create({ type: 'filesystem-legacy', options: {} })
+  const legacyResult = await legacyProvider.getPrivateKey(legacyPath)
+  let pem: string
+  try {
+    pem = await readFile(legacyResult.keyPath, 'utf8')
+  } finally {
+    await legacyResult.cleanup()
+  }
+
+  const passphrase = isEncryptedPrivateKeyPem(pem) ? await resolveKeyPassphrase() : undefined
+
+  const backendType: PrivateKeyBackendType = storageType
+  const { secretId, storageDescription } = await storePrivateKey(backendType, pem, identity.name)
+
+  try {
+    // eslint-disable-next-line security/detect-object-injection -- storageType is validated against STORAGE_TYPES above
+    const targetRegistryType = STORAGE_TYPE_TO_REGISTRY[storageType]
+    const targetProvider = KeyProviderRegistry.create({ type: targetRegistryType, options: {} })
+    const verifyResult = await targetProvider.getPrivateKey(secretId)
+    let storedPem: string
+    try {
+      storedPem = await readFile(verifyResult.keyPath, 'utf8')
+    } finally {
+      await verifyResult.cleanup()
+    }
+
+    const testMessage = `attest-it identity migrate verification for "${slug}" (${randomUUID()})`
+    const signature = signEd25519(testMessage, storedPem, passphrase)
+    const valid = verifyEd25519(testMessage, signature, identity.publicKey)
+    if (!valid) {
+      throw new Error(
+        'Signature produced by the imported key did not verify against the ' +
+          "identity's recorded public key",
+      )
+    }
+  } catch (verifyError) {
+    await deletePrivateKey(backendType, secretId).catch(() => {
+      // Best-effort cleanup -- the verification error below is the one that matters.
+    })
+    const message = verifyError instanceof Error ? verifyError.message : String(verifyError)
+    throw new Error(
+      `Failed to verify signing round-trip for identity "${slug}" after import: ${message}. ` +
+        'The legacy key file was left untouched and no config changes were made.',
+    )
+  }
+
+  return {
+    slug,
+    privateKeyRef: buildPrivateKeyRef(storageType, secretId),
+    storageDescription,
+    legacyPath,
+  }
+}
+
+/**
+ * Run the migrate command: import every (or one named) legacy
+ * `filesystem`-type identity's private key into VaultKeeper, verify it
+ * signs correctly, update the identity's config record to the v2 form, and
+ * (unless `--keep-files`) delete the original key file.
+ *
+ * @remarks
+ * Idempotent: with no legacy identities left to migrate (either none ever
+ * existed, or a prior run already migrated them), this exits 0 and says so
+ * rather than erroring. Non-interactive capable end-to-end via `--yes`; a
+ * closed/piped stdin without `--yes` fails fast rather than hanging on a
+ * prompt that can never resolve (matching `identity remove`'s convention).
+ * See issue #107.
+ *
+ * @public
+ */
+export async function runMigrate(slug: string | undefined, options: MigrateOptions): Promise<void> {
+  try {
+    const theme = getTheme()
+
+    const config = await loadLocalConfig()
+    if (!config) {
+      error('No identities configured')
+      log('')
+      log('Run: attest-it identity create')
+      process.exit(ExitCode.CONFIG_ERROR)
+    }
+
+    let storageType: StorageType = 'file'
+    if (options.storage !== undefined) {
+      if (!isStorageType(options.storage)) {
+        throw new Error(
+          `Unknown --storage value "${options.storage}". Supported values: ${STORAGE_TYPES.join(', ')}`,
+        )
+      }
+      storageType = options.storage
+    }
+
+    const legacyEntries = findLegacyIdentities(config, slug)
+
+    if (legacyEntries.length === 0) {
+      success(
+        slug !== undefined
+          ? `Identity "${slug}" is already on VaultKeeper -- nothing to migrate`
+          : 'No legacy identities to migrate -- nothing to do',
+      )
+      return
+    }
+
+    log('')
+    log(theme.blue.bold()('Identities to migrate:'))
+    log('')
+    for (const entry of legacyEntries) {
+      log(`  ${theme.blue(entry.slug)} (${entry.identity.name}) -- ${entry.legacyPath}`)
+    }
+    log('')
+    log(`Target VaultKeeper backend: ${storageType}`)
+    log('')
+
+    const proceed = await resolveConfirmation(options.yes, '--yes', () =>
+      confirm({
+        message: `Migrate ${legacyEntries.length.toString()} identit${legacyEntries.length === 1 ? 'y' : 'ies'} to VaultKeeper?`,
+        default: true,
+      }),
+    )
+    if (!proceed) {
+      log('Cancelled')
+      process.exit(ExitCode.CANCELLED)
+    }
+
+    const migrated: MigratedIdentity[] = []
+    const failures: { slug: string; message: string }[] = []
+
+    for (const entry of legacyEntries) {
+      try {
+        const result = await migrateOne(entry, storageType)
+        migrated.push(result)
+        info(`  Migrated "${result.slug}": ${result.storageDescription}`)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        failures.push({ slug: entry.slug, message })
+        error(`  Failed to migrate "${entry.slug}": ${message}`)
+      }
+    }
+
+    if (migrated.length > 0) {
+      const updatedIdentities: Record<string, Identity> = { ...config.identities }
+      for (const result of migrated) {
+        const current = updatedIdentities[result.slug]
+        if (!current) {
+          continue
+        }
+        updatedIdentities[result.slug] = { ...current, privateKey: result.privateKeyRef }
+      }
+
+      const newConfig: LocalConfig = {
+        version: 2,
+        activeIdentity: config.activeIdentity,
+        identities: updatedIdentities,
+      }
+      await saveLocalConfig(newConfig)
+
+      if (!options.keepFiles) {
+        for (const result of migrated) {
+          await deleteLegacyFile(result.legacyPath)
+        }
+      } else {
+        log('')
+        log('Keeping original legacy key file(s) (--keep-files)')
+      }
+    }
+
+    log('')
+    if (migrated.length > 0) {
+      success(
+        `Migrated ${migrated.length.toString()} identit${migrated.length === 1 ? 'y' : 'ies'} to VaultKeeper`,
+      )
+    }
+    if (failures.length > 0) {
+      log('')
+      warn(
+        `${failures.length.toString()} identit${failures.length === 1 ? 'y' : 'ies'} failed to migrate:`,
+      )
+      for (const failure of failures) {
+        log(`  ${failure.slug}: ${failure.message}`)
+      }
+      process.exit(ExitCode.CONFIG_ERROR)
+    }
+  } catch (err) {
+    handlePromptableError(err, ExitCode.CONFIG_ERROR)
+  }
+}
+
+/**
+ * Delete a migrated identity's legacy key file. Mirrors
+ * `identity/remove.ts`'s legacy-path deletion: `~` expansion is already
+ * resolved by `LegacyFilesystemKeyProvider.getPrivateKey` (the `legacyPath`
+ * recorded on `MigratedIdentity` is the raw, unresolved config path, so we
+ * re-resolve it here the same way `identity remove` does -- not shared via
+ * export because that module's internals are intentionally not part of the
+ * package's public API).
+ */
+async function deleteLegacyFile(rawPath: string): Promise<void> {
+  const resolvedPath =
+    rawPath === '~' || rawPath.startsWith('~/') ? path.join(homedir(), rawPath.slice(1)) : rawPath
+
+  try {
+    await unlink(resolvedPath)
+    log(`  Deleted legacy private key file: ${rawPath}`)
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
+      throw err
+    }
+  }
+}
+
+// Exported for testing
+export { findLegacyIdentities }

--- a/packages/cli/test/identity-migrate.test.ts
+++ b/packages/cli/test/identity-migrate.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for `identity migrate` (issue #107).
+ *
+ * These drive the real `runMigrate` implementation end-to-end against a real
+ * temp-directory home (via `setAttestItHomeDir`) and a real VaultKeeper
+ * `file` backend (redirected to the same temp directory via
+ * `VAULTKEEPER_CONFIG_DIR` -- issue #114's test-isolation guard). Nothing
+ * about config read/write, key storage, or signing is mocked: a legacy PEM
+ * file is written directly to disk (mirroring a hand-migrated v1 identity),
+ * `runMigrate` imports it into VaultKeeper, and the resulting identity is
+ * verified to actually sign with its recorded public key.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import {
+  setAttestItHomeDir,
+  saveLocalConfig,
+  loadLocalConfig,
+  generateEd25519KeyPair,
+  isEncryptedPrivateKeyPem,
+  signEd25519,
+  verifyEd25519,
+  KeyProviderRegistry,
+  type LocalConfig,
+  type PrivateKeyRef,
+} from '@attest-it/core'
+import { runMigrate, findLegacyIdentities } from '../src/commands/identity/migrate.js'
+import { ExitCode } from '../src/utils/exit-codes.js'
+
+/** Narrow a PrivateKeyRef to the v2 'file' variant, failing the test clearly if it isn't. */
+function expectFilePrivateKey(privateKey: PrivateKeyRef | undefined): {
+  type: 'file'
+  id: string
+} {
+  if (privateKey?.type !== 'file') {
+    throw new Error(
+      `Expected a file-backed private key reference, got: ${JSON.stringify(privateKey)}`,
+    )
+  }
+  return privateKey
+}
+
+/** Retrieve the PEM stored for a v2 file-backed key via the real VaultKeeper filesystem provider. */
+async function readStoredFilePem(privateKey: PrivateKeyRef | undefined): Promise<string> {
+  const ref = expectFilePrivateKey(privateKey)
+  const provider = KeyProviderRegistry.create({ type: 'filesystem', options: {} })
+  const result = await provider.getPrivateKey(ref.id)
+  try {
+    return await fs.promises.readFile(result.keyPath, 'utf8')
+  } finally {
+    await result.cleanup()
+  }
+}
+
+describe('identity migrate', () => {
+  let tempHome: string
+  let legacyKeysDir: string
+  const originalIsTTY = process.stdin.isTTY
+  const originalVaultKeeperConfigDir = process.env.VAULTKEEPER_CONFIG_DIR
+  const originalPassphraseEnv = process.env.ATTEST_IT_KEY_PASSPHRASE
+  let mockProcessExit: ReturnType<typeof vi.spyOn>
+  let mockConsoleLog: ReturnType<typeof vi.spyOn>
+  let mockConsoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-it-identity-migrate-'))
+    legacyKeysDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-it-identity-migrate-legacy-'))
+    setAttestItHomeDir(tempHome)
+    process.env.VAULTKEEPER_CONFIG_DIR = tempHome
+
+    // Non-interactive by default; individual tests override this.
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+
+    mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called')
+    })
+  })
+
+  afterEach(() => {
+    setAttestItHomeDir(null)
+    if (originalVaultKeeperConfigDir === undefined) {
+      delete process.env.VAULTKEEPER_CONFIG_DIR
+    } else {
+      process.env.VAULTKEEPER_CONFIG_DIR = originalVaultKeeperConfigDir
+    }
+    if (originalPassphraseEnv === undefined) {
+      delete process.env.ATTEST_IT_KEY_PASSPHRASE
+    } else {
+      process.env.ATTEST_IT_KEY_PASSPHRASE = originalPassphraseEnv
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true })
+    fs.rmSync(legacyKeysDir, { recursive: true, force: true })
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true })
+    vi.restoreAllMocks()
+  })
+
+  /** Write a legacy v1-style identity (raw PEM file + `type: 'filesystem'` config entry). */
+  async function seedLegacyIdentity(
+    slug: string,
+    options: { passphrase?: string } = {},
+  ): Promise<{ keyPath: string; publicKey: string }> {
+    const keyPair = generateEd25519KeyPair(
+      options.passphrase !== undefined ? { passphrase: options.passphrase } : {},
+    )
+    const keyPath = path.join(legacyKeysDir, `${slug}.pem`)
+    fs.writeFileSync(keyPath, keyPair.privateKey, { mode: 0o600 })
+
+    const existing = await loadLocalConfig()
+    const config: LocalConfig = {
+      version: 2,
+      activeIdentity: existing?.activeIdentity ?? slug,
+      identities: {
+        ...existing?.identities,
+        [slug]: {
+          name: slug,
+          publicKey: keyPair.publicKey,
+          privateKey: { type: 'filesystem', path: keyPath },
+        },
+      },
+    }
+    await saveLocalConfig(config)
+    return { keyPath, publicKey: keyPair.publicKey }
+  }
+
+  describe('successful migration (issue #107 AC: sign works after, legacy file gone)', () => {
+    it('imports the key into VaultKeeper, verifies a real sign/verify round-trip, and deletes the legacy file', async () => {
+      const { keyPath, publicKey } = await seedLegacyIdentity('alice')
+
+      await runMigrate(undefined, { yes: true, storage: 'file' })
+
+      const config = await loadLocalConfig()
+      const identity = config?.identities['alice']
+      expect(identity?.privateKey.type).toBe('file')
+
+      // The migrated identity's public key must be unchanged -- it's the
+      // same keypair, just relocated storage.
+      expect(identity?.publicKey).toBe(publicKey)
+
+      // Signing actually works with the new VaultKeeper-backed key.
+      const pem = await readStoredFilePem(identity?.privateKey)
+      const signature = signEd25519('post-migration message', pem)
+      expect(verifyEd25519('post-migration message', signature, publicKey)).toBe(true)
+
+      // The legacy file was deleted only after verification succeeded.
+      expect(fs.existsSync(keyPath)).toBe(false)
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('Deleted legacy'))
+      expect(mockProcessExit).not.toHaveBeenCalled()
+    })
+
+    it('no longer reports the identity as legacy in the migrated config record', async () => {
+      await seedLegacyIdentity('bob')
+
+      await runMigrate(undefined, { yes: true, storage: 'file' })
+
+      const config = await loadLocalConfig()
+      // `identity list`/`show` key off `privateKey.type` -- 'filesystem' is
+      // the only value that renders as "(legacy)"; anything else (here,
+      // 'file') flows through the normal v2 VaultKeeper display path.
+      expect(config?.identities['bob']?.privateKey.type).not.toBe('filesystem')
+    })
+
+    it('keeps the legacy file when --keep-files is passed', async () => {
+      const { keyPath } = await seedLegacyIdentity('carol')
+
+      await runMigrate(undefined, { yes: true, storage: 'file', keepFiles: true })
+
+      expect(fs.existsSync(keyPath)).toBe(true)
+      const config = await loadLocalConfig()
+      expect(config?.identities['carol']?.privateKey.type).toBe('file')
+    })
+  })
+
+  describe('passphrase-protected legacy keys (issue #107 AC)', () => {
+    it('migrates a passphrase-encrypted legacy key using ATTEST_IT_KEY_PASSPHRASE non-interactively', async () => {
+      const { keyPath, publicKey } = await seedLegacyIdentity('dave', {
+        passphrase: 'super-secret-passphrase',
+      })
+      process.env.ATTEST_IT_KEY_PASSPHRASE = 'super-secret-passphrase'
+
+      await runMigrate(undefined, { yes: true, storage: 'file' })
+
+      const config = await loadLocalConfig()
+      const identity = config?.identities['dave']
+      expect(identity?.privateKey.type).toBe('file')
+
+      const pem = await readStoredFilePem(identity?.privateKey)
+      // The imported PEM is byte-identical to the original -- still encrypted.
+      expect(isEncryptedPrivateKeyPem(pem)).toBe(true)
+      const signature = signEd25519('post-migration message', pem, 'super-secret-passphrase')
+      expect(verifyEd25519('post-migration message', signature, publicKey)).toBe(true)
+
+      expect(fs.existsSync(keyPath)).toBe(false)
+      expect(mockProcessExit).not.toHaveBeenCalled()
+    })
+
+    it('fails fast naming the env var when the key is encrypted and no passphrase is available non-interactively', async () => {
+      const { keyPath } = await seedLegacyIdentity('erin', { passphrase: 'another-secret' })
+
+      await expect(runMigrate(undefined, { yes: true, storage: 'file' })).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('ATTEST_IT_KEY_PASSPHRASE'),
+      )
+      // Never touched on failure.
+      expect(fs.existsSync(keyPath)).toBe(true)
+      const config = await loadLocalConfig()
+      expect(config?.identities['erin']?.privateKey.type).toBe('filesystem')
+    })
+  })
+
+  describe('failed-import path -- fail-closed (issue #107 AC)', () => {
+    it('leaves the legacy file untouched and reports a clear error when the round-trip verification fails', async () => {
+      // Simulate a corrupted/drifted v1 config: the recorded public key does
+      // not actually correspond to the private key on disk. Storing still
+      // succeeds (it's an opaque blob to VaultKeeper), but the post-import
+      // sign/verify round-trip must catch the mismatch before anything is
+      // deleted or written back to config.
+      const keyPair = generateEd25519KeyPair()
+      const wrongKeyPair = generateEd25519KeyPair()
+      const keyPath = path.join(legacyKeysDir, 'frank.pem')
+      fs.writeFileSync(keyPath, keyPair.privateKey, { mode: 0o600 })
+
+      const config: LocalConfig = {
+        version: 2,
+        activeIdentity: 'frank',
+        identities: {
+          frank: {
+            name: 'Frank',
+            publicKey: wrongKeyPair.publicKey, // Mismatched on purpose
+            privateKey: { type: 'filesystem', path: keyPath },
+          },
+        },
+      }
+      await saveLocalConfig(config)
+
+      await expect(runMigrate(undefined, { yes: true, storage: 'file' })).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to migrate "frank"'),
+      )
+
+      // Fail-closed: legacy file untouched, config unchanged.
+      expect(fs.existsSync(keyPath)).toBe(true)
+      const after = await loadLocalConfig()
+      expect(after?.identities['frank']?.privateKey).toEqual({ type: 'filesystem', path: keyPath })
+
+      // No orphaned VaultKeeper secret left behind by the rolled-back import
+      // (the backend's own `.key` wrap-key file is expected and untouched).
+      const storeDir = path.join(tempHome, 'file')
+      const remaining = fs.existsSync(storeDir)
+        ? fs.readdirSync(storeDir).filter((f) => f.endsWith('.enc'))
+        : []
+      expect(remaining).toEqual([])
+    })
+  })
+
+  describe('idempotency (issue #107 AC)', () => {
+    it('exits 0 and says there is nothing to migrate when no legacy identities exist', async () => {
+      await seedLegacyIdentity('grace')
+      await runMigrate(undefined, { yes: true, storage: 'file' })
+      mockConsoleLog.mockClear()
+
+      // Second run: grace is already migrated, so there is nothing left to do.
+      await runMigrate(undefined, { yes: true, storage: 'file' })
+
+      expect(mockProcessExit).not.toHaveBeenCalled()
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('nothing to'))
+    })
+
+    it('exits 0 for a config with zero identities configured needing migration', async () => {
+      const keyPair = generateEd25519KeyPair()
+      const config: LocalConfig = {
+        version: 2,
+        activeIdentity: 'heidi',
+        identities: {
+          heidi: {
+            name: 'Heidi',
+            publicKey: keyPair.publicKey,
+            privateKey: { type: 'file', id: 'attest-it-heidi-already-migrated' },
+          },
+        },
+      }
+      await saveLocalConfig(config)
+
+      await runMigrate(undefined, { yes: true, storage: 'file' })
+
+      expect(mockProcessExit).not.toHaveBeenCalled()
+      expect(mockConsoleLog).toHaveBeenCalledWith(expect.stringContaining('nothing to'))
+    })
+  })
+
+  describe('non-interactive confirmation (issue #107 AC: --yes, no TTY assumptions)', () => {
+    it('fails fast naming --yes when no flag is given and stdin is not a TTY', async () => {
+      await seedLegacyIdentity('ivan')
+
+      await expect(runMigrate(undefined, { storage: 'file' })).rejects.toThrow(
+        'process.exit called',
+      )
+
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('--yes'))
+      const config = await loadLocalConfig()
+      expect(config?.identities['ivan']?.privateKey.type).toBe('filesystem')
+    })
+  })
+
+  describe('findLegacyIdentities', () => {
+    it('returns only filesystem-typed identities', () => {
+      const keyPair = generateEd25519KeyPair()
+      const config: LocalConfig = {
+        version: 2,
+        activeIdentity: 'judy',
+        identities: {
+          judy: {
+            name: 'Judy',
+            publicKey: keyPair.publicKey,
+            privateKey: { type: 'filesystem', path: '/tmp/judy.pem' },
+          },
+          kim: {
+            name: 'Kim',
+            publicKey: keyPair.publicKey,
+            privateKey: { type: 'file', id: 'attest-it-kim-1' },
+          },
+        },
+      }
+
+      const result = findLegacyIdentities(config)
+      expect(result).toEqual([
+        { slug: 'judy', identity: config.identities['judy'], legacyPath: '/tmp/judy.pem' },
+      ])
+    })
+
+    it('throws for an unknown slug', () => {
+      const config: LocalConfig = { version: 2, activeIdentity: 'x', identities: {} }
+      expect(() => findLegacyIdentities(config, 'nonexistent')).toThrow('not found')
+    })
+
+    it('returns an empty list for a slug that already migrated', () => {
+      const keyPair = generateEd25519KeyPair()
+      const config: LocalConfig = {
+        version: 2,
+        activeIdentity: 'liam',
+        identities: {
+          liam: {
+            name: 'Liam',
+            publicKey: keyPair.publicKey,
+            privateKey: { type: 'file', id: 'attest-it-liam-1' },
+          },
+        },
+      }
+      expect(findLegacyIdentities(config, 'liam')).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds `attest-it identity migrate`, which imports every (or one named) `filesystem`-typed (v1
legacy) identity's private key into a VaultKeeper backend (default `file`), verifies it actually
signs correctly, and only then rewrites the identity's config record and deletes the legacy key
file.

## Design note: VaultKeeper's delegated-signing namespace

VaultKeeper 0.7.0's `SigningBackend` contract (`generateSigningKey(id, algorithm)`) only *mints a
brand-new keypair inside the backend* — there is no `importSigningKey` or equivalent that accepts
existing external key material. A migrated identity must keep its **original public key** (other
team members' `policy.yaml` `team:` entries, and any external verifiers, already trust that exact
key), so enrolling via `generateSigningKey` isn't an option here — it would silently produce a
different public key than the one being migrated.

Given that, this imports each legacy PEM via the backend's plain `SecretBackend.store()`/
`retrieve()` path — the same mechanism `identity create` already uses for every backend type today
(this codebase's `identity create` doesn't yet route through `generateSigningKey` for *any*
backend, signing-capable or not). This is fully functional: `VaultKeyProvider.getPrivateKey()`'s
existing PEM-retrieval fallback signs with it exactly like any other non-delegated key. Flagged
this discovered constraint on the issue (comment) before building around it, per the fleet
convention: https://github.com/mike-north/attest-it/issues/107#issuecomment-5009630318

## Acceptance criteria → tests

All in `packages/cli/test/identity-migrate.test.ts`, run end-to-end against a real temp-directory
home and a real VaultKeeper `file` backend (redirected via `VAULTKEEPER_CONFIG_DIR`, per #114's
test-isolation guard) — nothing about config read/write, key storage, or signing is mocked.

- **`identity migrate` enumerates `filesystem-legacy` identities and imports into VaultKeeper** →
  `successful migration > imports the key into VaultKeeper, verifies a real sign/verify
  round-trip, and deletes the legacy file`, `findLegacyIdentities` unit tests.
- **Passphrase-protected legacy keys: prompt once / env in non-interactive mode** →
  `passphrase-protected legacy keys > migrates a passphrase-encrypted legacy key using
  ATTEST_IT_KEY_PASSPHRASE non-interactively` and `> fails fast naming the env var when...no
  passphrase is available`.
- **Config updated to v2 form only after a verified signing round-trip; legacy file deleted only
  after that; `--keep-files` skips deletion** → `successful migration` describe block (all three
  tests), `successful migration > keeps the legacy file when --keep-files is passed`.
- **Idempotent: second run with nothing to migrate exits 0** → `idempotency > exits 0 and says
  there is nothing to migrate...` and `> exits 0 for a config with zero identities configured
  needing migration`.
- **Non-interactive capable end-to-end (`--yes`, no TTY assumptions)** → all tests run with
  `process.stdin.isTTY = undefined`; `non-interactive confirmation > fails fast naming --yes when
  no flag is given and stdin is not a TTY`.
- **`identity list`/`show` no longer display "(legacy)" for migrated identities** →
  `successful migration > no longer reports the identity as legacy in the migrated config record`
  (both commands key off the same `privateKey.type` this PR updates — verified manually end-to-end
  with the built CLI too; no changes needed in `list.ts`/`show.ts` themselves).
- **Tests: successful migration (sign works after, file gone), passphrase path, failed-import path
  (legacy file untouched, clear error), idempotency** → covered above, plus `failed-import path --
  fail-closed > leaves the legacy file untouched and reports a clear error when the round-trip
  verification fails` (simulates a drifted v1 config where the recorded public key doesn't match
  the private key on disk; asserts the legacy file is untouched, config is unchanged, and the
  just-stored VaultKeeper secret was rolled back — verified this test fails against a
  pre-fix build that skips the round-trip check).
- **Docs: migration section in the identity/configuration docs** → `docs/configuration.md`, new
  "Migrating Legacy Identities" subsection under Private Key Storage Options.

## Verify-before-delete flow

Per identity: read the legacy PEM → resolve a passphrase if it's encrypted
(`ATTEST_IT_KEY_PASSPHRASE` env var or interactive prompt) → import the exact PEM into the target
VaultKeeper backend via `storePrivateKey` → sign a fresh random test message with the
just-imported key and verify the signature against the identity's already-recorded public key →
**only on success**, return the new `PrivateKeyRef` for the caller to persist. If verification
throws, the just-stored VaultKeeper secret is deleted (best-effort) and a clear error is
re-thrown; the legacy file and `config.yaml` are never touched. Config is written and the legacy
file deleted only after every identity's `migrateOne()` call above has resolved (per-identity, so
one failure doesn't block others in the same run).

## CLI UX

```
attest-it identity migrate            # migrate every legacy identity, prompting for confirmation
attest-it identity migrate alice      # migrate only "alice"
attest-it identity migrate --yes      # non-interactive, no confirmation prompt
attest-it identity migrate --storage keychain   # import into a backend other than the default `file`
attest-it identity migrate --keep-files         # keep the original key file(s)
```

## Non-goals (unchanged)

- Does not remove the `filesystem-legacy` key provider itself.
- Does not touch already-1Password/YubiKey-backed identities (only `filesystem`-typed identities
  are ever candidates for migration).

## Test plan

- [x] `pnpm check` (workspace: syncpack, formatting, api-report, eslint, typecheck for
  `@attest-it/core`, `@attest-it/cli`, `attest-it`) — green
- [x] `pnpm test` (all 3 projects, 808 CLI + 597 core tests) — green
- [x] Manually verified end-to-end against the built CLI: `identity list` shows `file (legacy)` →
  `identity migrate --yes` → `identity list`/`identity show` show `file (VaultKeeper)`, legacy
  file deleted, second `identity migrate --yes` reports "nothing to do" and exits 0.
- [x] Confirmed the new failed-import regression test fails against a build that skips the
  round-trip verification check (sanity-checked the test isn't tautological).

Refs #107
