### PR TITLE
docs: note migrated identities don't yet use delegated signing (Refs #122)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -564,6 +564,9 @@ second run with nothing left to migrate exits `0` and reports there is nothing t
 that namespace (`generateSigningKey`) always mints a brand-new keypair, which would change the
 identity's public key. This does not affect signing: the imported key still signs through the
 same VaultKeeper-backed `getPrivateKey()` path used by every other non-delegated-signing key.
+Migrated keys therefore do not yet get delegated signing's no-disk-write benefit; re-enrolling
+them once VaultKeeper offers a public-key-preserving external-key import is tracked in
+[#122](https://github.com/mike-north/attest-it/issues/122).
 
 ---
 


### PR DESCRIPTION
Adds a one-line cross-reference from the identity-migration note in `docs/configuration.md` to the tracked follow-up #122.

Migrated (`filesystem-legacy` → VaultKeeper) identities currently sign via VaultKeeper's plain secret-store path (`getPrivateKey()`), not #119's delegated no-disk-write path, because VaultKeeper 0.7.0 has no public-key-preserving external-key import. The migration note already explained the mechanism; this adds the explicit "not yet" framing and links #122 so readers know it's a known limitation with a planned fix.

Docs-only; no code or package behavior change (no changeset needed).

Refs #122