### PR TITLE
feat(core): per-artifact pattern gates with optional (indefinite) maxAge

### DIFF
--- a/.changeset/pattern-and-optional-maxage-gates.md
+++ b/.changeset/pattern-and-optional-maxage-gates.md
@@ -1,0 +1,13 @@
+---
+'@attest-it/core': minor
+'attest-it': minor
+---
+
+Add per-artifact **pattern gates** and make gate `maxAge` optional (default: never expires).
+
+- **Pattern gates.** A gate may now declare `kind: pattern` (the default remains `single`). Under a pattern gate each file matched by the gate's fingerprint globs is fingerprinted and sealed **independently**: sealing `tools/a.sh` says nothing about `tools/b.sh`, a new file matching the pattern shows up as unsealed with **no `policy.yaml` edit** (and therefore no re-seal of unrelated files), and changing one byte of a sealed file flips only that file to invalid while its siblings stay valid. `status` and `verify` report one deterministically ordered (lexicographic by path) result per matched file.
+- **Optional `maxAge`.** `maxAge` is no longer required on a gate. When omitted, the gate is **indefinite** — `verify`/`status` never report a `STALE`/age-based failure for it regardless of seal age (indefinite is the genuine default, not a large-number sentinel).
+- **New exports.** `computeFingerprintsPerFile` / `computeFingerprintsPerFileSync` (one `PerFileFingerprint` per matched file, path-bound so symlink aliases cannot share a fingerprint), `verifyPatternArtifactSeal`, and the low-level per-file seal primitives `writeSealFile` / `listStoredSeals`.
+- **Additive `Seal.artifactPath`.** Per-file seals carry an optional `artifactPath` identifying which file within a pattern gate they cover, and are stored under an artifact path segment (`<gate>/<artifact>/<signer>.seal`) reusing the existing collision-safe slug. They are written and read via the low-level per-file API and are deliberately excluded from — and never pruned by — the aggregate one-per-gate seals path, so per-file and single-gate seals coexist without clobbering each other.
+
+This change is fully additive: existing single-fingerprint gates and their seals behave exactly as before.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ suites:
 
 - **Team** - People authorized to create seals, identified by their public key (in `policy.yaml`)
 - **Root gate** - The trust anchor over `policy.yaml` itself; only `rootGate.authorizedSigners` may authorize changes to the trust data. Established via the `attest-it init --root-signer` bootstrap ceremony (in `policy.yaml`)
-- **Gates** - Define which files require attestation and who can sign, including the fingerprint config (in `policy.yaml`)
+- **Gates** - Define which files require attestation and who can sign, including the fingerprint config (in `policy.yaml`). A gate's `kind` is `single` by default (all matched files → one combined seal); set `kind: pattern` to seal each matched file independently, so adding a new matching file just shows as unsealed without a config edit. `maxAge` is optional — omit it for a gate whose seals never expire (valid until content changes).
 - **Fingerprint** - Files to hash; any change invalidates the seal (lives on the gate)
 - **Suites** - Test commands that reference a gate; every suite must specify `gate` (in `config.yaml`)
 - **minVersion** - Optional; minimum attest-it version required for this configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -338,13 +338,52 @@ gates:
 
 ### Gate Fields
 
-| Field               | Type     | Required | Default | Description                                  |
-| ------------------- | -------- | -------- | ------- | -------------------------------------------- |
-| `name`              | string   | Yes      | -       | Display name (min 1 character)               |
-| `description`       | string   | Yes      | -       | Human-readable description (min 1 character) |
-| `authorizedSigners` | string[] | Yes      | -       | Team member slugs who can seal (min 1)       |
-| `fingerprint`       | object   | Yes      | -       | Fingerprint configuration                    |
-| `maxAge`            | string   | Yes      | -       | Maximum seal age (duration string)           |
+| Field               | Type                  | Required | Default    | Description                                                    |
+| ------------------- | --------------------- | -------- | ---------- | -------------------------------------------------------------- |
+| `name`              | string                | Yes      | -          | Display name (min 1 character)                                 |
+| `description`       | string                | Yes      | -          | Human-readable description (min 1 character)                   |
+| `kind`              | `single` \| `pattern` | No       | `single`   | How matched files map to seals (see [Gate Kinds](#gate-kinds)) |
+| `authorizedSigners` | string[]              | Yes      | -          | Team member slugs who can seal (min 1)                         |
+| `fingerprint`       | object                | Yes      | -          | Fingerprint configuration                                      |
+| `maxAge`            | string                | No       | indefinite | Maximum seal age (duration string). Omit to never expire.      |
+
+### Gate Kinds
+
+A gate's `kind` controls how its matched files map to seals:
+
+- **`single`** (the default when `kind` is omitted): every matched file is combined
+  into **one** fingerprint covered by **one** seal. Changing any matched file
+  invalidates the gate's single seal. This is the historical gate behavior.
+- **`pattern`**: each matched file is fingerprinted and sealed **independently**.
+  Sealing `tools/a.sh` says nothing about `tools/b.sh`, and a **new** file matching
+  the gate's globs simply shows up as unsealed — no `policy.yaml` edit (and therefore
+  no re-seal of unrelated files) is required. Changing one byte of a sealed file flips
+  only that file to invalid; its siblings are unaffected.
+
+```yaml
+# .attest-it/policy.yaml — a pattern gate: one definition, per-file seals
+gates:
+  tools:
+    name: Tool Scripts
+    description: Each tool script is attested independently
+    kind: pattern
+    authorizedSigners:
+      - alice
+    fingerprint:
+      paths:
+        - tools/*.sh
+    # maxAge omitted → these seals never expire (valid until content changes)
+```
+
+Under a pattern gate, `status` and `verify` report one row **per matched file**
+(deterministically ordered by path), each with its own sealed/unsealed/invalid state.
+
+### Optional `maxAge` (indefinite gates)
+
+`maxAge` is optional. When omitted, the gate **never expires**: `verify` and `status`
+never report an age-based (`STALE`) result for it, regardless of how old the seal is —
+the seal stays valid until the covered content changes. Provide a duration string only
+when you want seals to be considered stale after a fixed period.
 
 ### Fingerprint Configuration
 

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -81,6 +81,12 @@ export interface CliExperiencePreferences {
 export function computeFingerprint(options: FingerprintOptions): Promise<FingerprintResult>;
 
 // @public
+export function computeFingerprintsPerFile(options: FingerprintOptions): Promise<PerFileFingerprint[]>;
+
+// @public
+export function computeFingerprintsPerFileSync(options: FingerprintOptions): PerFileFingerprint[];
+
+// @public
 export function computeFingerprintSync(options: FingerprintOptions): FingerprintResult;
 
 // @public
@@ -240,7 +246,8 @@ export interface GateConfig {
     authorizedSigners: string[];
     description: string;
     fingerprint: FingerprintConfig;
-    maxAge: string;
+    kind?: GateKind | undefined;
+    maxAge?: string | undefined;
     name: string;
 }
 
@@ -250,10 +257,14 @@ export interface GateDescriptor {
     description: string;
     exclude: string[];
     gateId: string;
-    maxAge: string;
+    kind?: 'pattern' | 'single';
+    maxAge?: string;
     name: string;
     paths: string[];
 }
+
+// @public
+export type GateKind = 'pattern' | 'single';
 
 // @public
 export function generateEd25519KeyPair(options?: Ed25519GenerateKeyPairOptions): Ed25519KeyPair;
@@ -457,6 +468,9 @@ export function listOnePasswordVaults(accountUuid?: string): Promise<OnePassword
 
 // @public
 export function listPackageFiles(packages: string[], ignore?: string[], baseDir?: string): Promise<string[]>;
+
+// @public
+export function listStoredSeals(root: string): Promise<StoredSeal[]>;
 
 // @public
 export function listStoredSealsSync(root: string): StoredSeal[];
@@ -711,6 +725,12 @@ export function parseOperationalContent(content: string, format: 'json' | 'yaml'
 export function parsePolicyContent(content: string, format: 'json' | 'yaml'): PolicyConfig;
 
 // @public
+export interface PerFileFingerprint {
+    fingerprint: string;
+    path: string;
+}
+
+// @public
 export type PolicyConfig = z.infer<typeof policySchema>;
 
 // @public
@@ -728,7 +748,8 @@ export const policySchema: z.ZodObject<{
             exclude?: string[] | undefined;
             paths: string[];
         }>;
-        maxAge: z.ZodEffects<z.ZodString, string, string>;
+        kind: z.ZodOptional<z.ZodEnum<["single", "pattern"]>>;
+        maxAge: z.ZodOptional<z.ZodEffects<z.ZodString, string, string>>;
         name: z.ZodString;
     }, "strict", z.ZodTypeAny, {
         authorizedSigners: string[];
@@ -737,7 +758,8 @@ export const policySchema: z.ZodObject<{
             exclude?: string[] | undefined;
             paths: string[];
         };
-        maxAge: string;
+        kind?: "pattern" | "single" | undefined;
+        maxAge?: string | undefined;
         name: string;
     }, {
         authorizedSigners: string[];
@@ -746,7 +768,8 @@ export const policySchema: z.ZodObject<{
             exclude?: string[] | undefined;
             paths: string[];
         };
-        maxAge: string;
+        kind?: "pattern" | "single" | undefined;
+        maxAge?: string | undefined;
         name: string;
     }>>>;
     minVersion: z.ZodOptional<z.ZodString>;
@@ -807,7 +830,8 @@ export const policySchema: z.ZodObject<{
             exclude?: string[] | undefined;
             paths: string[];
         };
-        maxAge: string;
+        kind?: "pattern" | "single" | undefined;
+        maxAge?: string | undefined;
         name: string;
     }> | undefined;
     minVersion?: string | undefined;
@@ -838,7 +862,8 @@ export const policySchema: z.ZodObject<{
             exclude?: string[] | undefined;
             paths: string[];
         };
-        maxAge: string;
+        kind?: "pattern" | "single" | undefined;
+        maxAge?: string | undefined;
         name: string;
     }> | undefined;
     minVersion?: string | undefined;
@@ -959,6 +984,7 @@ export function savePublicKeySync(slug: string, publicKey: string): SavePublicKe
 
 // @public
 export interface Seal {
+    artifactPath?: string | undefined;
     fingerprint: string;
     gateId: string;
     sealedBy: string;
@@ -992,6 +1018,7 @@ export interface SealsFile {
 
 // @public
 export interface SealVerificationResult {
+    artifactPath?: string;
     gateId: string;
     message?: string;
     seal?: Seal;
@@ -1196,6 +1223,9 @@ export function verifyGateSeal(config: AttestItConfig, gateId: string, seals: Se
 export function verifyOne(artifactPath: string, options?: ApiOptions): Promise<ArtifactVerification>;
 
 // @public
+export function verifyPatternArtifactSeal(config: AttestItConfig, gateId: string, artifactPath: string, seal: Seal | undefined, currentFingerprint: string, maxAge: string | undefined): SealVerificationResult;
+
+// @public
 export function verifyRootGate(params: {
     config: AttestItConfig;
     policyFingerprint: string;
@@ -1215,6 +1245,9 @@ export class VersionIncompatibleError extends Error {
     readonly currentVersion: string;
     readonly requiredVersion: string;
 }
+
+// @public
+export function writeSealFile(root: string, seal: Seal): Promise<string>;
 
 // @public
 export function writeSealFileSync(root: string, seal: Seal): string;

--- a/packages/core/src/api/internal.ts
+++ b/packages/core/src/api/internal.ts
@@ -8,7 +8,7 @@
  */
 
 import * as path from 'node:path'
-import type { AttestItConfig } from '../types.js'
+import type { AttestItConfig, GateConfig } from '../types.js'
 import type { Identity } from '../identity/index.js'
 import { listPackageFiles } from '../fingerprint.js'
 import { KeyProviderRegistry } from '../key-provider/index.js'
@@ -82,12 +82,21 @@ export function stateToFailureClass(state: Exclude<VerificationState, 'VALID'>):
  *
  * @internal
  */
-function normalizeRelativePath(artifactPath: string, baseDir: string): string {
+export function normalizeRelativePath(artifactPath: string, baseDir: string): string {
   const absolute = path.isAbsolute(artifactPath)
     ? artifactPath
     : path.resolve(baseDir, artifactPath)
   const relative = path.relative(baseDir, absolute)
   return relative.split(path.sep).join('/')
+}
+
+/**
+ * Whether a gate seals each matched file independently (pattern gate) rather
+ * than as one combined fingerprint (the `single` default).
+ * @internal
+ */
+export function isPatternGate(gate: GateConfig): boolean {
+  return gate.kind === 'pattern'
 }
 
 /**

--- a/packages/core/src/api/operations.ts
+++ b/packages/core/src/api/operations.ts
@@ -15,23 +15,31 @@
 
 import { stat } from 'node:fs/promises'
 import * as path from 'node:path'
-import type { AttestItConfig } from '../types.js'
+import type { AttestItConfig, GateConfig } from '../types.js'
 import { loadSplitConfig } from '../config/index.js'
-import { computeFingerprint, listPackageFiles } from '../fingerprint.js'
+import { computeFingerprint, computeFingerprintsPerFile, listPackageFiles } from '../fingerprint.js'
 import { loadLocalConfigSync } from '../identity/index.js'
 import {
   createSealWithProvider,
   readSeals,
   writeSeals,
+  writeSealFile,
+  listStoredSeals,
+  resolveSealsRoot,
   verifyGateSeal,
+  verifyPatternArtifactSeal,
+  type Seal,
   type SealsFile,
+  type SealVerificationResult,
 } from '../seal/index.js'
 import {
   evaluateConfigTrust,
   fail,
   isApiFailure,
+  isPatternGate,
   keyProviderForIdentity,
   keyRefForIdentity,
+  normalizeRelativePath,
   resolveGatesForPath,
   stateToFailureClass,
 } from './internal.js'
@@ -46,7 +54,6 @@ import {
   type SealParams,
   type SealResult,
   type StatusResult,
-  type VerificationSuccess,
   type VerifyAllParams,
   type VerifyAllResult,
 } from './types.js'
@@ -139,25 +146,121 @@ async function verifyGate(
     })
   }
   const verdict = verifyGateSeal(config, gateId, seals, fingerprint)
+  return verdictToArtifactVerification(verdict, gateId, fingerprint, artifactPath)
+}
 
+/**
+ * Shape a core {@link SealVerificationResult} into a path-keyed
+ * {@link ArtifactVerification}, echoing `artifactPath` (as `path`) when present.
+ */
+function verdictToArtifactVerification(
+  verdict: SealVerificationResult,
+  gateId: string,
+  fingerprint: string,
+  artifactPath?: string,
+): ArtifactVerification {
+  const pathValue = artifactPath ?? verdict.artifactPath
   if (verdict.state === 'VALID') {
-    const success: VerificationSuccess = {
+    return {
       schemaVersion: API_SCHEMA_VERSION,
       ok: true,
       gateId,
       fingerprint,
       sealedBy: verdict.seal?.sealedBy ?? '',
       sealedAt: verdict.seal?.timestamp ?? '',
-      ...(artifactPath !== undefined && { path: artifactPath }),
+      ...(pathValue !== undefined && { path: pathValue }),
     }
-    return success
   }
-
   return fail(stateToFailureClass(verdict.state), verdict.message ?? verdict.state, {
     gateId,
     underlyingState: verdict.state,
-    ...(artifactPath !== undefined && { path: artifactPath }),
+    ...(pathValue !== undefined && { path: pathValue }),
   })
+}
+
+/**
+ * The latest per-file seal for each matched file of a pattern gate, keyed by
+ * artifact path. When several signers sealed the same file, the most recent wins
+ * (ties broken by signer slug) — the same deterministic collapse the aggregate
+ * storage uses for multiple signers.
+ */
+async function readPatternSealsByArtifact(
+  config: AttestItConfig,
+  gateId: string,
+  baseDir: string,
+): Promise<Map<string, Seal>> {
+  const root = resolveSealsRoot(baseDir, config.settings.sealsPath)
+  const byArtifact = new Map<string, Seal>()
+  for (const { seal } of await listStoredSeals(root)) {
+    if (seal.gateId !== gateId || seal.artifactPath === undefined) continue
+    const current = byArtifact.get(seal.artifactPath)
+    if (
+      !current ||
+      seal.timestamp > current.timestamp ||
+      (seal.timestamp === current.timestamp && seal.sealedBy > current.sealedBy)
+    ) {
+      byArtifact.set(seal.artifactPath, seal)
+    }
+  }
+  return byArtifact
+}
+
+/**
+ * Verify a pattern gate: one independent {@link ArtifactVerification} per matched
+ * file, sorted lexicographically by path (deterministic for `status --json`).
+ *
+ * When `filterPath` is given, only that file's result is returned (path-keyed
+ * verification of a single file within a pattern gate).
+ */
+async function verifyPatternGate(
+  config: AttestItConfig,
+  gateId: string,
+  gate: GateConfig,
+  baseDir: string,
+  filterPath?: string,
+): Promise<ArtifactVerification[]> {
+  let perFile
+  try {
+    perFile = await computeFingerprintsPerFile({
+      paths: gate.fingerprint.paths,
+      ...(gate.fingerprint.exclude && { exclude: gate.fingerprint.exclude }),
+      baseDir,
+    })
+  } catch (error) {
+    return [
+      fail('malformed', error instanceof Error ? error.message : String(error), {
+        gateId,
+        ...(filterPath !== undefined && { path: filterPath }),
+      }),
+    ]
+  }
+
+  let sealsByArtifact: Map<string, Seal>
+  try {
+    sealsByArtifact = await readPatternSealsByArtifact(config, gateId, baseDir)
+  } catch (error) {
+    return [
+      fail('malformed', error instanceof Error ? error.message : String(error), {
+        gateId,
+        ...(filterPath !== undefined && { path: filterPath }),
+      }),
+    ]
+  }
+
+  const results: ArtifactVerification[] = []
+  for (const { path: filePath, fingerprint } of perFile) {
+    if (filterPath !== undefined && filePath !== filterPath) continue
+    const verdict = verifyPatternArtifactSeal(
+      config,
+      gateId,
+      filePath,
+      sealsByArtifact.get(filePath),
+      fingerprint,
+      gate.maxAge,
+    )
+    results.push(verdictToArtifactVerification(verdict, gateId, fingerprint, filePath))
+  }
+  return results
 }
 
 /**
@@ -183,10 +286,11 @@ export async function listGates(options: ApiOptions = {}): Promise<ListGatesResu
     gateId,
     name: gate.name,
     description: gate.description,
+    ...(gate.kind !== undefined && { kind: gate.kind }),
     authorizedSigners: [...gate.authorizedSigners],
     paths: [...gate.fingerprint.paths],
     exclude: [...(gate.fingerprint.exclude ?? [])],
-    maxAge: gate.maxAge,
+    ...(gate.maxAge !== undefined && { maxAge: gate.maxAge }),
   }))
 
   return { schemaVersion: API_SCHEMA_VERSION, ok: true, gates }
@@ -224,20 +328,53 @@ export async function status(
 
   if (paths && paths.length > 0) {
     for (const artifactPath of paths) {
-      const gate = await resolveSingleGateOrFail(loaded, artifactPath, baseDir)
-      if (typeof gate !== 'string') {
-        results.push(gate)
+      const gateId = await resolveSingleGateOrFail(loaded, artifactPath, baseDir)
+      if (typeof gateId !== 'string') {
+        results.push(gateId)
         continue
       }
-      results.push(await verifyGate(loaded, gate, baseDir, artifactPath))
+      results.push(await verifyPathInGate(loaded, gateId, baseDir, artifactPath))
     }
   } else {
     for (const gateId of Object.keys(loaded.gates ?? {})) {
-      results.push(await verifyGate(loaded, gateId, baseDir))
+      // eslint-disable-next-line security/detect-object-injection
+      const gate = loaded.gates?.[gateId]
+      if (gate && isPatternGate(gate)) {
+        results.push(...(await verifyPatternGate(loaded, gateId, gate, baseDir)))
+      } else {
+        results.push(await verifyGate(loaded, gateId, baseDir))
+      }
     }
   }
 
   return { schemaVersion: API_SCHEMA_VERSION, ok: true, results }
+}
+
+/**
+ * Verify one artifact path against its governing gate, dispatching to the
+ * pattern-gate per-file path when the gate is a pattern gate (so only that file's
+ * seal is evaluated), or the whole-gate path otherwise.
+ */
+async function verifyPathInGate(
+  config: AttestItConfig,
+  gateId: string,
+  baseDir: string,
+  artifactPath: string,
+): Promise<ArtifactVerification> {
+  // eslint-disable-next-line security/detect-object-injection
+  const gate = config.gates?.[gateId]
+  if (gate && isPatternGate(gate)) {
+    const target = normalizeRelativePath(artifactPath, baseDir)
+    const [only] = await verifyPatternGate(config, gateId, gate, baseDir, target)
+    return (
+      only ??
+      fail('malformed', `Path '${artifactPath}' is not matched by pattern gate '${gateId}'`, {
+        gateId,
+        path: artifactPath,
+      })
+    )
+  }
+  return verifyGate(config, gateId, baseDir, artifactPath)
 }
 
 /**
@@ -277,6 +414,37 @@ export async function fingerprint(
   }
 
   try {
+    if (isPatternGate(gateConfig)) {
+      // A pattern gate fingerprints each file individually; return the requested
+      // file's own fingerprint (the one its per-file seal binds), not a combined
+      // hash over the whole gate.
+      const target = normalizeRelativePath(artifactPath, baseDir)
+      const perFile = await computeFingerprintsPerFile({
+        paths: gateConfig.fingerprint.paths,
+        ...(gateConfig.fingerprint.exclude && { exclude: gateConfig.fingerprint.exclude }),
+        baseDir,
+      })
+      const match = perFile.find((f) => f.path === target)
+      if (!match) {
+        return fail(
+          'malformed',
+          `Path '${artifactPath}' is not matched by pattern gate '${gate}'`,
+          {
+            gateId: gate,
+            path: artifactPath,
+          },
+        )
+      }
+      return {
+        schemaVersion: API_SCHEMA_VERSION,
+        ok: true,
+        gateId: gate,
+        path: artifactPath,
+        fingerprint: match.fingerprint,
+        fileCount: 1,
+      }
+    }
+
     const result = await computeFingerprint({
       paths: gateConfig.fingerprint.paths,
       ...(gateConfig.fingerprint.exclude && { exclude: gateConfig.fingerprint.exclude }),
@@ -367,6 +535,60 @@ export async function seal(
     )
   }
 
+  const keyProvider = keyProviderForIdentity(identity)
+  const keyRef = keyRefForIdentity(identity)
+
+  // Pattern gate: seal ONLY the requested file, using its individual fingerprint,
+  // and persist via the low-level per-file writer. It must NOT go through the
+  // aggregate writeSeals path, which is one-file-per-gate and would prune every
+  // sibling file's seal.
+  if (isPatternGate(gateConfig)) {
+    const target = normalizeRelativePath(artifactPath, baseDir)
+    let perFile
+    try {
+      perFile = await computeFingerprintsPerFile({
+        paths: gateConfig.fingerprint.paths,
+        ...(gateConfig.fingerprint.exclude && { exclude: gateConfig.fingerprint.exclude }),
+        baseDir,
+      })
+    } catch (error) {
+      return fail('malformed', error instanceof Error ? error.message : String(error), {
+        gateId: gate,
+        path: artifactPath,
+      })
+    }
+    const match = perFile.find((f) => f.path === target)
+    if (!match) {
+      return fail('malformed', `Path '${artifactPath}' is not matched by pattern gate '${gate}'`, {
+        gateId: gate,
+        path: artifactPath,
+      })
+    }
+
+    const signed = await createSealWithProvider({
+      gateId: gate,
+      fingerprint: match.fingerprint,
+      sealedBy: params.identity,
+      keyProvider,
+      keyRef,
+    })
+    // artifactPath is a storage/linkage field; the signature already binds the
+    // file's path via its fingerprint, so it is attached after signing.
+    const perFileSeal: Seal = { ...signed, artifactPath: target }
+    const root = resolveSealsRoot(baseDir, loaded.settings.sealsPath)
+    await writeSealFile(root, perFileSeal)
+
+    return {
+      schemaVersion: API_SCHEMA_VERSION,
+      ok: true,
+      gateId: gate,
+      path: artifactPath,
+      fingerprint: perFileSeal.fingerprint,
+      sealedBy: perFileSeal.sealedBy,
+      sealedAt: perFileSeal.timestamp,
+    }
+  }
+
   // Compute the fingerprint to sign.
   const fingerprintResult = await computeFingerprint({
     paths: gateConfig.fingerprint.paths,
@@ -376,13 +598,12 @@ export async function seal(
 
   // Sign the seal via the identity's backend. Delegated signing keeps the raw
   // private key inside the backend; otherwise the key is unlocked to a temp PEM.
-  const keyProvider = keyProviderForIdentity(identity)
   const newSeal = await createSealWithProvider({
     gateId: gate,
     fingerprint: fingerprintResult.fingerprint,
     sealedBy: params.identity,
     keyProvider,
-    keyRef: keyRefForIdentity(identity),
+    keyRef,
   })
 
   let existing: SealsFile
@@ -442,12 +663,12 @@ export async function verifyOne(
     })
   }
 
-  const gate = await resolveSingleGateOrFail(loaded, artifactPath, baseDir)
-  if (typeof gate !== 'string') {
-    return gate
+  const gateId = await resolveSingleGateOrFail(loaded, artifactPath, baseDir)
+  if (typeof gateId !== 'string') {
+    return gateId
   }
 
-  return verifyGate(loaded, gate, baseDir, artifactPath)
+  return verifyPathInGate(loaded, gateId, baseDir, artifactPath)
 }
 
 /**
@@ -528,7 +749,13 @@ export async function verifyAll(
     if (since && !(await gateChangedSince(loaded, gateId, baseDir, since))) {
       continue
     }
-    results.push(await verifyGate(loaded, gateId, baseDir))
+    // eslint-disable-next-line security/detect-object-injection
+    const gate = loaded.gates?.[gateId]
+    if (gate && isPatternGate(gate)) {
+      results.push(...(await verifyPatternGate(loaded, gateId, gate, baseDir)))
+    } else {
+      results.push(await verifyGate(loaded, gateId, baseDir))
+    }
   }
 
   return { schemaVersion: API_SCHEMA_VERSION, ok: true, results }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -113,14 +113,23 @@ export interface GateDescriptor {
   name: string
   /** Description of what the gate protects. */
   description: string
+  /**
+   * How the gate maps matched files to seals: `single` (one combined
+   * fingerprint) or `pattern` (one seal per matched file). Absent when the gate
+   * omits `kind` (defaults to `single`).
+   */
+  kind?: 'single' | 'pattern'
   /** Team member slugs authorized to seal this gate. */
   authorizedSigners: string[]
   /** Glob patterns whose matched files form the gate's fingerprint. */
   paths: string[]
   /** Glob patterns excluded from the fingerprint. */
   exclude: string[]
-  /** Maximum seal age before it is considered expired (duration string). */
-  maxAge: string
+  /**
+   * Maximum seal age before it is considered expired (duration string). Absent
+   * when the gate omits `maxAge`, meaning it never expires (indefinite).
+   */
+  maxAge?: string
 }
 
 /**

--- a/packages/core/src/config/merge.ts
+++ b/packages/core/src/config/merge.ts
@@ -72,13 +72,22 @@ function toGateConfig(gate: NonNullable<PolicyConfig['gates']>[string]): GateCon
     fingerprint.exclude = gate.fingerprint.exclude
   }
 
-  return {
+  const result: GateConfig = {
     name: gate.name,
     description: gate.description,
     authorizedSigners: gate.authorizedSigners,
     fingerprint,
-    maxAge: gate.maxAge,
   }
+  // `kind` and `maxAge` are optional (a pattern gate; an indefinite gate). Only
+  // carry them through when present so exactOptionalPropertyTypes stays happy and
+  // an omitted `maxAge` remains genuinely absent (never expires).
+  if (gate.kind !== undefined) {
+    result.kind = gate.kind
+  }
+  if (gate.maxAge !== undefined) {
+    result.maxAge = gate.maxAge
+  }
+  return result
 }
 
 /**

--- a/packages/core/src/config/migrations/seals-graph.ts
+++ b/packages/core/src/config/migrations/seals-graph.ts
@@ -42,6 +42,10 @@ function versionSchema<V extends number>(version: V) {
  */
 const sealSchemaV1 = z.object({
   gateId: z.string().min(1, 'Gate ID cannot be empty'),
+  // Present only for per-file seals of a pattern gate; identifies which file
+  // within the gate the seal covers (repo-relative, forward-slash). Additive and
+  // optional so existing single-gate seals validate unchanged.
+  artifactPath: z.string().min(1, 'Artifact path cannot be empty').optional(),
   fingerprint: z
     .string()
     .regex(/^sha256:[a-f0-9]+$/i, 'Invalid fingerprint format (expected sha256:<hex>)'),

--- a/packages/core/src/config/shared-schemas.ts
+++ b/packages/core/src/config/shared-schemas.ts
@@ -94,11 +94,17 @@ export const gateSchema = z
   .object({
     name: z.string().min(1, 'Gate name cannot be empty'),
     description: z.string().min(1, 'Gate description cannot be empty'),
+    // How the gate maps matched files to seals. Omitted = `single` (one combined
+    // fingerprint, one seal) for backward compatibility; `pattern` seals each
+    // matched file independently.
+    kind: z.enum(['single', 'pattern']).optional(),
     authorizedSigners: z
       .array(z.string().min(1, 'Authorized signer slug cannot be empty'))
       .min(1, 'At least one authorized signer is required'),
     fingerprint: fingerprintConfigSchema,
-    maxAge: durationSchema,
+    // Optional: when omitted the gate never expires (indefinite is the default —
+    // not a large-number sentinel). See GateConfig.maxAge.
+    maxAge: durationSchema.optional(),
   })
   .strict()
 

--- a/packages/core/src/fingerprint.ts
+++ b/packages/core/src/fingerprint.ts
@@ -333,6 +333,132 @@ export function computeFingerprintSync(options: FingerprintOptions): Fingerprint
 }
 
 /**
+ * A single matched file's independent fingerprint, produced by the per-file
+ * (pattern-gate) fingerprinting mode.
+ *
+ * @remarks
+ * The `fingerprint` binds the file's path: it is computed over
+ * `normalizedPath + ":" + content`, exactly as the file contributes to a
+ * combined fingerprint, then finalized as if it were the gate's only file. Two
+ * files that differ only in path — including symlink aliases of the same bytes —
+ * therefore produce **distinct** fingerprints, so one file's seal can never
+ * authorize another.
+ *
+ * @public
+ */
+export interface PerFileFingerprint {
+  /** Repo-relative, forward-slash path of the matched file. */
+  path: string
+  /** The file's individual fingerprint, in `sha256:...` form. */
+  fingerprint: string
+}
+
+/**
+ * Compute one fingerprint **per matched file** (async) — the pattern-gate mode.
+ *
+ * Unlike {@link computeFingerprint}, which concatenates every matched file into a
+ * single combined digest, this returns an independent {@link PerFileFingerprint}
+ * for each file so each can be sealed and verified on its own. Results are sorted
+ * lexicographically by path (matching {@link computeFingerprint}'s file ordering)
+ * so downstream enumeration (e.g. `status --json`) is deterministic across runs.
+ *
+ * Broken symlinks and non-file matches are skipped. Because each file's hash
+ * embeds its own path, symlink aliases of the same content yield distinct
+ * fingerprints — the per-file independence cannot be gamed by aliasing.
+ *
+ * @param options - Configuration for fingerprint computation
+ * @returns One fingerprint per matched file, sorted by path
+ * @throws Error if paths array is empty or if non-glob paths don't exist
+ * @public
+ */
+export async function computeFingerprintsPerFile(
+  options: FingerprintOptions,
+): Promise<PerFileFingerprint[]> {
+  const baseDir = validateOptions(options)
+  const files = await listPackageFiles(options.paths, options.exclude, baseDir)
+  const sortedFiles = sortFiles(files)
+
+  const results: PerFileFingerprint[] = []
+  for (const file of sortedFiles) {
+    const filePath = path.resolve(baseDir, file)
+
+    let realPath = filePath
+    let stats = await fs.promises.lstat(filePath)
+    if (stats.isSymbolicLink()) {
+      try {
+        realPath = await fs.promises.realpath(filePath)
+      } catch {
+        continue // Skip broken symlinks
+      }
+      try {
+        stats = await fs.promises.stat(realPath)
+      } catch {
+        continue // Skip broken symlinks
+      }
+    }
+
+    if (!stats.isFile()) {
+      continue
+    }
+
+    const normalizedPath = normalizePath(file)
+    // The hash embeds normalizedPath, so distinct paths (incl. symlink aliases)
+    // produce distinct fingerprints — no cross-path hash reuse.
+    const hash = await hashFileAsync(realPath, normalizedPath, stats)
+    const fingerprint = computeFinalFingerprint([{ relativePath: normalizedPath, hash }])
+    results.push({ path: normalizedPath, fingerprint })
+  }
+
+  return results
+}
+
+/**
+ * Compute one fingerprint **per matched file** (sync). See
+ * {@link computeFingerprintsPerFile} for behavior.
+ *
+ * @param options - Configuration for fingerprint computation
+ * @returns One fingerprint per matched file, sorted by path
+ * @throws Error if paths array is empty or if non-glob paths don't exist
+ * @public
+ */
+export function computeFingerprintsPerFileSync(options: FingerprintOptions): PerFileFingerprint[] {
+  const baseDir = validateOptions(options)
+  const files = listPackageFilesSync(options.paths, options.exclude, baseDir)
+  const sortedFiles = sortFiles(files)
+
+  const results: PerFileFingerprint[] = []
+  for (const file of sortedFiles) {
+    const filePath = path.resolve(baseDir, file)
+
+    let realPath = filePath
+    let stats = fs.lstatSync(filePath)
+    if (stats.isSymbolicLink()) {
+      try {
+        realPath = fs.realpathSync(filePath)
+      } catch {
+        continue // Skip broken symlinks
+      }
+      try {
+        stats = fs.statSync(realPath)
+      } catch {
+        continue // Skip broken symlinks
+      }
+    }
+
+    if (!stats.isFile()) {
+      continue
+    }
+
+    const normalizedPath = normalizePath(file)
+    const hash = hashFileSync(realPath, normalizedPath)
+    const fingerprint = computeFinalFingerprint([{ relativePath: normalizedPath, hash }])
+    results.push({ path: normalizedPath, fingerprint })
+  }
+
+  return results
+}
+
+/**
  * Resolve a package path to a glob pattern.
  *
  * - If the path is a glob pattern, return it as-is

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   TeamMember,
   FingerprintConfig,
   GateConfig,
+  GateKind,
   RootGateConfig,
   SuiteConfig,
   AttestItConfig,
@@ -87,8 +88,14 @@ export {
 } from './config/index.js'
 
 // Fingerprinting
-export { computeFingerprint, computeFingerprintSync, listPackageFiles } from './fingerprint.js'
-export type { FingerprintOptions, FingerprintResult } from './fingerprint.js'
+export {
+  computeFingerprint,
+  computeFingerprintSync,
+  computeFingerprintsPerFile,
+  computeFingerprintsPerFileSync,
+  listPackageFiles,
+} from './fingerprint.js'
+export type { FingerprintOptions, FingerprintResult, PerFileFingerprint } from './fingerprint.js'
 
 // Cryptography
 export {
@@ -241,11 +248,14 @@ export {
   writeSealsSync,
   verifyGateSeal,
   verifyAllSeals,
+  verifyPatternArtifactSeal,
   CURRENT_SEALS_VERSION,
   slugifySegment,
   resolveSealsRoot,
   writeSealFileSync,
+  writeSealFile,
   listStoredSealsSync,
+  listStoredSeals,
   type Seal,
   type SealsFile,
   type StoredSeal,

--- a/packages/core/src/seal/index.ts
+++ b/packages/core/src/seal/index.ts
@@ -29,7 +29,9 @@ export {
   slugifySegment,
   resolveSealsRoot,
   writeSealFileSync,
+  writeSealFile,
   listStoredSealsSync,
+  listStoredSeals,
   type StoredSeal,
 } from './storage.js'
 
@@ -37,6 +39,7 @@ export {
 export {
   verifyGateSeal,
   verifyAllSeals,
+  verifyPatternArtifactSeal,
   type VerificationState,
   type SealVerificationResult,
 } from './verification.js'

--- a/packages/core/src/seal/storage.ts
+++ b/packages/core/src/seal/storage.ts
@@ -118,11 +118,30 @@ export function slugifySegment(input: string): string {
 
 /**
  * Compute the repo-relative path (from the seals root) of the file that stores a
- * given gate's seal by a given signer.
+ * seal.
+ *
+ * @remarks
+ * An ordinary single-gate seal is stored at `<gateSlug>/<signerSlug>.seal`. A
+ * per-file **pattern-gate** seal (one whose `artifactPath` is set) inserts an
+ * artifact segment — `<gateSlug>/<artifactSlug>/<signerSlug>.seal` — so every
+ * matched file's seal lives in its own path and none collides. Every segment
+ * reuses the same collision-safe {@link slugifySegment}.
  * @internal
  */
-function sealRelPath(gateId: string, sealedBy: string): string {
-  return path.join(slugifySegment(gateId), slugifySegment(sealedBy) + SEAL_FILE_EXT)
+function sealRelPath(gateId: string, sealedBy: string, artifactPath?: string): string {
+  const signerFile = slugifySegment(sealedBy) + SEAL_FILE_EXT
+  if (artifactPath !== undefined) {
+    return path.join(slugifySegment(gateId), slugifySegment(artifactPath), signerFile)
+  }
+  return path.join(slugifySegment(gateId), signerFile)
+}
+
+/**
+ * Compute the storage path for a seal, honoring its {@link Seal.artifactPath}.
+ * @internal
+ */
+function sealRelPathFor(seal: Seal): string {
+  return sealRelPath(seal.gateId, seal.sealedBy, seal.artifactPath)
 }
 
 /**
@@ -169,6 +188,10 @@ function legacyMonolithCandidates(root: string): string[] {
 function serializeSeal(seal: Seal): string {
   const ordered = {
     gateId: seal.gateId,
+    // Emitted immediately after gateId (and only when set) so per-file pattern
+    // seals round-trip; omitted entirely for single-gate seals so their content
+    // stays byte-identical to the pre-pattern format.
+    ...(seal.artifactPath !== undefined && { artifactPath: seal.artifactPath }),
     fingerprint: seal.fingerprint,
     timestamp: seal.timestamp,
     sealedBy: seal.sealedBy,
@@ -270,15 +293,48 @@ export function listStoredSealsSync(root: string): StoredSeal[] {
 }
 
 /**
- * Write a single seal file (sync) at its deterministic per-(gate, signer) path,
- * coexisting with any other signer's file for the same gate.
+ * Write a single seal file (sync) at its deterministic path, coexisting with any
+ * other seal file (a different signer, or a different pattern-gate artifact) for
+ * the same gate.
+ *
+ * @remarks
+ * This is the low-level primitive that pattern-gate per-file seals **must** use.
+ * The aggregate `writeSealsToDirSync` is inherently one-file-per-gate and prunes
+ * every file outside its desired set, so routing per-file seals through it would
+ * delete siblings. Per-file seals are written here (and read via
+ * {@link listStoredSealsSync}); the aggregate read/write path deliberately
+ * ignores any seal carrying an {@link Seal.artifactPath}.
  * @public
  */
 export function writeSealFileSync(root: string, seal: Seal): string {
-  const target = path.join(root, sealRelPath(seal.gateId, seal.sealedBy))
+  const target = path.join(root, sealRelPathFor(seal))
   fs.mkdirSync(path.dirname(target), { recursive: true })
   fs.writeFileSync(target, serializeSeal(seal), 'utf8')
   return target
+}
+
+/**
+ * Write a single seal file (async) at its deterministic path. See
+ * {@link writeSealFileSync} for the pattern-gate rationale.
+ * @public
+ */
+export async function writeSealFile(root: string, seal: Seal): Promise<string> {
+  const target = path.join(root, sealRelPathFor(seal))
+  await fs.promises.mkdir(path.dirname(target), { recursive: true })
+  await fs.promises.writeFile(target, serializeSeal(seal), 'utf8')
+  return target
+}
+
+/**
+ * Whether a seal participates in the aggregate (one-per-gate) view.
+ *
+ * Per-file pattern-gate seals (those carrying an {@link Seal.artifactPath}) do
+ * not: the aggregate is keyed by gate alone and cannot represent one seal per
+ * matched file, so it must neither surface them on read nor prune them on write.
+ * @internal
+ */
+function isAggregateSeal(seal: Seal): boolean {
+  return seal.artifactPath === undefined
 }
 
 /**
@@ -290,6 +346,8 @@ export function writeSealFileSync(root: string, seal: Seal): string {
 export function readSealsFromDirSync(root: string): SealsFile {
   const seals: Record<string, Seal> = {}
   for (const { seal } of listStoredSealsSync(root)) {
+    // Per-file pattern-gate seals are not part of the one-per-gate aggregate.
+    if (!isAggregateSeal(seal)) continue
     const current = seals[seal.gateId]
     if (!current || isPreferredOver(seal, current)) {
       seals[seal.gateId] = seal
@@ -333,14 +391,32 @@ export function writeSealsToDirSync(root: string, sealsFile: SealsFile): void {
     }
   }
 
-  // Remove files not in the desired set (removed gates / stale signer files).
+  // Remove files not in the desired set (removed gates / stale signer files),
+  // but never touch per-file pattern-gate seals: they live outside the aggregate
+  // and are managed only through the low-level per-file API. Pruning them here is
+  // exactly the silent seal loss the pattern-gate write path must avoid.
   for (const p of existing) {
-    if (!desired.has(p)) {
+    if (!desired.has(p) && isAggregateSealFileSync(p)) {
       fs.rmSync(p, { force: true })
     }
   }
 
   pruneEmptyDirsSync(root)
+}
+
+/**
+ * Whether the seal file at `p` participates in the aggregate view. A file that
+ * cannot be read/parsed is treated as an aggregate seal (fail toward the existing
+ * one-per-gate behavior); a validly-parsed per-file pattern seal is excluded so
+ * an aggregate write never prunes it.
+ * @internal
+ */
+function isAggregateSealFileSync(p: string): boolean {
+  try {
+    return isAggregateSeal(parseSeal(fs.readFileSync(p, 'utf8'), p))
+  } catch {
+    return true
+  }
 }
 
 /**
@@ -475,12 +551,29 @@ export async function readSealsFromDir(root: string): Promise<SealsFile> {
   const seals: Record<string, Seal> = {}
   for (const p of paths) {
     const seal = parseSeal(await fs.promises.readFile(p, 'utf8'), p)
+    // Per-file pattern-gate seals are not part of the one-per-gate aggregate.
+    if (!isAggregateSeal(seal)) continue
     const current = seals[seal.gateId]
     if (!current || isPreferredOver(seal, current)) {
       seals[seal.gateId] = seal
     }
   }
   return { version: CURRENT_SEALS_VERSION, seals }
+}
+
+/**
+ * List every stored seal under `root` (async), one entry per `.seal` file,
+ * including per-file pattern-gate seals. The async counterpart to
+ * {@link listStoredSealsSync}.
+ * @public
+ */
+export async function listStoredSeals(root: string): Promise<StoredSeal[]> {
+  const paths = await listSealFilePaths(root)
+  const out: StoredSeal[] = []
+  for (const p of paths) {
+    out.push({ path: p, seal: parseSeal(await fs.promises.readFile(p, 'utf8'), p) })
+  }
+  return out
 }
 
 /**
@@ -510,12 +603,25 @@ export async function writeSealsToDir(root: string, sealsFile: SealsFile): Promi
   }
 
   for (const p of existing) {
-    if (!desired.has(p)) {
+    // Never prune per-file pattern-gate seals (see writeSealsToDirSync).
+    if (!desired.has(p) && (await isAggregateSealFile(p))) {
       await fs.promises.rm(p, { force: true })
     }
   }
 
   pruneEmptyDirsSync(root)
+}
+
+/**
+ * Async counterpart to {@link isAggregateSealFileSync}.
+ * @internal
+ */
+async function isAggregateSealFile(p: string): Promise<boolean> {
+  try {
+    return isAggregateSeal(parseSeal(await fs.promises.readFile(p, 'utf8'), p))
+  } catch {
+    return true
+  }
 }
 
 /**

--- a/packages/core/src/seal/types.ts
+++ b/packages/core/src/seal/types.ts
@@ -11,6 +11,21 @@
 export interface Seal {
   /** Gate identifier (slug) */
   gateId: string
+  /**
+   * The specific file within a **pattern gate** that this seal covers, as a
+   * forward-slash path relative to the repository root. Present only for
+   * per-file seals produced by a pattern gate; absent (`undefined`) for an
+   * ordinary single-gate seal that covers the gate's one combined fingerprint.
+   *
+   * @remarks
+   * This is a **storage/linkage** identifier, not the cryptographic binding: the
+   * signed `fingerprint` already binds the file's path (it hashes
+   * `normalizedPath + ":" + content`), so two files that differ only in path —
+   * even symlink aliases of the same bytes — produce distinct fingerprints and
+   * cannot borrow one another's seal. `artifactPath` disambiguates which per-file
+   * seal is which on disk and in the aggregate views.
+   */
+  artifactPath?: string | undefined
   /** SHA-256 fingerprint of the gate's content in format "sha256:..." */
   fingerprint: string
   /** ISO 8601 timestamp when the seal was created */

--- a/packages/core/src/seal/verification.ts
+++ b/packages/core/src/seal/verification.ts
@@ -27,6 +27,12 @@ export type VerificationState =
 export interface SealVerificationResult {
   /** Gate identifier */
   gateId: string
+  /**
+   * For a pattern-gate per-file verification, the specific matched file this
+   * result covers (repo-relative, forward-slash). Absent for an ordinary
+   * single-gate result.
+   */
+  artifactPath?: string
   /** Verification state */
   state: VerificationState
   /** The seal, if one exists */
@@ -72,10 +78,69 @@ export function verifyGateSeal(
     }
   }
 
+  return evaluateSeal({ config, gateId, seal, currentFingerprint, maxAge: gate.maxAge })
+}
+
+/**
+ * Verify a single matched file within a **pattern gate**.
+ *
+ * The caller supplies the specific per-file seal (looked up by gate + artifact
+ * path, or `undefined` if none exists) and the file's individual current
+ * fingerprint. This mirrors {@link verifyGateSeal} but is keyed to one file, so a
+ * pattern gate's files verify independently.
+ *
+ * @param config - The attest-it configuration
+ * @param gateId - The pattern gate's identifier
+ * @param artifactPath - The matched file (repo-relative, forward-slash)
+ * @param seal - The per-file seal for this file, or `undefined` if none exists
+ * @param currentFingerprint - The file's current individual fingerprint
+ * @param maxAge - The gate's `maxAge`, or `undefined` for an indefinite gate
+ * @returns Verification result for this file, carrying `artifactPath`
+ * @public
+ */
+export function verifyPatternArtifactSeal(
+  config: AttestItConfig,
+  gateId: string,
+  artifactPath: string,
+  seal: Seal | undefined,
+  currentFingerprint: string,
+  maxAge: string | undefined,
+): SealVerificationResult {
+  if (!seal) {
+    return {
+      gateId,
+      artifactPath,
+      state: 'MISSING',
+      message: `No seal found for '${artifactPath}' in gate '${gateId}'`,
+    }
+  }
+  return evaluateSeal({ config, gateId, seal, currentFingerprint, maxAge, artifactPath })
+}
+
+/**
+ * Shared seal evaluation: fingerprint match, signer authorization, signature
+ * validity, then optional staleness. Used by both the single-gate and
+ * pattern-gate verification entry points so their rules never drift.
+ *
+ * When `maxAge` is `undefined` the gate is **indefinite**: the staleness check is
+ * skipped entirely and no `STALE` state is ever produced, regardless of seal age.
+ * @internal
+ */
+function evaluateSeal(params: {
+  config: AttestItConfig
+  gateId: string
+  seal: Seal
+  currentFingerprint: string
+  maxAge: string | undefined
+  artifactPath?: string
+}): SealVerificationResult {
+  const { config, gateId, seal, currentFingerprint, maxAge, artifactPath } = params
+  const base = artifactPath !== undefined ? { gateId, artifactPath } : { gateId }
+
   // Check if fingerprint matches
   if (seal.fingerprint !== currentFingerprint) {
     return {
-      gateId,
+      ...base,
       state: 'FINGERPRINT_MISMATCH',
       seal,
       message: `Fingerprint changed since seal was created`,
@@ -84,18 +149,13 @@ export function verifyGateSeal(
 
   // Check if signer is in team and authorized
   if (!config.team) {
-    return {
-      gateId,
-      state: 'UNKNOWN_SIGNER',
-      seal,
-      message: `No team configuration found`,
-    }
+    return { ...base, state: 'UNKNOWN_SIGNER', seal, message: `No team configuration found` }
   }
 
   const teamMember = config.team[seal.sealedBy]
   if (!teamMember) {
     return {
-      gateId,
+      ...base,
       state: 'UNKNOWN_SIGNER',
       seal,
       message: `Signer '${seal.sealedBy}' not found in team`,
@@ -106,7 +166,7 @@ export function verifyGateSeal(
   const authorized = isAuthorizedSigner(config, gateId, teamMember.publicKey)
   if (!authorized) {
     return {
-      gateId,
+      ...base,
       state: 'UNKNOWN_SIGNER',
       seal,
       message: `Signer '${seal.sealedBy}' is not authorized for gate '${gateId}'`,
@@ -117,47 +177,45 @@ export function verifyGateSeal(
   const verificationResult = verifySeal(seal, config)
   if (!verificationResult.valid) {
     return {
-      gateId,
+      ...base,
       state: 'INVALID_SIGNATURE',
       seal,
       message: verificationResult.error ?? 'Signature verification failed',
     }
   }
 
-  // Check if seal is stale (exceeds maxAge)
-  try {
-    const maxAgeMs = parseDuration(gate.maxAge)
-    const sealTimestamp = new Date(seal.timestamp).getTime()
-    const now = Date.now()
-    const ageMs = now - sealTimestamp
+  // Staleness — only when the gate declares a maxAge. An indefinite gate (no
+  // maxAge) never expires: skip the check so it can never be reported STALE.
+  if (maxAge !== undefined) {
+    try {
+      const maxAgeMs = parseDuration(maxAge)
+      const sealTimestamp = new Date(seal.timestamp).getTime()
+      const ageMs = Date.now() - sealTimestamp
 
-    if (ageMs > maxAgeMs) {
-      const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24))
-      const maxAgeDays = Math.floor(maxAgeMs / (1000 * 60 * 60 * 24))
+      if (ageMs > maxAgeMs) {
+        const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24))
+        const maxAgeDays = Math.floor(maxAgeMs / (1000 * 60 * 60 * 24))
+        return {
+          ...base,
+          state: 'STALE',
+          seal,
+          message: `Seal is ${ageDays.toString()} days old, exceeds maxAge of ${maxAgeDays.toString()} days`,
+        }
+      }
+    } catch (error) {
+      // If we can't parse maxAge, fail closed - treat as stale to enforce freshness
+      // This prevents bypassing staleness checks with invalid maxAge values
       return {
-        gateId,
+        ...base,
         state: 'STALE',
         seal,
-        message: `Seal is ${ageDays.toString()} days old, exceeds maxAge of ${maxAgeDays.toString()} days`,
+        message: `Cannot verify freshness: invalid maxAge format: ${error instanceof Error ? error.message : String(error)}`,
       }
-    }
-  } catch (error) {
-    // If we can't parse maxAge, fail closed - treat as stale to enforce freshness
-    // This prevents bypassing staleness checks with invalid maxAge values
-    return {
-      gateId,
-      state: 'STALE',
-      seal,
-      message: `Cannot verify freshness: invalid maxAge format: ${error instanceof Error ? error.message : String(error)}`,
     }
   }
 
   // All checks passed
-  return {
-    gateId,
-    state: 'VALID',
-    seal,
-  }
+  return { ...base, state: 'VALID', seal }
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -73,6 +73,20 @@ export interface FingerprintConfig {
 }
 
 /**
+ * Discriminates how a gate maps its matched files to seals.
+ *
+ * - `single` (default): the gate's matched files are combined into **one**
+ *   fingerprint and covered by **one** seal. Changing any matched file
+ *   invalidates the single seal. This is the historical gate behavior.
+ * - `pattern`: each matched file is fingerprinted and sealed **individually**.
+ *   Sealing one file says nothing about its siblings, and a new file matching
+ *   the gate's globs simply appears as unsealed — no config edit required.
+ *
+ * @public
+ */
+export type GateKind = 'single' | 'pattern'
+
+/**
  * Gate definition - defines what needs to be signed and who can sign it.
  * @public
  */
@@ -81,12 +95,23 @@ export interface GateConfig {
   name: string
   /** Description of what this gate protects */
   description: string
+  /**
+   * How this gate maps its matched files to seals. Omitted defaults to
+   * `single` (one combined fingerprint, one seal) for backward compatibility;
+   * `pattern` seals each matched file independently. See {@link GateKind}.
+   */
+  kind?: GateKind | undefined
   /** Team member slugs authorized to sign for this gate */
   authorizedSigners: string[]
   /** Fingerprint configuration */
   fingerprint: FingerprintConfig
-  /** Maximum age before attestation expires (duration string like "30d", "7d", "24h") */
-  maxAge: string
+  /**
+   * Maximum age before an attestation expires (duration string like `"30d"`,
+   * `"7d"`, `"24h"`). When omitted the gate **never expires**: `verify` and
+   * `status` never report an age-based failure for it, regardless of seal age.
+   * Indefinite is the default — there is no large-number sentinel.
+   */
+  maxAge?: string | undefined
 }
 
 /**

--- a/packages/core/test/api/helpers.ts
+++ b/packages/core/test/api/helpers.ts
@@ -43,6 +43,26 @@ export interface TestProject {
 export interface CreateTestProjectOptions {
   /** Signers authorized on the gate. Defaults to `['alice']`. */
   authorizedSigners?: string[]
+  /**
+   * Gate kind. Defaults to `single` (omitted from config). When `pattern`, the
+   * gate seals each matched file independently.
+   */
+  kind?: 'single' | 'pattern'
+  /**
+   * Glob paths the gate fingerprints. Defaults to `['src/**']`. Pattern-gate
+   * tests typically pass something like `['tools/*.sh']`.
+   */
+  gatePaths?: string[]
+  /**
+   * Gate `maxAge`. Defaults to `'30d'`. Pass `null` to omit `maxAge` entirely
+   * (an indefinite gate that never expires).
+   */
+  maxAge?: string | null
+  /**
+   * Extra files to create under `baseDir` before the gate is evaluated, as a map
+   * of repo-relative path → content. Used to populate a pattern gate's matches.
+   */
+  files?: Record<string, string>
 }
 
 /**
@@ -52,6 +72,7 @@ export interface CreateTestProjectOptions {
  */
 export function createTestProject(options: CreateTestProjectOptions = {}): TestProject {
   const authorizedSigners = options.authorizedSigners ?? ['alice']
+  const gatePaths = options.gatePaths ?? ['src/**']
   const baseDir = mkdtempSync(join(tmpdir(), 'attest-it-api-base-'))
   const homeDir = mkdtempSync(join(tmpdir(), 'attest-it-api-home-'))
 
@@ -68,21 +89,30 @@ export function createTestProject(options: CreateTestProjectOptions = {}): TestP
   mkdirSync(join(baseDir, 'src', 'lib'), { recursive: true })
   writeFileSync(join(baseDir, gatedFile), 'export const tool = () => 42\n', 'utf8')
 
+  // Any extra files (e.g. a pattern gate's matched artifacts).
+  for (const [relPath, content] of Object.entries(options.files ?? {})) {
+    const abs = join(baseDir, relPath)
+    mkdirSync(join(abs, '..'), { recursive: true })
+    writeFileSync(abs, content, 'utf8')
+  }
+
   // Split config: policy (trust) + operational (suites).
   const gateId = 'tools'
+  const gateConfig: Record<string, unknown> = {
+    name: 'Tools',
+    description: 'Forged tool scripts',
+    ...(options.kind !== undefined && { kind: options.kind }),
+    authorizedSigners,
+    fingerprint: { paths: gatePaths },
+    ...(options.maxAge !== null && { maxAge: options.maxAge ?? '30d' }),
+  }
   const policy = {
     version: 1,
     team: {
       alice: { name: 'Alice Developer', publicKey: alice.publicKey },
     },
     gates: {
-      [gateId]: {
-        name: 'Tools',
-        description: 'Forged tool scripts',
-        authorizedSigners,
-        fingerprint: { paths: ['src/**'] },
-        maxAge: '30d',
-      },
+      [gateId]: gateConfig,
     },
   }
   const operational = {

--- a/packages/core/test/config/policy-schema.test.ts
+++ b/packages/core/test/config/policy-schema.test.ts
@@ -187,6 +187,63 @@ gates:
         expect(gate?.maxAge).toBe('7d')
       })
 
+      it('should accept a gate with NO maxAge (indefinite gate, #69)', () => {
+        const yaml = `
+version: 1
+gates:
+  forever:
+    name: Forever Gate
+    description: Sealed until content changes
+    authorizedSigners:
+      - alice
+    fingerprint:
+      paths:
+        - src/**
+`
+        const config = parsePolicyContent(yaml, 'yaml')
+        const gate = config.gates?.forever
+        expect(gate).toBeDefined()
+        // maxAge is genuinely absent, not defaulted to a sentinel.
+        expect(gate?.maxAge).toBeUndefined()
+      })
+
+      it('should accept a pattern-kind gate (#69)', () => {
+        const yaml = `
+version: 1
+gates:
+  tools:
+    name: Tools
+    description: Per-file sealed tool scripts
+    kind: pattern
+    authorizedSigners:
+      - alice
+    fingerprint:
+      paths:
+        - tools/*.sh
+    maxAge: 30d
+`
+        const config = parsePolicyContent(yaml, 'yaml')
+        const gate = config.gates?.tools
+        expect(gate?.kind).toBe('pattern')
+      })
+
+      it('should reject an unknown gate kind', () => {
+        const yaml = `
+version: 1
+gates:
+  tools:
+    name: Tools
+    description: Bad kind
+    kind: quorum
+    authorizedSigners:
+      - alice
+    fingerprint:
+      paths:
+        - tools/*.sh
+`
+        expect(() => parsePolicyContent(yaml, 'yaml')).toThrow()
+      })
+
       it('should parse policy with both team and gates', () => {
         const yaml = `
 version: 1
@@ -441,7 +498,9 @@ gates:
         expect(() => parsePolicyContent(yaml, 'yaml')).toThrow('fingerprint')
       })
 
-      it('should reject gate without maxAge', () => {
+      it('should ACCEPT a gate without maxAge (indefinite gate, #69)', () => {
+        // maxAge became optional in #69: a gate with no maxAge never expires.
+        // This previously rejected; the new contract is that it is valid.
         const yaml = `
 version: 1
 gates:
@@ -454,8 +513,8 @@ gates:
       paths:
         - src/**
 `
-        expect(() => parsePolicyContent(yaml, 'yaml')).toThrow(PolicyValidationError)
-        expect(() => parsePolicyContent(yaml, 'yaml')).toThrow('maxAge')
+        const config = parsePolicyContent(yaml, 'yaml')
+        expect(config.gates?.test?.maxAge).toBeUndefined()
       })
 
       it('should reject gate with invalid maxAge duration', () => {

--- a/packages/core/test/fingerprint.test.ts
+++ b/packages/core/test/fingerprint.test.ts
@@ -1,7 +1,13 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { computeFingerprint, computeFingerprintSync, listPackageFiles } from '../src/fingerprint.js'
+import {
+  computeFingerprint,
+  computeFingerprintSync,
+  computeFingerprintsPerFile,
+  computeFingerprintsPerFileSync,
+  listPackageFiles,
+} from '../src/fingerprint.js'
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures')
 const TEST_PROJECT_DIR = path.join(FIXTURES_DIR, 'fingerprint-test-project')
@@ -438,5 +444,85 @@ describe('fingerprint', () => {
         fs.rmSync(tempDir, { recursive: true })
       }
     })
+  })
+})
+
+describe('computeFingerprintsPerFile (pattern-gate mode, #69)', () => {
+  it('returns one independent fingerprint per matched file, sorted by path', async () => {
+    const tempDir = fs.mkdtempSync(path.join(__dirname, 'perfile-'))
+    try {
+      fs.mkdirSync(path.join(tempDir, 'tools'))
+      fs.writeFileSync(path.join(tempDir, 'tools', 'b.sh'), 'echo b\n')
+      fs.writeFileSync(path.join(tempDir, 'tools', 'a.sh'), 'echo a\n')
+
+      const results = await computeFingerprintsPerFile({ paths: ['tools/*.sh'], baseDir: tempDir })
+
+      // One result per file, lexicographically ordered (matches sortFiles).
+      expect(results.map((r) => r.path)).toEqual(['tools/a.sh', 'tools/b.sh'])
+      for (const r of results) {
+        expect(r.fingerprint).toMatch(/^sha256:[0-9a-f]{64}$/)
+      }
+      // Distinct files → distinct fingerprints.
+      expect(results[0]?.fingerprint).not.toBe(results[1]?.fingerprint)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
+  it('sync and async modes agree', () => {
+    const tempDir = fs.mkdtempSync(path.join(__dirname, 'perfile-sync-'))
+    try {
+      fs.mkdirSync(path.join(tempDir, 'tools'))
+      fs.writeFileSync(path.join(tempDir, 'tools', 'a.sh'), 'echo a\n')
+      fs.writeFileSync(path.join(tempDir, 'tools', 'b.sh'), 'echo b\n')
+
+      const sync = computeFingerprintsPerFileSync({ paths: ['tools/*.sh'], baseDir: tempDir })
+      expect(sync.map((r) => r.path)).toEqual(['tools/a.sh', 'tools/b.sh'])
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
+  it('a per-file fingerprint equals the combined fingerprint of that file alone', async () => {
+    // The per-file mode must bind exactly what a single-file gate would seal, so
+    // a file that migrates between gate shapes keeps a stable fingerprint.
+    const tempDir = fs.mkdtempSync(path.join(__dirname, 'perfile-eq-'))
+    try {
+      fs.mkdirSync(path.join(tempDir, 'tools'))
+      fs.writeFileSync(path.join(tempDir, 'tools', 'a.sh'), 'echo a\n')
+      fs.writeFileSync(path.join(tempDir, 'tools', 'b.sh'), 'echo b\n')
+
+      const perFile = await computeFingerprintsPerFile({ paths: ['tools/*.sh'], baseDir: tempDir })
+      const combinedA = await computeFingerprint({ paths: ['tools/a.sh'], baseDir: tempDir })
+      const a = perFile.find((r) => r.path === 'tools/a.sh')
+      expect(a?.fingerprint).toBe(combinedA.fingerprint)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
+  })
+
+  it('ADVERSARIAL: symlink aliases of the same content do NOT share a fingerprint', async () => {
+    // Per-file independence must not be gameable by aliasing two logical paths to
+    // the same bytes: the fingerprint binds the path (SHA256(path + ":" + bytes)),
+    // so a seal for one path can never authorize the other.
+    const tempDir = fs.mkdtempSync(path.join(__dirname, 'perfile-symlink-'))
+    try {
+      fs.mkdirSync(path.join(tempDir, 'tools'))
+      fs.writeFileSync(path.join(tempDir, 'tools', 'real.sh'), 'echo shared\n')
+      // alias.sh is a symlink to real.sh — identical bytes, different path.
+      fs.symlinkSync(
+        path.join(tempDir, 'tools', 'real.sh'),
+        path.join(tempDir, 'tools', 'alias.sh'),
+      )
+
+      const results = await computeFingerprintsPerFile({ paths: ['tools/*.sh'], baseDir: tempDir })
+      const real = results.find((r) => r.path === 'tools/real.sh')
+      const alias = results.find((r) => r.path === 'tools/alias.sh')
+      expect(real).toBeDefined()
+      expect(alias).toBeDefined()
+      expect(real?.fingerprint).not.toBe(alias?.fingerprint)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true })
+    }
   })
 })

--- a/packages/core/test/seal/pattern-gate.test.ts
+++ b/packages/core/test/seal/pattern-gate.test.ts
@@ -1,0 +1,192 @@
+/**
+ * End-to-end tests for pattern gates (#69): one gate definition under which each
+ * matching file is fingerprinted and sealed INDEPENDENTLY.
+ *
+ * These drive the genuine embeddable-API path — `seal` → `status` → `verifyOne`
+ * against a real on-disk split config and a filesystem-backed identity — rather
+ * than mocks, so they exercise the same load/fingerprint/seal/verify contract a
+ * consumer (e.g. Toolsmith) uses. Each test maps to a PRD R2 acceptance
+ * criterion; assertions are written by hand from those criteria, not snapshotted.
+ *
+ * @see Issue #69 acceptance criteria (PRD R2)
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { seal, status, verifyOne, fingerprint } from '../../src/api/index.js'
+import { listStoredSealsSync, resolveSealsRoot } from '../../src/seal/storage.js'
+import { createTestProject, type TestProject } from '../api/helpers.js'
+
+let project: TestProject
+
+afterEach(() => {
+  project.cleanup()
+})
+
+/**
+ * Scaffold a pattern gate `tools` over `tools/*.sh` with the given files.
+ */
+function patternProject(files: Record<string, string>): TestProject {
+  return createTestProject({ kind: 'pattern', gatePaths: ['tools/*.sh'], files })
+}
+
+/** Find the status/verify result for a specific artifact path. */
+function resultFor(results: { path?: string }[], p: string): { path?: string } | undefined {
+  return results.find((r) => r.path === p)
+}
+
+describe('pattern gate: independent per-file seals (PRD R2)', () => {
+  it('sealing one file leaves its sibling unsealed (seal → status → verify)', async () => {
+    project = patternProject({
+      'tools/a.sh': '#!/bin/sh\necho a\n',
+      'tools/b.sh': '#!/bin/sh\necho b\n',
+    })
+
+    // Seal ONLY tools/a.sh.
+    const sealed = await seal('tools/a.sh', { identity: 'alice' }, { baseDir: project.baseDir })
+    expect(sealed.ok).toBe(true)
+
+    // The seal is a per-file seal: it carries artifactPath and lives under an
+    // artifact segment, coexisting rather than collapsing to one-per-gate.
+    const stored = listStoredSealsSync(resolveSealsRoot(project.baseDir))
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.seal.artifactPath).toBe('tools/a.sh')
+
+    // status reports a.sh VALID and b.sh unsealed — independence proven.
+    const st = await status(undefined, { baseDir: project.baseDir })
+    expect(st.ok).toBe(true)
+    if (!st.ok) return
+    const a = resultFor(st.results, 'tools/a.sh')
+    const b = resultFor(st.results, 'tools/b.sh')
+    expect(a?.ok).toBe(true)
+    expect(b?.ok).toBe(false)
+    if (b && !b.ok) expect(b.failureClass).toBe('unsealed')
+
+    // verifyOne agrees for each file individually.
+    const va = await verifyOne('tools/a.sh', { baseDir: project.baseDir })
+    const vb = await verifyOne('tools/b.sh', { baseDir: project.baseDir })
+    expect(va.ok).toBe(true)
+    expect(vb.ok).toBe(false)
+    if (!vb.ok) expect(vb.failureClass).toBe('unsealed')
+  })
+
+  it('changing one byte of a sealed file flips ONLY that file to invalid', async () => {
+    project = patternProject({
+      'tools/a.sh': '#!/bin/sh\necho a\n',
+      'tools/b.sh': '#!/bin/sh\necho b\n',
+    })
+
+    await seal('tools/a.sh', { identity: 'alice' }, { baseDir: project.baseDir })
+    await seal('tools/b.sh', { identity: 'alice' }, { baseDir: project.baseDir })
+
+    // Both valid before the edit.
+    expect((await verifyOne('tools/a.sh', { baseDir: project.baseDir })).ok).toBe(true)
+    expect((await verifyOne('tools/b.sh', { baseDir: project.baseDir })).ok).toBe(true)
+
+    // Flip one byte of a.sh only.
+    const aPath = join(project.baseDir, 'tools/a.sh')
+    writeFileSync(aPath, readFileSync(aPath, 'utf8').replace('echo a', 'echo A'), 'utf8')
+
+    const va = await verifyOne('tools/a.sh', { baseDir: project.baseDir })
+    const vb = await verifyOne('tools/b.sh', { baseDir: project.baseDir })
+    expect(va.ok).toBe(false)
+    if (!va.ok) expect(va.failureClass).toBe('fingerprint-mismatch')
+    // The sibling is entirely unaffected.
+    expect(vb.ok).toBe(true)
+  })
+
+  it('a new file matching the pattern shows as unsealed with ZERO config change', async () => {
+    project = patternProject({
+      'tools/a.sh': '#!/bin/sh\necho a\n',
+      'tools/b.sh': '#!/bin/sh\necho b\n',
+    })
+
+    await seal('tools/a.sh', { identity: 'alice' }, { baseDir: project.baseDir })
+    await seal('tools/b.sh', { identity: 'alice' }, { baseDir: project.baseDir })
+
+    // Add a third matching file — no policy.yaml / config.yaml edit.
+    writeFileSync(join(project.baseDir, 'tools/c.sh'), '#!/bin/sh\necho c\n', 'utf8')
+
+    const st = await status(undefined, { baseDir: project.baseDir })
+    expect(st.ok).toBe(true)
+    if (!st.ok) return
+    expect(st.results.map((r) => r.path)).toEqual(['tools/a.sh', 'tools/b.sh', 'tools/c.sh'])
+    const c = resultFor(st.results, 'tools/c.sh')
+    expect(c?.ok).toBe(false)
+    if (c && !c.ok) expect(c.failureClass).toBe('unsealed')
+    // Existing seals stay valid.
+    expect(resultFor(st.results, 'tools/a.sh')?.ok).toBe(true)
+    expect(resultFor(st.results, 'tools/b.sh')?.ok).toBe(true)
+  })
+
+  it('status --json ordering is deterministic across repeated runs (PRD Q5)', async () => {
+    project = patternProject({
+      'tools/zebra.sh': '#!/bin/sh\n',
+      'tools/alpha.sh': '#!/bin/sh\n',
+      'tools/mike.sh': '#!/bin/sh\n',
+    })
+
+    const first = await status(undefined, { baseDir: project.baseDir })
+    const second = await status(undefined, { baseDir: project.baseDir })
+    expect(first.ok && second.ok).toBe(true)
+    if (!first.ok || !second.ok) return
+
+    const order1 = first.results.map((r) => r.path)
+    const order2 = second.results.map((r) => r.path)
+    // Stable lexicographic-by-path ordering, identical across runs.
+    expect(order1).toEqual(['tools/alpha.sh', 'tools/mike.sh', 'tools/zebra.sh'])
+    expect(order2).toEqual(order1)
+  })
+
+  it('per-file fingerprint API returns each file’s own fingerprint', async () => {
+    project = patternProject({
+      'tools/a.sh': '#!/bin/sh\necho a\n',
+      'tools/b.sh': '#!/bin/sh\necho b\n',
+    })
+    const fa = await fingerprint('tools/a.sh', { baseDir: project.baseDir })
+    const fb = await fingerprint('tools/b.sh', { baseDir: project.baseDir })
+    expect(fa.ok && fb.ok).toBe(true)
+    if (!fa.ok || !fb.ok) return
+    expect(fa.fileCount).toBe(1)
+    expect(fb.fileCount).toBe(1)
+    // Distinct files → distinct fingerprints.
+    expect(fa.fingerprint).not.toBe(fb.fingerprint)
+  })
+})
+
+describe('REGRESSION: single (non-pattern) gates behave exactly as before (#69)', () => {
+  it('a single gate produces one combined seal with NO artifact segment', async () => {
+    // Default kind (omitted) is `single`: multiple matched files roll into one
+    // combined fingerprint covered by one seal — the historical behavior.
+    project = createTestProject({
+      gatePaths: ['tools/*.sh'],
+      files: {
+        'tools/a.sh': '#!/bin/sh\necho a\n',
+        'tools/b.sh': '#!/bin/sh\necho b\n',
+      },
+    })
+
+    const sealed = await seal('tools/a.sh', { identity: 'alice' }, { baseDir: project.baseDir })
+    expect(sealed.ok).toBe(true)
+
+    // Exactly one seal file, carrying NO artifactPath (aggregate one-per-gate).
+    const stored = listStoredSealsSync(resolveSealsRoot(project.baseDir))
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.seal.artifactPath).toBeUndefined()
+    expect(stored[0]?.seal.gateId).toBe('tools')
+
+    // status reports ONE result for the whole gate (gate-keyed, not per-file).
+    const st = await status(undefined, { baseDir: project.baseDir })
+    expect(st.ok).toBe(true)
+    if (!st.ok) return
+    expect(st.results).toHaveLength(1)
+    expect(st.results[0]?.ok).toBe(true)
+    expect(st.results[0]?.gateId).toBe('tools')
+
+    // Verifying the gate's sibling reports VALID too — the single seal covers the
+    // whole gate, unlike a pattern gate.
+    const vb = await verifyOne('tools/b.sh', { baseDir: project.baseDir })
+    expect(vb.ok).toBe(true)
+  })
+})

--- a/packages/core/test/seal/storage.test.ts
+++ b/packages/core/test/seal/storage.test.ts
@@ -17,6 +17,8 @@ import {
   resolveSealsRoot,
   writeSealFileSync,
   listStoredSealsSync,
+  readSealsFromDirSync,
+  writeSealsToDirSync,
 } from '../../src/seal/storage.js'
 import { createSeal } from '../../src/seal/operations.js'
 import { generateKeyPair } from '../../src/crypto/ed25519.js'
@@ -25,6 +27,11 @@ import type { Seal } from '../../src/seal/types.js'
 function seal(gateId: string, sealedBy: string): Seal {
   const { privateKey } = generateKeyPair()
   return createSeal({ gateId, fingerprint: 'sha256:abc123', sealedBy, privateKey })
+}
+
+/** A per-file pattern-gate seal carrying an artifactPath. */
+function patternSeal(gateId: string, artifactPath: string, sealedBy: string): Seal {
+  return { ...seal(gateId, sealedBy), artifactPath }
 }
 
 describe('slugifySegment collision-safety', () => {
@@ -136,5 +143,77 @@ describe('m-of-n coexistence (PRD R12 not precluded)', () => {
     writeSealFileSync(root, seal('tools', 'bob'))
 
     expect(fs.readFileSync(aPath, 'utf8')).toBe(before)
+  })
+})
+
+describe('pattern-gate per-file seals (#69)', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'attest-pattern-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('stores two artifacts of the SAME gate as two coexisting files (artifact segment)', () => {
+    const aPath = writeSealFileSync(root, patternSeal('tools', 'tools/a.sh', 'alice'))
+    const bPath = writeSealFileSync(root, patternSeal('tools', 'tools/b.sh', 'alice'))
+
+    expect(aPath).not.toBe(bPath)
+    expect(fs.existsSync(aPath)).toBe(true)
+    expect(fs.existsSync(bPath)).toBe(true)
+
+    const stored = listStoredSealsSync(root)
+    expect(stored).toHaveLength(2)
+    const artifacts = stored.map((s) => s.seal.artifactPath).sort()
+    expect(artifacts).toEqual(['tools/a.sh', 'tools/b.sh'])
+    // artifactPath round-trips through serialize/parse.
+    expect(stored.every((s) => s.seal.gateId === 'tools')).toBe(true)
+  })
+
+  it('CASE-INSENSITIVE FS: artifact paths differing ONLY in case get DISTINCT files', () => {
+    // On a case-insensitive filesystem (e.g. macOS default), a naive slug would
+    // collapse Foo.sh and foo.sh onto the same on-disk path and silently overwrite
+    // one seal with the other. The collision-safe artifact segment must keep them
+    // apart.
+    const upperPath = writeSealFileSync(root, patternSeal('tools', 'tools/Foo.sh', 'alice'))
+    const lowerPath = writeSealFileSync(root, patternSeal('tools', 'tools/foo.sh', 'alice'))
+
+    expect(upperPath).not.toBe(lowerPath)
+    // Both files must survive independently — writing the second did not clobber
+    // the first even on a case-insensitive FS.
+    const stored = listStoredSealsSync(root)
+    expect(stored).toHaveLength(2)
+    expect(stored.map((s) => s.seal.artifactPath).sort()).toEqual(['tools/Foo.sh', 'tools/foo.sh'])
+  })
+
+  it('aggregate read EXCLUDES per-file pattern seals (they are not one-per-gate)', () => {
+    writeSealFileSync(root, patternSeal('tools', 'tools/a.sh', 'alice'))
+    writeSealFileSync(root, patternSeal('tools', 'tools/b.sh', 'alice'))
+    // A plain single-gate seal for a different gate DOES belong to the aggregate.
+    writeSealFileSync(root, seal('single-gate', 'alice'))
+
+    const aggregate = readSealsFromDirSync(root)
+    expect(Object.keys(aggregate.seals)).toEqual(['single-gate'])
+  })
+
+  it('aggregate write does NOT prune per-file pattern seals (constraint: no silent loss)', () => {
+    // Pattern seals exist for gate `tools`.
+    const aPath = writeSealFileSync(root, patternSeal('tools', 'tools/a.sh', 'alice'))
+    const bPath = writeSealFileSync(root, patternSeal('tools', 'tools/b.sh', 'alice'))
+
+    // An aggregate write for an UNRELATED single gate must not delete them, even
+    // though they are outside its desired one-per-gate set.
+    writeSealsToDirSync(root, {
+      version: 2,
+      seals: { 'single-gate': seal('single-gate', 'alice') },
+    })
+
+    expect(fs.existsSync(aPath)).toBe(true)
+    expect(fs.existsSync(bPath)).toBe(true)
+    const stored = listStoredSealsSync(root)
+    expect(stored.filter((s) => s.seal.artifactPath !== undefined)).toHaveLength(2)
   })
 })

--- a/packages/core/test/seal/verification.test.ts
+++ b/packages/core/test/seal/verification.test.ts
@@ -774,3 +774,67 @@ describe('verification edge cases', () => {
     expect(result.state).toBe('VALID')
   })
 })
+
+describe('verifyGateSeal - optional maxAge (indefinite gate, #69)', () => {
+  it('never reports STALE for a gate with NO maxAge, regardless of seal age', () => {
+    const { publicKey, privateKey } = generateKeyPair()
+    const config = createTestConfig()
+    config.team ??= {}
+    config.team.alice = { name: 'Alice Developer', publicKey }
+    config.gates ??= {}
+    // A gate with maxAge omitted entirely (indefinite — never expires).
+    config.gates.indefinite = {
+      name: 'Indefinite',
+      description: 'Sealed forever until content changes',
+      authorizedSigners: ['alice'],
+      fingerprint: { paths: ['**/*'] },
+      // no maxAge
+    }
+
+    const fingerprint = 'sha256:abc123'
+    // A seal from 1000 days ago — ancient by any duration standard.
+    const ancient = new Date(Date.now() - 1000 * 24 * 60 * 60 * 1000).toISOString()
+    const canonicalString = `indefinite:${fingerprint}:${ancient}`
+    const seal: Seal = {
+      gateId: 'indefinite',
+      fingerprint,
+      timestamp: ancient,
+      sealedBy: 'alice',
+      signature: sign(canonicalString, privateKey),
+    }
+    const seals: SealsFile = { version: 1, seals: { indefinite: seal } }
+
+    const result = verifyGateSeal(config, 'indefinite', seals, fingerprint)
+    expect(result.state).toBe('VALID')
+    expect(result.state).not.toBe('STALE')
+  })
+
+  it('CONTRAST: the same ancient seal IS stale once the gate declares a maxAge', () => {
+    const { publicKey, privateKey } = generateKeyPair()
+    const config = createTestConfig()
+    config.team ??= {}
+    config.team.alice = { name: 'Alice Developer', publicKey }
+    config.gates ??= {}
+    config.gates.bounded = {
+      name: 'Bounded',
+      description: 'Expires after 30 days',
+      authorizedSigners: ['alice'],
+      fingerprint: { paths: ['**/*'] },
+      maxAge: '30d',
+    }
+
+    const fingerprint = 'sha256:abc123'
+    const ancient = new Date(Date.now() - 1000 * 24 * 60 * 60 * 1000).toISOString()
+    const seal: Seal = {
+      gateId: 'bounded',
+      fingerprint,
+      timestamp: ancient,
+      sealedBy: 'alice',
+      signature: sign(`bounded:${fingerprint}:${ancient}`, privateKey),
+    }
+    const seals: SealsFile = { version: 1, seals: { bounded: seal } }
+
+    const result = verifyGateSeal(config, 'bounded', seals, fingerprint)
+    expect(result.state).toBe('STALE')
+  })
+})

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -1021,14 +1021,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`;
-        let path3 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path4 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin.endsWith("/")) {
           origin = origin.substring(0, origin.length - 1);
         }
-        if (path3 && !path3.startsWith("/")) {
-          path3 = `/${path3}`;
+        if (path4 && !path4.startsWith("/")) {
+          path4 = `/${path4}`;
         }
-        url = new URL(origin + path3);
+        url = new URL(origin + path4);
       }
       return url;
     }
@@ -2651,20 +2651,20 @@ var require_basename = __commonJS({
   "../../node_modules/.pnpm/@fastify+busboy@2.1.1/node_modules/@fastify/busboy/lib/utils/basename.js"(exports2, module2) {
     "use strict";
     init_cjs_shims();
-    module2.exports = function basename2(path3) {
-      if (typeof path3 !== "string") {
+    module2.exports = function basename2(path4) {
+      if (typeof path4 !== "string") {
         return "";
       }
-      for (var i = path3.length - 1; i >= 0; --i) {
-        switch (path3.charCodeAt(i)) {
+      for (var i = path4.length - 1; i >= 0; --i) {
+        switch (path4.charCodeAt(i)) {
           case 47:
           // '/'
           case 92:
-            path3 = path3.slice(i + 1);
-            return path3 === ".." || path3 === "." ? "" : path3;
+            path4 = path4.slice(i + 1);
+            return path4 === ".." || path4 === "." ? "" : path4;
         }
       }
-      return path3 === ".." || path3 === "." ? "" : path3;
+      return path4 === ".." || path4 === "." ? "" : path4;
     };
   }
 });
@@ -5709,7 +5709,7 @@ var require_request = __commonJS({
     }
     var Request2 = class _Request {
       constructor(origin, {
-        path: path3,
+        path: path4,
         method,
         body,
         headers,
@@ -5723,11 +5723,11 @@ var require_request = __commonJS({
         throwOnError,
         expectContinue
       }, handler2) {
-        if (typeof path3 !== "string") {
+        if (typeof path4 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path3[0] !== "/" && !(path3.startsWith("http://") || path3.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path4[0] !== "/" && !(path4.startsWith("http://") || path4.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.exec(path3) !== null) {
+        } else if (invalidPathRegex.exec(path4) !== null) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -5790,7 +5790,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? util2.buildURL(path3, query) : path3;
+        this.path = query ? util2.buildURL(path4, query) : path4;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6804,9 +6804,9 @@ var require_RedirectHandler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util2.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path3 = search ? `${pathname}${search}` : pathname;
+        const path4 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path3;
+        this.opts.path = path4;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8052,7 +8052,7 @@ var require_client = __commonJS({
         writeH2(client, client[kHTTP2Session], request2);
         return;
       }
-      const { body, method, path: path3, host, upgrade, headers, blocking, reset } = request2;
+      const { body, method, path: path4, host, upgrade, headers, blocking, reset } = request2;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
         body.read(0);
@@ -8102,7 +8102,7 @@ var require_client = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path3} HTTP/1.1\r
+      let header = `${method} ${path4} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -8165,7 +8165,7 @@ upgrade: ${upgrade}\r
       return true;
     }
     function writeH2(client, session, request2) {
-      const { body, method, path: path3, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
+      const { body, method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
       let headers;
       if (typeof reqHeaders === "string") headers = Request2[kHTTP2CopyHeaders](reqHeaders.trim());
       else headers = reqHeaders;
@@ -8208,7 +8208,7 @@ upgrade: ${upgrade}\r
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path3;
+      headers[HTTP2_HEADER_PATH] = path4;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -10470,20 +10470,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path3) {
-      if (typeof path3 !== "string") {
-        return path3;
+    function safeUrl(path4) {
+      if (typeof path4 !== "string") {
+        return path4;
       }
-      const pathSegments = path3.split("?");
+      const pathSegments = path4.split("?");
       if (pathSegments.length !== 2) {
-        return path3;
+        return path4;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path3, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path3);
+    function matchKey(mockDispatch2, { path: path4, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path4);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10501,7 +10501,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path3 }) => matchValue(safeUrl(path3), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path4 }) => matchValue(safeUrl(path4), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10538,9 +10538,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path3, method, body, headers, query } = opts;
+      const { path: path4, method, body, headers, query } = opts;
       return {
-        path: path3,
+        path: path4,
         method,
         body,
         headers,
@@ -10994,10 +10994,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path3, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path4, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path3,
+            Path: path4,
             "Status code": statusCode,
             Persistent: persist ? "\u2705" : "\u274C",
             Invocations: timesInvoked,
@@ -15638,8 +15638,8 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path3) {
-      for (const char of path3) {
+    function validateCookiePath(path4) {
+      for (const char of path4) {
         const code = char.charCodeAt(0);
         if (code < 33 || char === ";") {
           throw new Error("Invalid cookie path");
@@ -17330,11 +17330,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path3 = opts.path;
+          let path4 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path3 = `/${path3}`;
+            path4 = `/${path4}`;
           }
-          url = new URL(util2.parseOrigin(url).origin + path3);
+          url = new URL(util2.parseOrigin(url).origin + path4);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -18562,7 +18562,7 @@ var require_path_utils = __commonJS({
     };
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.toPlatformPath = exports2.toWin32Path = exports2.toPosixPath = void 0;
-    var path3 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -18572,7 +18572,7 @@ var require_path_utils = __commonJS({
     }
     exports2.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path3.sep);
+      return pth.replace(/[/\\]/g, path4.sep);
     }
     exports2.toPlatformPath = toPlatformPath;
   }
@@ -18637,7 +18637,7 @@ var require_io_util = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getCmdPath = exports2.tryGetExecutablePath = exports2.isRooted = exports2.isDirectory = exports2.exists = exports2.READONLY = exports2.UV_FS_O_EXLOCK = exports2.IS_WINDOWS = exports2.unlink = exports2.symlink = exports2.stat = exports2.rmdir = exports2.rm = exports2.rename = exports2.readlink = exports2.readdir = exports2.open = exports2.mkdir = exports2.lstat = exports2.copyFile = exports2.chmod = void 0;
     var fs = __importStar(require("fs"));
-    var path3 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     _a = fs.promises, exports2.chmod = _a.chmod, exports2.copyFile = _a.copyFile, exports2.lstat = _a.lstat, exports2.mkdir = _a.mkdir, exports2.open = _a.open, exports2.readdir = _a.readdir, exports2.readlink = _a.readlink, exports2.rename = _a.rename, exports2.rm = _a.rm, exports2.rmdir = _a.rmdir, exports2.stat = _a.stat, exports2.symlink = _a.symlink, exports2.unlink = _a.unlink;
     exports2.IS_WINDOWS = process.platform === "win32";
     exports2.UV_FS_O_EXLOCK = 268435456;
@@ -18686,7 +18686,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports2.IS_WINDOWS) {
-            const upperExt = path3.extname(filePath).toUpperCase();
+            const upperExt = path4.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -18710,11 +18710,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports2.IS_WINDOWS) {
               try {
-                const directory = path3.dirname(filePath);
-                const upperName = path3.basename(filePath).toUpperCase();
+                const directory = path4.dirname(filePath);
+                const upperName = path4.basename(filePath).toUpperCase();
                 for (const actualName of yield exports2.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path3.join(directory, actualName);
+                    filePath = path4.join(directory, actualName);
                     break;
                   }
                 }
@@ -18810,7 +18810,7 @@ var require_io = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.findInPath = exports2.which = exports2.mkdirP = exports2.rmRF = exports2.mv = exports2.cp = void 0;
     var assert_1 = require("assert");
-    var path3 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     var ioUtil = __importStar(require_io_util());
     function cp(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
@@ -18819,7 +18819,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path3.join(dest, path3.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path4.join(dest, path4.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -18831,7 +18831,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path3.relative(source, newDest) === "") {
+          if (path4.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile(source, newDest, force);
@@ -18844,7 +18844,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path3.join(dest, path3.basename(source));
+            dest = path4.join(dest, path4.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -18855,7 +18855,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path3.dirname(dest));
+        yield mkdirP(path4.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -18918,7 +18918,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path3.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path4.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -18931,12 +18931,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path3.sep)) {
+        if (tool.includes(path4.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path3.delimiter)) {
+          for (const p of process.env.PATH.split(path4.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -18944,7 +18944,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path3.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path4.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -19061,7 +19061,7 @@ var require_toolrunner = __commonJS({
     var os3 = __importStar(require("os"));
     var events = __importStar(require("events"));
     var child = __importStar(require("child_process"));
-    var path3 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     var io = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = require("timers");
@@ -19276,7 +19276,7 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path4.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io.which(this.toolPath, true);
           return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
@@ -19779,7 +19779,7 @@ var require_core = __commonJS({
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os3 = __importStar(require("os"));
-    var path3 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -19807,7 +19807,7 @@ var require_core = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path3.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path4.delimiter}${process.env["PATH"]}`;
     }
     exports2.addPath = addPath;
     function getInput2(name, options) {
@@ -21998,17 +21998,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path3) {
-      const ctrl = callVisitor(key, node, visitor, path3);
+    function visit_(key, node, visitor, path4) {
+      const ctrl = callVisitor(key, node, visitor, path4);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path3, ctrl);
-        return visit_(key, ctrl, visitor, path3);
+        replaceNode(key, path4, ctrl);
+        return visit_(key, ctrl, visitor, path4);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path3 = Object.freeze(path3.concat(node));
+          path4 = Object.freeze(path4.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path3);
+            const ci = visit_(i, node.items[i], visitor, path4);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22019,13 +22019,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path3 = Object.freeze(path3.concat(node));
-          const ck = visit_("key", node.key, visitor, path3);
+          path4 = Object.freeze(path4.concat(node));
+          const ck = visit_("key", node.key, visitor, path4);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path3);
+          const cv = visit_("value", node.value, visitor, path4);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22046,17 +22046,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path3) {
-      const ctrl = await callVisitor(key, node, visitor, path3);
+    async function visitAsync_(key, node, visitor, path4) {
+      const ctrl = await callVisitor(key, node, visitor, path4);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path3, ctrl);
-        return visitAsync_(key, ctrl, visitor, path3);
+        replaceNode(key, path4, ctrl);
+        return visitAsync_(key, ctrl, visitor, path4);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path3 = Object.freeze(path3.concat(node));
+          path4 = Object.freeze(path4.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path3);
+            const ci = await visitAsync_(i, node.items[i], visitor, path4);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22067,13 +22067,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path3 = Object.freeze(path3.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path3);
+          path4 = Object.freeze(path4.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path4);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path3);
+          const cv = await visitAsync_("value", node.value, visitor, path4);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22100,23 +22100,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path3) {
+    function callVisitor(key, node, visitor, path4) {
       if (typeof visitor === "function")
-        return visitor(key, node, path3);
+        return visitor(key, node, path4);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path3);
+        return visitor.Map?.(key, node, path4);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path3);
+        return visitor.Seq?.(key, node, path4);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path3);
+        return visitor.Pair?.(key, node, path4);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path3);
+        return visitor.Scalar?.(key, node, path4);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path3);
+        return visitor.Alias?.(key, node, path4);
       return void 0;
     }
-    function replaceNode(key, path3, node) {
-      const parent = path3[path3.length - 1];
+    function replaceNode(key, path4, node) {
+      const parent = path4[path4.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -22733,10 +22733,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path3, value) {
+    function collectionFromPath(schema, path4, value) {
       let v = value;
-      for (let i = path3.length - 1; i >= 0; --i) {
-        const k = path3[i];
+      for (let i = path4.length - 1; i >= 0; --i) {
+        const k = path4[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -22755,7 +22755,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path3) => path3 == null || typeof path3 === "object" && !!path3[Symbol.iterator]().next().done;
+    var isEmptyPath = (path4) => path4 == null || typeof path4 === "object" && !!path4[Symbol.iterator]().next().done;
     var Collection2 = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -22785,11 +22785,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path3, value) {
-        if (isEmptyPath(path3))
+      addIn(path4, value) {
+        if (isEmptyPath(path4))
           this.add(value);
         else {
-          const [key, ...rest] = path3;
+          const [key, ...rest] = path4;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -22803,8 +22803,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path3) {
-        const [key, ...rest] = path3;
+      deleteIn(path4) {
+        const [key, ...rest] = path4;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -22818,8 +22818,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path3, keepScalar) {
-        const [key, ...rest] = path3;
+      getIn(path4, keepScalar) {
+        const [key, ...rest] = path4;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -22837,8 +22837,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path3) {
-        const [key, ...rest] = path3;
+      hasIn(path4) {
+        const [key, ...rest] = path4;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -22848,8 +22848,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path3, value) {
-        const [key, ...rest] = path3;
+      setIn(path4, value) {
+        const [key, ...rest] = path4;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -25388,9 +25388,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path3, value) {
+      addIn(path4, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path3, value);
+          this.contents.addIn(path4, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -25465,14 +25465,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path3) {
-        if (Collection2.isEmptyPath(path3)) {
+      deleteIn(path4) {
+        if (Collection2.isEmptyPath(path4)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path3) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path4) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -25487,10 +25487,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path3, keepScalar) {
-        if (Collection2.isEmptyPath(path3))
+      getIn(path4, keepScalar) {
+        if (Collection2.isEmptyPath(path4))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path3, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path4, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -25501,10 +25501,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path3) {
-        if (Collection2.isEmptyPath(path3))
+      hasIn(path4) {
+        if (Collection2.isEmptyPath(path4))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path3) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path4) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -25521,13 +25521,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path3, value) {
-        if (Collection2.isEmptyPath(path3)) {
+      setIn(path4, value) {
+        if (Collection2.isEmptyPath(path4)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path3), value);
+          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path4), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path3, value);
+          this.contents.setIn(path4, value);
         }
       }
       /**
@@ -27499,9 +27499,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path3) => {
+    visit.itemAtPath = (cst, path4) => {
       let item = cst;
-      for (const [field, index] of path3) {
+      for (const [field, index] of path4) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -27510,23 +27510,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path3) => {
-      const parent = visit.itemAtPath(cst, path3.slice(0, -1));
-      const field = path3[path3.length - 1][0];
+    visit.parentCollection = (cst, path4) => {
+      const parent = visit.itemAtPath(cst, path4.slice(0, -1));
+      const field = path4[path4.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path3, item, visitor) {
-      let ctrl = visitor(item, path3);
+    function _visit(path4, item, visitor) {
+      let ctrl = visitor(item, path4);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path3.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path4.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -27537,10 +27537,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path3);
+            ctrl = ctrl(item, path4);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path3) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path4) : ctrl;
     }
     exports2.visit = visit;
   }
@@ -29688,8 +29688,8 @@ var require_utils3 = __commonJS({
       }
       return output;
     };
-    exports2.basename = (path3, { windows } = {}) => {
-      const segs = path3.split(windows ? /[\\/]/ : "/");
+    exports2.basename = (path4, { windows } = {}) => {
+      const segs = path4.split(windows ? /[\\/]/ : "/");
       const last = segs[segs.length - 1];
       if (last === "") {
         return segs[segs.length - 2];
@@ -31626,8 +31626,8 @@ ${val.stack}`;
     module2.exports.__wbindgen_throw = function(arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     };
-    var path3 = require("path").join(__dirname, "core_bg.wasm");
-    var bytes = require("fs").readFileSync(path3);
+    var path4 = require("path").join(__dirname, "core_bg.wasm");
+    var bytes = require("fs").readFileSync(path4);
     var wasmModule = new WebAssembly.Module(bytes);
     var wasmInstance = new WebAssembly.Instance(wasmModule, imports);
     wasm = wasmInstance.exports;
@@ -33071,17 +33071,17 @@ var require_shared_lib_core = __commonJS({
     exports2.SharedLibCore = void 0;
     var fs = __importStar(require("fs"));
     var os3 = __importStar(require("os"));
-    var path3 = __importStar(require("path"));
+    var path4 = __importStar(require("path"));
     var errors_1 = require_errors3();
     var find1PasswordLibPath = () => {
       const platform = os3.platform();
-      const appRoot = path3.dirname(process.execPath);
+      const appRoot = path4.dirname(process.execPath);
       let searchPaths = [];
       switch (platform) {
         case "darwin":
           searchPaths = [
             "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib",
-            path3.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
+            path4.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
           ];
           break;
         case "linux":
@@ -33093,10 +33093,10 @@ var require_shared_lib_core = __commonJS({
           break;
         case "win32":
           searchPaths = [
-            path3.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
+            path4.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
             "C:/Program Files/1Password/app/8/op_sdk_ipc_client.dll",
             "C:/Program Files (x86)/1Password/app/8/op_sdk_ipc_client.dll",
-            path3.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
+            path4.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
           ];
           break;
         default:
@@ -33329,8 +33329,8 @@ var require_context = __commonJS({
           if ((0, fs_1.existsSync)(process.env.GITHUB_EVENT_PATH)) {
             this.payload = JSON.parse((0, fs_1.readFileSync)(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
           } else {
-            const path3 = process.env.GITHUB_EVENT_PATH;
-            process.stdout.write(`GITHUB_EVENT_PATH ${path3} does not exist${os_1.EOL}`);
+            const path4 = process.env.GITHUB_EVENT_PATH;
+            process.stdout.write(`GITHUB_EVENT_PATH ${path4} does not exist${os_1.EOL}`);
           }
         }
         this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -38281,7 +38281,7 @@ var import_node_path = require("path");
 init_cjs_shims();
 var fs2 = __toESM(require("fs"), 1);
 var import_fs3 = require("fs");
-var path4 = __toESM(require("path"), 1);
+var path3 = __toESM(require("path"), 1);
 var import_path4 = require("path");
 var import_semver = __toESM(require_semver2(), 1);
 var import_yaml = __toESM(require_dist(), 1);
@@ -38779,8 +38779,8 @@ function getErrorMap() {
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js
 init_cjs_shims();
 var makeIssue = (params) => {
-  const { data, path: path3, errorMaps, issueData } = params;
-  const fullPath = [...path3, ...issueData.path || []];
+  const { data, path: path4, errorMaps, issueData } = params;
+  const fullPath = [...path4, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -38900,11 +38900,11 @@ var errorUtil;
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path3, key) {
+  constructor(parent, value, path4, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path3;
+    this._path = path4;
     this._key = key;
   }
   get path() {
@@ -42845,7 +42845,7 @@ var MigrationGraphImpl = class {
         hasIrreversibleStep: false
       };
     }
-    const path3 = findPath(
+    const path4 = findPath(
       normalizedFrom,
       normalizedTo,
       this.adjacencyList,
@@ -42853,10 +42853,10 @@ var MigrationGraphImpl = class {
       this.versionStrategy,
       (from, to) => this.getMigrationKey(from, to)
     );
-    if (!path3) {
+    if (!path4) {
       throw new NoPathError(fromVersion, toVersion);
     }
-    return path3;
+    return path4;
   }
   migrate(data, fromVersion, toVersion, options = {}) {
     const startTime = performance.now();
@@ -42885,12 +42885,12 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path3;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path3 = this.getPath(normalizedFrom, normalizedTo);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path3, pathDuration);
+      this.telemetry?.onPathComputed?.(path4, pathDuration);
     } catch (err) {
       return {
         success: false,
@@ -42900,27 +42900,27 @@ var MigrationGraphImpl = class {
         error: err
       };
     }
-    if (path3.steps.length === 0) {
+    if (path4.steps.length === 0) {
       return {
         success: true,
         data,
-        path: path3,
+        path: path4,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
     }
-    const context = createMigrationContext(path3.steps.length, options.initialStash);
+    const context = createMigrationContext(path4.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path3.steps.length; i++) {
-      const step = path3.steps[i];
+    for (let i = 0; i < path4.steps.length; i++) {
+      const step = path4.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path3.steps.length
+        totalSteps: path4.steps.length
       });
-      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
       const stepStartTime = performance.now();
       try {
         if (step.direction === "up") {
@@ -42945,20 +42945,20 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, step, context);
         return {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: error2
         };
       }
-      if (options.validateIntermediate && i < path3.steps.length - 1) {
+      if (options.validateIntermediate && i < path4.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             return {
               success: false,
-              path: path3,
+              path: path4,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -42982,7 +42982,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, null, context);
         const result2 = {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43002,7 +43002,7 @@ var MigrationGraphImpl = class {
           this.telemetry?.onError?.(error2, null, context);
           const result2 = {
             success: false,
-            path: path3,
+            path: path4,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43018,7 +43018,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path3,
+      path: path4,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43050,11 +43050,11 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path3;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path3 = this.getPath(normalizedFrom, normalizedTo);
-      this.telemetry?.onPathComputed?.(path3, performance.now() - pathStartTime);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
+      this.telemetry?.onPathComputed?.(path4, performance.now() - pathStartTime);
     } catch (err) {
       const result2 = {
         success: false,
@@ -43066,30 +43066,30 @@ var MigrationGraphImpl = class {
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    if (path3.steps.length === 0) {
+    if (path4.steps.length === 0) {
       const result2 = {
         success: true,
         data,
-        path: path3,
+        path: path4,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    const context = createMigrationContext(path3.steps.length, options.initialStash);
+    const context = createMigrationContext(path4.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path3.steps.length; i++) {
-      const step = path3.steps[i];
+    for (let i = 0; i < path4.steps.length; i++) {
+      const step = path4.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path3.steps.length
+        totalSteps: path4.steps.length
       });
       const stepStartTime = performance.now();
-      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
       try {
         if (step.direction === "up") {
           const result2 = step.migration.up(currentData, context);
@@ -43104,7 +43104,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(err, step, context);
         const result2 = {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: new MigrationError(
@@ -43120,14 +43120,14 @@ var MigrationGraphImpl = class {
         this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
         return result2;
       }
-      if (options.validateIntermediate && i < path3.steps.length - 1) {
+      if (options.validateIntermediate && i < path4.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             const result2 = {
               success: false,
-              path: path3,
+              path: path4,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -43148,7 +43148,7 @@ var MigrationGraphImpl = class {
       if (!validation.success) {
         const result2 = {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43165,7 +43165,7 @@ var MigrationGraphImpl = class {
         if (!validation.success) {
           const result2 = {
             success: false,
-            path: path3,
+            path: path4,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43183,7 +43183,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path3,
+      path: path4,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43195,12 +43195,12 @@ var MigrationGraphImpl = class {
   migrateMany(data, fromVersion, toVersion, options = {}) {
     const normalizedFrom = this.normalizeVersion(fromVersion);
     const normalizedTo = this.normalizeVersion(toVersion);
-    let path3;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path3 = this.getPath(normalizedFrom, normalizedTo);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path3, pathDuration);
+      this.telemetry?.onPathComputed?.(path4, pathDuration);
     } catch {
       return {
         total: 0,
@@ -43226,7 +43226,7 @@ var MigrationGraphImpl = class {
           for (let j = i + 1; j < items.length; j++) {
             results.push({
               success: false,
-              path: path3,
+              path: path4,
               stash: { consumed: [], unconsumed: [], lossless: true },
               preservedFields: [],
               error: new MigrationError(
@@ -43247,7 +43247,7 @@ var MigrationGraphImpl = class {
       succeeded,
       failed,
       results,
-      path: path3
+      path: path4
     };
   }
   getVersions() {
@@ -43327,8 +43327,8 @@ function createMigrationGraph(options) {
 
 // ../../node_modules/.pnpm/@migrex+zod@1.0.0-alpha.1_@migrex+core@0.2.0-alpha.1_zod@3.25.76/node_modules/@migrex/zod/dist/index.js
 init_cjs_shims();
-function pathToStringArray(path3) {
-  return path3.map((p) => String(p));
+function pathToStringArray(path4) {
+  return path4.map((p) => String(p));
 }
 function zodErrorToValidationErrors(error2) {
   return error2.issues.map((issue) => ({
@@ -43377,27 +43377,27 @@ var import_module = require("module");
 var import_path = require("path");
 var nativeFs = __toESM(require("fs"), 1);
 var __require = /* @__PURE__ */ (0, import_module.createRequire)(importMetaUrl);
-function cleanPath(path3) {
-  let normalized = (0, import_path.normalize)(path3);
+function cleanPath(path4) {
+  let normalized = (0, import_path.normalize)(path4);
   if (normalized.length > 1 && normalized[normalized.length - 1] === import_path.sep) normalized = normalized.substring(0, normalized.length - 1);
   return normalized;
 }
 var SLASHES_REGEX = /[\\/]/g;
-function convertSlashes(path3, separator) {
-  return path3.replace(SLASHES_REGEX, separator);
+function convertSlashes(path4, separator) {
+  return path4.replace(SLASHES_REGEX, separator);
 }
 var WINDOWS_ROOT_DIR_REGEX = /^[a-z]:[\\/]$/i;
-function isRootDirectory(path3) {
-  return path3 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path3);
+function isRootDirectory(path4) {
+  return path4 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path4);
 }
-function normalizePath(path3, options) {
+function normalizePath(path4, options) {
   const { resolvePaths, normalizePath: normalizePath$1, pathSeparator } = options;
-  const pathNeedsCleaning = process.platform === "win32" && path3.includes("/") || path3.startsWith(".");
-  if (resolvePaths) path3 = (0, import_path.resolve)(path3);
-  if (normalizePath$1 || pathNeedsCleaning) path3 = cleanPath(path3);
-  if (path3 === ".") return "";
-  const needsSeperator = path3[path3.length - 1] !== pathSeparator;
-  return convertSlashes(needsSeperator ? path3 + pathSeparator : path3, pathSeparator);
+  const pathNeedsCleaning = process.platform === "win32" && path4.includes("/") || path4.startsWith(".");
+  if (resolvePaths) path4 = (0, import_path.resolve)(path4);
+  if (normalizePath$1 || pathNeedsCleaning) path4 = cleanPath(path4);
+  if (path4 === ".") return "";
+  const needsSeperator = path4[path4.length - 1] !== pathSeparator;
+  return convertSlashes(needsSeperator ? path4 + pathSeparator : path4, pathSeparator);
 }
 function joinPathWithBasePath(filename, directoryPath) {
   return directoryPath + filename;
@@ -43434,8 +43434,8 @@ var pushDirectory = (directoryPath, paths) => {
   paths.push(directoryPath || ".");
 };
 var pushDirectoryFilter = (directoryPath, paths, filters) => {
-  const path3 = directoryPath || ".";
-  if (filters.every((filter) => filter(path3, true))) paths.push(path3);
+  const path4 = directoryPath || ".";
+  if (filters.every((filter) => filter(path4, true))) paths.push(path4);
 };
 var empty$2 = () => {
 };
@@ -43487,26 +43487,26 @@ var empty = () => {
 function build$3(options) {
   return options.group ? groupFiles : empty;
 }
-var resolveSymlinksAsync = function(path3, state, callback$1) {
+var resolveSymlinksAsync = function(path4, state, callback$1) {
   const { queue, fs, options: { suppressErrors } } = state;
   queue.enqueue();
-  fs.realpath(path3, (error2, resolvedPath) => {
+  fs.realpath(path4, (error2, resolvedPath) => {
     if (error2) return queue.dequeue(suppressErrors ? null : error2, state);
     fs.stat(resolvedPath, (error$1, stat3) => {
       if (error$1) return queue.dequeue(suppressErrors ? null : error$1, state);
-      if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return queue.dequeue(null, state);
+      if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return queue.dequeue(null, state);
       callback$1(stat3, resolvedPath);
       queue.dequeue(null, state);
     });
   });
 };
-var resolveSymlinks = function(path3, state, callback$1) {
+var resolveSymlinks = function(path4, state, callback$1) {
   const { queue, fs, options: { suppressErrors } } = state;
   queue.enqueue();
   try {
-    const resolvedPath = fs.realpathSync(path3);
+    const resolvedPath = fs.realpathSync(path4);
     const stat3 = fs.statSync(resolvedPath);
-    if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return;
+    if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return;
     callback$1(stat3, resolvedPath);
   } catch (e) {
     if (!suppressErrors) throw e;
@@ -43516,9 +43516,9 @@ function build$2(options, isSynchronous) {
   if (!options.resolveSymlinks || options.excludeSymlinks) return null;
   return isSynchronous ? resolveSymlinks : resolveSymlinksAsync;
 }
-function isRecursive(path3, resolved, state) {
+function isRecursive(path4, resolved, state) {
   if (state.options.useRealPaths) return isRecursiveUsingRealPaths(resolved, state);
-  let parent = (0, import_path.dirname)(path3);
+  let parent = (0, import_path.dirname)(path4);
   let depth = 1;
   while (parent !== state.root && depth < 2) {
     const resolvedPath = state.symlinks.get(parent);
@@ -43526,7 +43526,7 @@ function isRecursive(path3, resolved, state) {
     if (isSameRoot) depth++;
     else parent = (0, import_path.dirname)(parent);
   }
-  state.symlinks.set(path3, resolved);
+  state.symlinks.set(path4, resolved);
   return depth > 1;
 }
 function isRecursiveUsingRealPaths(resolved, state) {
@@ -43698,19 +43698,19 @@ var Walker = class {
         const filename = this.joinPath(entry.name, directoryPath);
         this.pushFile(filename, files, this.state.counts, filters);
       } else if (entry.isDirectory()) {
-        let path3 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
-        if (exclude && exclude(entry.name, path3)) continue;
-        this.pushDirectory(path3, paths, filters);
-        this.walkDirectory(this.state, path3, path3, depth - 1, this.walk);
+        let path4 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
+        if (exclude && exclude(entry.name, path4)) continue;
+        this.pushDirectory(path4, paths, filters);
+        this.walkDirectory(this.state, path4, path4, depth - 1, this.walk);
       } else if (this.resolveSymlink && entry.isSymbolicLink()) {
-        let path3 = joinPathWithBasePath(entry.name, directoryPath);
-        this.resolveSymlink(path3, this.state, (stat3, resolvedPath) => {
+        let path4 = joinPathWithBasePath(entry.name, directoryPath);
+        this.resolveSymlink(path4, this.state, (stat3, resolvedPath) => {
           if (stat3.isDirectory()) {
             resolvedPath = normalizePath(resolvedPath, this.state.options);
-            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path3 + pathSeparator)) return;
-            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path3 + pathSeparator, depth - 1, this.walk);
+            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path4 + pathSeparator)) return;
+            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path4 + pathSeparator, depth - 1, this.walk);
           } else {
-            resolvedPath = useRealPaths ? resolvedPath : path3;
+            resolvedPath = useRealPaths ? resolvedPath : path4;
             const filename = (0, import_path.basename)(resolvedPath);
             const directoryPath$1 = normalizePath((0, import_path.dirname)(resolvedPath), this.state.options);
             resolvedPath = this.joinPath(filename, directoryPath$1);
@@ -43876,7 +43876,7 @@ var Builder = class {
       isMatch = globFn(patterns, ...options);
       this.globCache[patterns.join("\0")] = isMatch;
     }
-    this.options.filters.push((path3) => isMatch(path3));
+    this.options.filters.push((path4) => isMatch(path4));
     return this;
   }
 };
@@ -46197,9 +46197,15 @@ var durationSchema = external_exports.string().refine(
 var gateSchema = external_exports.object({
   name: external_exports.string().min(1, "Gate name cannot be empty"),
   description: external_exports.string().min(1, "Gate description cannot be empty"),
+  // How the gate maps matched files to seals. Omitted = `single` (one combined
+  // fingerprint, one seal) for backward compatibility; `pattern` seals each
+  // matched file independently.
+  kind: external_exports.enum(["single", "pattern"]).optional(),
   authorizedSigners: external_exports.array(external_exports.string().min(1, "Authorized signer slug cannot be empty")).min(1, "At least one authorized signer is required"),
   fingerprint: fingerprintConfigSchema,
-  maxAge: durationSchema
+  // Optional: when omitted the gate never expires (indefinite is the default —
+  // not a large-number sentinel). See GateConfig.maxAge.
+  maxAge: durationSchema.optional()
 }).strict();
 var keyProviderOptionsSchema = external_exports.object({
   privateKeyPath: external_exports.string().optional(),
@@ -46341,6 +46347,10 @@ function versionSchema(version2) {
 }
 var sealSchemaV1 = external_exports.object({
   gateId: external_exports.string().min(1, "Gate ID cannot be empty"),
+  // Present only for per-file seals of a pattern gate; identifies which file
+  // within the gate the seal covers (repo-relative, forward-slash). Additive and
+  // optional so existing single-gate seals validate unchanged.
+  artifactPath: external_exports.string().min(1, "Artifact path cannot be empty").optional(),
   fingerprint: external_exports.string().regex(/^sha256:[a-f0-9]+$/i, "Invalid fingerprint format (expected sha256:<hex>)"),
   timestamp: external_exports.string().datetime({ message: "Invalid ISO 8601 timestamp" }),
   sealedBy: external_exports.string().min(1, "Signer slug cannot be empty"),
@@ -46586,13 +46596,19 @@ function toGateConfig(gate) {
   if (gate.fingerprint.exclude !== void 0) {
     fingerprint2.exclude = gate.fingerprint.exclude;
   }
-  return {
+  const result = {
     name: gate.name,
     description: gate.description,
     authorizedSigners: gate.authorizedSigners,
-    fingerprint: fingerprint2,
-    maxAge: gate.maxAge
+    fingerprint: fingerprint2
   };
+  if (gate.kind !== void 0) {
+    result.kind = gate.kind;
+  }
+  if (gate.maxAge !== void 0) {
+    result.maxAge = gate.maxAge;
+  }
+  return result;
 }
 function toKeyProvider(provider) {
   const result = {
@@ -46876,7 +46892,7 @@ function sortFiles(files) {
   });
 }
 function normalizePath2(filePath) {
-  return filePath.split(path4.sep).join("/");
+  return filePath.split(path3.sep).join("/");
 }
 function computeFinalFingerprint(fileHashes) {
   const sorted = [...fileHashes].sort((a, b) => {
@@ -46922,7 +46938,7 @@ function validateOptions(options) {
   const baseDir = options.baseDir ?? process.cwd();
   for (const p of options.paths) {
     if (!isGlobPattern(p)) {
-      const resolvedPath = path4.resolve(baseDir, p);
+      const resolvedPath = path3.resolve(baseDir, p);
       if (!fs2.existsSync(resolvedPath)) {
         throw new Error(`Path does not exist: ${resolvedPath}`);
       }
@@ -46937,7 +46953,7 @@ async function computeFingerprint(options) {
   const fileHashCache = /* @__PURE__ */ new Map();
   const fileHashInputs = [];
   for (const file of sortedFiles) {
-    const filePath = path4.resolve(baseDir, file);
+    const filePath = path3.resolve(baseDir, file);
     let realPath = filePath;
     let stats = await fs2.promises.lstat(filePath);
     if (stats.isSymbolicLink()) {
@@ -46977,7 +46993,7 @@ function resolvePackagePattern(pkg, baseDir) {
   if (isGlobPattern(pkg)) {
     return pkg;
   }
-  const fullPath = path4.resolve(baseDir, pkg);
+  const fullPath = path3.resolve(baseDir, pkg);
   try {
     const stats = fs2.statSync(fullPath);
     return stats.isFile() ? pkg : `${pkg}/**/*`;
@@ -47113,14 +47129,18 @@ function slugifySegment(input) {
   const prefix = readable.length > 0 ? readable : "seg";
   return `${prefix}-${hash}`;
 }
-function sealRelPath(gateId, sealedBy) {
-  return path4.join(slugifySegment(gateId), slugifySegment(sealedBy) + SEAL_FILE_EXT);
+function sealRelPath(gateId, sealedBy, artifactPath) {
+  const signerFile = slugifySegment(sealedBy) + SEAL_FILE_EXT;
+  if (artifactPath !== void 0) {
+    return path3.join(slugifySegment(gateId), slugifySegment(artifactPath), signerFile);
+  }
+  return path3.join(slugifySegment(gateId), signerFile);
 }
 function resolveSealsRoot(dir, sealsPathOverride) {
   if (sealsPathOverride === void 0) {
-    return path4.join(dir, ".attest-it", "seals");
+    return path3.join(dir, ".attest-it", "seals");
   }
-  const resolved = path4.resolve(dir, sealsPathOverride);
+  const resolved = path3.resolve(dir, sealsPathOverride);
   return resolved.replace(/\.(json|ya?ml)$/i, "");
 }
 function legacyMonolithCandidates(root) {
@@ -47129,6 +47149,10 @@ function legacyMonolithCandidates(root) {
 function serializeSeal(seal2) {
   const ordered = {
     gateId: seal2.gateId,
+    // Emitted immediately after gateId (and only when set) so per-file pattern
+    // seals round-trip; omitted entirely for single-gate seals so their content
+    // stays byte-identical to the pre-pattern format.
+    ...seal2.artifactPath !== void 0 && { artifactPath: seal2.artifactPath },
     fingerprint: seal2.fingerprint,
     timestamp: seal2.timestamp,
     sealedBy: seal2.sealedBy,
@@ -47158,6 +47182,9 @@ function isPreferredOver(candidate, current) {
   }
   return candidate.sealedBy > current.sealedBy;
 }
+function isAggregateSeal(seal2) {
+  return seal2.artifactPath === void 0;
+}
 function pruneEmptyDirsSync(root) {
   let entries;
   try {
@@ -47167,7 +47194,7 @@ function pruneEmptyDirsSync(root) {
   }
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      const child = path4.join(root, entry.name);
+      const child = path3.join(root, entry.name);
       pruneEmptyDirsSync(child);
       try {
         if (fs2.readdirSync(child).length === 0) {
@@ -47208,7 +47235,7 @@ async function listSealFilePaths(root) {
       throw error2;
     }
     for (const entry of entries) {
-      const full = path4.join(dir, entry.name);
+      const full = path3.join(dir, entry.name);
       if (entry.isDirectory()) {
         await walk(full);
       } else if (entry.isFile() && entry.name.endsWith(SEAL_FILE_EXT)) {
@@ -47224,6 +47251,7 @@ async function readSealsFromDir(root) {
   const seals = {};
   for (const p of paths) {
     const seal2 = parseSeal(await fs2.promises.readFile(p, "utf8"), p);
+    if (!isAggregateSeal(seal2)) continue;
     const current = seals[seal2.gateId];
     if (!current || isPreferredOver(seal2, current)) {
       seals[seal2.gateId] = seal2;
@@ -47234,7 +47262,7 @@ async function readSealsFromDir(root) {
 async function writeSealsToDir(root, sealsFile) {
   const desired = /* @__PURE__ */ new Map();
   for (const seal2 of Object.values(sealsFile.seals)) {
-    desired.set(path4.join(root, sealRelPath(seal2.gateId, seal2.sealedBy)), seal2);
+    desired.set(path3.join(root, sealRelPath(seal2.gateId, seal2.sealedBy)), seal2);
   }
   const existing = await listSealFilePaths(root);
   for (const [target, seal2] of desired) {
@@ -47246,16 +47274,23 @@ async function writeSealsToDir(root, sealsFile) {
       prior = void 0;
     }
     if (prior !== content) {
-      await fs2.promises.mkdir(path4.dirname(target), { recursive: true });
+      await fs2.promises.mkdir(path3.dirname(target), { recursive: true });
       await fs2.promises.writeFile(target, content, "utf8");
     }
   }
   for (const p of existing) {
-    if (!desired.has(p)) {
+    if (!desired.has(p) && await isAggregateSealFile(p)) {
       await fs2.promises.rm(p, { force: true });
     }
   }
   pruneEmptyDirsSync(root);
+}
+async function isAggregateSealFile(p) {
+  try {
+    return isAggregateSeal(parseSeal(await fs2.promises.readFile(p, "utf8"), p));
+  } catch {
+    return true;
+  }
 }
 async function migrateMonoliths(dir, root) {
   const candidates = legacyMonolithCandidates(root);
@@ -47389,26 +47424,26 @@ function verifyGateSeal(config, gateId, seals, currentFingerprint) {
       message: `No seal found for gate '${gateId}'`
     };
   }
+  return evaluateSeal({ config, gateId, seal: seal2, currentFingerprint, maxAge: gate.maxAge });
+}
+function evaluateSeal(params) {
+  const { config, gateId, seal: seal2, currentFingerprint, maxAge, artifactPath } = params;
+  const base = artifactPath !== void 0 ? { gateId, artifactPath } : { gateId };
   if (seal2.fingerprint !== currentFingerprint) {
     return {
-      gateId,
+      ...base,
       state: "FINGERPRINT_MISMATCH",
       seal: seal2,
       message: `Fingerprint changed since seal was created`
     };
   }
   if (!config.team) {
-    return {
-      gateId,
-      state: "UNKNOWN_SIGNER",
-      seal: seal2,
-      message: `No team configuration found`
-    };
+    return { ...base, state: "UNKNOWN_SIGNER", seal: seal2, message: `No team configuration found` };
   }
   const teamMember = config.team[seal2.sealedBy];
   if (!teamMember) {
     return {
-      gateId,
+      ...base,
       state: "UNKNOWN_SIGNER",
       seal: seal2,
       message: `Signer '${seal2.sealedBy}' not found in team`
@@ -47417,7 +47452,7 @@ function verifyGateSeal(config, gateId, seals, currentFingerprint) {
   const authorized = isAuthorizedSigner(config, gateId, teamMember.publicKey);
   if (!authorized) {
     return {
-      gateId,
+      ...base,
       state: "UNKNOWN_SIGNER",
       seal: seal2,
       message: `Signer '${seal2.sealedBy}' is not authorized for gate '${gateId}'`
@@ -47426,40 +47461,37 @@ function verifyGateSeal(config, gateId, seals, currentFingerprint) {
   const verificationResult = verifySeal(seal2, config);
   if (!verificationResult.valid) {
     return {
-      gateId,
+      ...base,
       state: "INVALID_SIGNATURE",
       seal: seal2,
       message: verificationResult.error ?? "Signature verification failed"
     };
   }
-  try {
-    const maxAgeMs = parseDuration(gate.maxAge);
-    const sealTimestamp = new Date(seal2.timestamp).getTime();
-    const now = Date.now();
-    const ageMs = now - sealTimestamp;
-    if (ageMs > maxAgeMs) {
-      const ageDays = Math.floor(ageMs / (1e3 * 60 * 60 * 24));
-      const maxAgeDays = Math.floor(maxAgeMs / (1e3 * 60 * 60 * 24));
+  if (maxAge !== void 0) {
+    try {
+      const maxAgeMs = parseDuration(maxAge);
+      const sealTimestamp = new Date(seal2.timestamp).getTime();
+      const ageMs = Date.now() - sealTimestamp;
+      if (ageMs > maxAgeMs) {
+        const ageDays = Math.floor(ageMs / (1e3 * 60 * 60 * 24));
+        const maxAgeDays = Math.floor(maxAgeMs / (1e3 * 60 * 60 * 24));
+        return {
+          ...base,
+          state: "STALE",
+          seal: seal2,
+          message: `Seal is ${ageDays.toString()} days old, exceeds maxAge of ${maxAgeDays.toString()} days`
+        };
+      }
+    } catch (error2) {
       return {
-        gateId,
+        ...base,
         state: "STALE",
         seal: seal2,
-        message: `Seal is ${ageDays.toString()} days old, exceeds maxAge of ${maxAgeDays.toString()} days`
+        message: `Cannot verify freshness: invalid maxAge format: ${error2 instanceof Error ? error2.message : String(error2)}`
       };
     }
-  } catch (error2) {
-    return {
-      gateId,
-      state: "STALE",
-      seal: seal2,
-      message: `Cannot verify freshness: invalid maxAge format: ${error2 instanceof Error ? error2.message : String(error2)}`
-    };
   }
-  return {
-    gateId,
-    state: "VALID",
-    seal: seal2
-  };
+  return { ...base, state: "VALID", seal: seal2 };
 }
 function verifyAllSeals(config, seals, fingerprints) {
   if (!config.gates) {
@@ -47682,8 +47714,8 @@ var VaultKeyProvider = class {
    */
   async getPrivateKey(keyRef) {
     const pemContent = await this.backend.retrieve(keyRef);
-    const tempDir = await fs32.mkdtemp(path4.join(os2.tmpdir(), "attest-it-vk-"));
-    const tempKeyPath = path4.join(tempDir, "private.pem");
+    const tempDir = await fs32.mkdtemp(path3.join(os2.tmpdir(), "attest-it-vk-"));
+    const tempKeyPath = path3.join(tempDir, "private.pem");
     try {
       await fs32.writeFile(tempKeyPath, pemContent, "utf-8");
       await setKeyPermissions(tempKeyPath);
@@ -47738,7 +47770,7 @@ var VaultKeyProvider = class {
       }
     }
     const secretId = `attest-it-${crypto22.randomUUID()}`;
-    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
+    await fs32.mkdir(path3.dirname(publicKeyPath), { recursive: true });
     if (isSigningBackend(this.backend)) {
       await this.backend.generateSigningKey(secretId, DELEGATED_SIGNING_ALGORITHM);
       const { publicKeyPem } = await this.backend.getPublicKey(secretId);
@@ -47770,7 +47802,7 @@ var VaultKeyProvider = class {
 };
 function resolveLegacyPath(p) {
   if (p === "~" || p.startsWith("~/")) {
-    return path4.join((0, import_os.homedir)(), p.slice(1));
+    return path3.join((0, import_os.homedir)(), p.slice(1));
   }
   return p;
 }

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -1029,14 +1029,14 @@ var require_util = __commonJS({
         }
         const port = url.port != null ? url.port : url.protocol === "https:" ? 443 : 80;
         let origin = url.origin != null ? url.origin : `${url.protocol}//${url.hostname}:${port}`;
-        let path3 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
+        let path4 = url.path != null ? url.path : `${url.pathname || ""}${url.search || ""}`;
         if (origin.endsWith("/")) {
           origin = origin.substring(0, origin.length - 1);
         }
-        if (path3 && !path3.startsWith("/")) {
-          path3 = `/${path3}`;
+        if (path4 && !path4.startsWith("/")) {
+          path4 = `/${path4}`;
         }
-        url = new URL(origin + path3);
+        url = new URL(origin + path4);
       }
       return url;
     }
@@ -2659,20 +2659,20 @@ var require_basename = __commonJS({
   "../../node_modules/.pnpm/@fastify+busboy@2.1.1/node_modules/@fastify/busboy/lib/utils/basename.js"(exports, module) {
     "use strict";
     init_esm_shims();
-    module.exports = function basename2(path3) {
-      if (typeof path3 !== "string") {
+    module.exports = function basename2(path4) {
+      if (typeof path4 !== "string") {
         return "";
       }
-      for (var i = path3.length - 1; i >= 0; --i) {
-        switch (path3.charCodeAt(i)) {
+      for (var i = path4.length - 1; i >= 0; --i) {
+        switch (path4.charCodeAt(i)) {
           case 47:
           // '/'
           case 92:
-            path3 = path3.slice(i + 1);
-            return path3 === ".." || path3 === "." ? "" : path3;
+            path4 = path4.slice(i + 1);
+            return path4 === ".." || path4 === "." ? "" : path4;
         }
       }
-      return path3 === ".." || path3 === "." ? "" : path3;
+      return path4 === ".." || path4 === "." ? "" : path4;
     };
   }
 });
@@ -5717,7 +5717,7 @@ var require_request = __commonJS({
     }
     var Request2 = class _Request {
       constructor(origin, {
-        path: path3,
+        path: path4,
         method,
         body,
         headers,
@@ -5731,11 +5731,11 @@ var require_request = __commonJS({
         throwOnError,
         expectContinue
       }, handler2) {
-        if (typeof path3 !== "string") {
+        if (typeof path4 !== "string") {
           throw new InvalidArgumentError("path must be a string");
-        } else if (path3[0] !== "/" && !(path3.startsWith("http://") || path3.startsWith("https://")) && method !== "CONNECT") {
+        } else if (path4[0] !== "/" && !(path4.startsWith("http://") || path4.startsWith("https://")) && method !== "CONNECT") {
           throw new InvalidArgumentError("path must be an absolute URL or start with a slash");
-        } else if (invalidPathRegex.exec(path3) !== null) {
+        } else if (invalidPathRegex.exec(path4) !== null) {
           throw new InvalidArgumentError("invalid request path");
         }
         if (typeof method !== "string") {
@@ -5798,7 +5798,7 @@ var require_request = __commonJS({
         this.completed = false;
         this.aborted = false;
         this.upgrade = upgrade || null;
-        this.path = query ? util2.buildURL(path3, query) : path3;
+        this.path = query ? util2.buildURL(path4, query) : path4;
         this.origin = origin;
         this.idempotent = idempotent == null ? method === "HEAD" || method === "GET" : idempotent;
         this.blocking = blocking == null ? false : blocking;
@@ -6812,9 +6812,9 @@ var require_RedirectHandler = __commonJS({
           return this.handler.onHeaders(statusCode, headers, resume, statusText);
         }
         const { origin, pathname, search } = util2.parseURL(new URL(this.location, this.opts.origin && new URL(this.opts.path, this.opts.origin)));
-        const path3 = search ? `${pathname}${search}` : pathname;
+        const path4 = search ? `${pathname}${search}` : pathname;
         this.opts.headers = cleanRequestHeaders(this.opts.headers, statusCode === 303, this.opts.origin !== origin);
-        this.opts.path = path3;
+        this.opts.path = path4;
         this.opts.origin = origin;
         this.opts.maxRedirections = 0;
         this.opts.query = null;
@@ -8060,7 +8060,7 @@ var require_client = __commonJS({
         writeH2(client, client[kHTTP2Session], request2);
         return;
       }
-      const { body, method, path: path3, host, upgrade, headers, blocking, reset } = request2;
+      const { body, method, path: path4, host, upgrade, headers, blocking, reset } = request2;
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
         body.read(0);
@@ -8110,7 +8110,7 @@ var require_client = __commonJS({
       if (blocking) {
         socket[kBlocking] = true;
       }
-      let header = `${method} ${path3} HTTP/1.1\r
+      let header = `${method} ${path4} HTTP/1.1\r
 `;
       if (typeof host === "string") {
         header += `host: ${host}\r
@@ -8173,7 +8173,7 @@ upgrade: ${upgrade}\r
       return true;
     }
     function writeH2(client, session, request2) {
-      const { body, method, path: path3, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
+      const { body, method, path: path4, host, upgrade, expectContinue, signal, headers: reqHeaders } = request2;
       let headers;
       if (typeof reqHeaders === "string") headers = Request2[kHTTP2CopyHeaders](reqHeaders.trim());
       else headers = reqHeaders;
@@ -8216,7 +8216,7 @@ upgrade: ${upgrade}\r
         });
         return true;
       }
-      headers[HTTP2_HEADER_PATH] = path3;
+      headers[HTTP2_HEADER_PATH] = path4;
       headers[HTTP2_HEADER_SCHEME] = "https";
       const expectsPayload = method === "PUT" || method === "POST" || method === "PATCH";
       if (body && typeof body.read === "function") {
@@ -10478,20 +10478,20 @@ var require_mock_utils = __commonJS({
       }
       return true;
     }
-    function safeUrl(path3) {
-      if (typeof path3 !== "string") {
-        return path3;
+    function safeUrl(path4) {
+      if (typeof path4 !== "string") {
+        return path4;
       }
-      const pathSegments = path3.split("?");
+      const pathSegments = path4.split("?");
       if (pathSegments.length !== 2) {
-        return path3;
+        return path4;
       }
       const qp = new URLSearchParams(pathSegments.pop());
       qp.sort();
       return [...pathSegments, qp.toString()].join("?");
     }
-    function matchKey(mockDispatch2, { path: path3, method, body, headers }) {
-      const pathMatch = matchValue(mockDispatch2.path, path3);
+    function matchKey(mockDispatch2, { path: path4, method, body, headers }) {
+      const pathMatch = matchValue(mockDispatch2.path, path4);
       const methodMatch = matchValue(mockDispatch2.method, method);
       const bodyMatch = typeof mockDispatch2.body !== "undefined" ? matchValue(mockDispatch2.body, body) : true;
       const headersMatch = matchHeaders(mockDispatch2, headers);
@@ -10509,7 +10509,7 @@ var require_mock_utils = __commonJS({
     function getMockDispatch(mockDispatches, key) {
       const basePath = key.query ? buildURL(key.path, key.query) : key.path;
       const resolvedPath = typeof basePath === "string" ? safeUrl(basePath) : basePath;
-      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path3 }) => matchValue(safeUrl(path3), resolvedPath));
+      let matchedMockDispatches = mockDispatches.filter(({ consumed }) => !consumed).filter(({ path: path4 }) => matchValue(safeUrl(path4), resolvedPath));
       if (matchedMockDispatches.length === 0) {
         throw new MockNotMatchedError(`Mock dispatch not matched for path '${resolvedPath}'`);
       }
@@ -10546,9 +10546,9 @@ var require_mock_utils = __commonJS({
       }
     }
     function buildKey(opts) {
-      const { path: path3, method, body, headers, query } = opts;
+      const { path: path4, method, body, headers, query } = opts;
       return {
-        path: path3,
+        path: path4,
         method,
         body,
         headers,
@@ -11002,10 +11002,10 @@ var require_pending_interceptors_formatter = __commonJS({
       }
       format(pendingInterceptors) {
         const withPrettyHeaders = pendingInterceptors.map(
-          ({ method, path: path3, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
+          ({ method, path: path4, data: { statusCode }, persist, times, timesInvoked, origin }) => ({
             Method: method,
             Origin: origin,
-            Path: path3,
+            Path: path4,
             "Status code": statusCode,
             Persistent: persist ? "\u2705" : "\u274C",
             Invocations: timesInvoked,
@@ -15646,8 +15646,8 @@ var require_util6 = __commonJS({
         }
       }
     }
-    function validateCookiePath(path3) {
-      for (const char of path3) {
+    function validateCookiePath(path4) {
+      for (const char of path4) {
         const code = char.charCodeAt(0);
         if (code < 33 || char === ";") {
           throw new Error("Invalid cookie path");
@@ -17338,11 +17338,11 @@ var require_undici = __commonJS({
           if (typeof opts.path !== "string") {
             throw new InvalidArgumentError("invalid opts.path");
           }
-          let path3 = opts.path;
+          let path4 = opts.path;
           if (!opts.path.startsWith("/")) {
-            path3 = `/${path3}`;
+            path4 = `/${path4}`;
           }
-          url = new URL(util2.parseOrigin(url).origin + path3);
+          url = new URL(util2.parseOrigin(url).origin + path4);
         } else {
           if (!opts) {
             opts = typeof url === "object" ? url : {};
@@ -18570,7 +18570,7 @@ var require_path_utils = __commonJS({
     };
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.toPlatformPath = exports.toWin32Path = exports.toPosixPath = void 0;
-    var path3 = __importStar(__require("path"));
+    var path4 = __importStar(__require("path"));
     function toPosixPath(pth) {
       return pth.replace(/[\\]/g, "/");
     }
@@ -18580,7 +18580,7 @@ var require_path_utils = __commonJS({
     }
     exports.toWin32Path = toWin32Path;
     function toPlatformPath(pth) {
-      return pth.replace(/[/\\]/g, path3.sep);
+      return pth.replace(/[/\\]/g, path4.sep);
     }
     exports.toPlatformPath = toPlatformPath;
   }
@@ -18645,7 +18645,7 @@ var require_io_util = __commonJS({
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.READONLY = exports.UV_FS_O_EXLOCK = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rm = exports.rename = exports.readlink = exports.readdir = exports.open = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
     var fs = __importStar(__require("fs"));
-    var path3 = __importStar(__require("path"));
+    var path4 = __importStar(__require("path"));
     _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.open = _a.open, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rm = _a.rm, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
     exports.IS_WINDOWS = process.platform === "win32";
     exports.UV_FS_O_EXLOCK = 268435456;
@@ -18694,7 +18694,7 @@ var require_io_util = __commonJS({
         }
         if (stats && stats.isFile()) {
           if (exports.IS_WINDOWS) {
-            const upperExt = path3.extname(filePath).toUpperCase();
+            const upperExt = path4.extname(filePath).toUpperCase();
             if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) {
               return filePath;
             }
@@ -18718,11 +18718,11 @@ var require_io_util = __commonJS({
           if (stats && stats.isFile()) {
             if (exports.IS_WINDOWS) {
               try {
-                const directory = path3.dirname(filePath);
-                const upperName = path3.basename(filePath).toUpperCase();
+                const directory = path4.dirname(filePath);
+                const upperName = path4.basename(filePath).toUpperCase();
                 for (const actualName of yield exports.readdir(directory)) {
                   if (upperName === actualName.toUpperCase()) {
-                    filePath = path3.join(directory, actualName);
+                    filePath = path4.join(directory, actualName);
                     break;
                   }
                 }
@@ -18818,7 +18818,7 @@ var require_io = __commonJS({
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
     var assert_1 = __require("assert");
-    var path3 = __importStar(__require("path"));
+    var path4 = __importStar(__require("path"));
     var ioUtil = __importStar(require_io_util());
     function cp(source, dest, options = {}) {
       return __awaiter(this, void 0, void 0, function* () {
@@ -18827,7 +18827,7 @@ var require_io = __commonJS({
         if (destStat && destStat.isFile() && !force) {
           return;
         }
-        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path3.join(dest, path3.basename(source)) : dest;
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory ? path4.join(dest, path4.basename(source)) : dest;
         if (!(yield ioUtil.exists(source))) {
           throw new Error(`no such file or directory: ${source}`);
         }
@@ -18839,7 +18839,7 @@ var require_io = __commonJS({
             yield cpDirRecursive(source, newDest, 0, force);
           }
         } else {
-          if (path3.relative(source, newDest) === "") {
+          if (path4.relative(source, newDest) === "") {
             throw new Error(`'${newDest}' and '${source}' are the same file`);
           }
           yield copyFile(source, newDest, force);
@@ -18852,7 +18852,7 @@ var require_io = __commonJS({
         if (yield ioUtil.exists(dest)) {
           let destExists = true;
           if (yield ioUtil.isDirectory(dest)) {
-            dest = path3.join(dest, path3.basename(source));
+            dest = path4.join(dest, path4.basename(source));
             destExists = yield ioUtil.exists(dest);
           }
           if (destExists) {
@@ -18863,7 +18863,7 @@ var require_io = __commonJS({
             }
           }
         }
-        yield mkdirP(path3.dirname(dest));
+        yield mkdirP(path4.dirname(dest));
         yield ioUtil.rename(source, dest);
       });
     }
@@ -18926,7 +18926,7 @@ var require_io = __commonJS({
         }
         const extensions = [];
         if (ioUtil.IS_WINDOWS && process.env["PATHEXT"]) {
-          for (const extension of process.env["PATHEXT"].split(path3.delimiter)) {
+          for (const extension of process.env["PATHEXT"].split(path4.delimiter)) {
             if (extension) {
               extensions.push(extension);
             }
@@ -18939,12 +18939,12 @@ var require_io = __commonJS({
           }
           return [];
         }
-        if (tool.includes(path3.sep)) {
+        if (tool.includes(path4.sep)) {
           return [];
         }
         const directories = [];
         if (process.env.PATH) {
-          for (const p of process.env.PATH.split(path3.delimiter)) {
+          for (const p of process.env.PATH.split(path4.delimiter)) {
             if (p) {
               directories.push(p);
             }
@@ -18952,7 +18952,7 @@ var require_io = __commonJS({
         }
         const matches = [];
         for (const directory of directories) {
-          const filePath = yield ioUtil.tryGetExecutablePath(path3.join(directory, tool), extensions);
+          const filePath = yield ioUtil.tryGetExecutablePath(path4.join(directory, tool), extensions);
           if (filePath) {
             matches.push(filePath);
           }
@@ -19069,7 +19069,7 @@ var require_toolrunner = __commonJS({
     var os3 = __importStar(__require("os"));
     var events = __importStar(__require("events"));
     var child = __importStar(__require("child_process"));
-    var path3 = __importStar(__require("path"));
+    var path4 = __importStar(__require("path"));
     var io = __importStar(require_io());
     var ioUtil = __importStar(require_io_util());
     var timers_1 = __require("timers");
@@ -19284,7 +19284,7 @@ var require_toolrunner = __commonJS({
       exec() {
         return __awaiter(this, void 0, void 0, function* () {
           if (!ioUtil.isRooted(this.toolPath) && (this.toolPath.includes("/") || IS_WINDOWS && this.toolPath.includes("\\"))) {
-            this.toolPath = path3.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
+            this.toolPath = path4.resolve(process.cwd(), this.options.cwd || process.cwd(), this.toolPath);
           }
           this.toolPath = yield io.which(this.toolPath, true);
           return new Promise((resolve7, reject) => __awaiter(this, void 0, void 0, function* () {
@@ -19787,7 +19787,7 @@ var require_core = __commonJS({
     var file_command_1 = require_file_command();
     var utils_1 = require_utils();
     var os3 = __importStar(__require("os"));
-    var path3 = __importStar(__require("path"));
+    var path4 = __importStar(__require("path"));
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function(ExitCode2) {
@@ -19815,7 +19815,7 @@ var require_core = __commonJS({
       } else {
         (0, command_1.issueCommand)("add-path", {}, inputPath);
       }
-      process.env["PATH"] = `${inputPath}${path3.delimiter}${process.env["PATH"]}`;
+      process.env["PATH"] = `${inputPath}${path4.delimiter}${process.env["PATH"]}`;
     }
     exports.addPath = addPath;
     function getInput2(name, options) {
@@ -22006,17 +22006,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path3) {
-      const ctrl = callVisitor(key, node, visitor, path3);
+    function visit_(key, node, visitor, path4) {
+      const ctrl = callVisitor(key, node, visitor, path4);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path3, ctrl);
-        return visit_(key, ctrl, visitor, path3);
+        replaceNode(key, path4, ctrl);
+        return visit_(key, ctrl, visitor, path4);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path3 = Object.freeze(path3.concat(node));
+          path4 = Object.freeze(path4.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path3);
+            const ci = visit_(i, node.items[i], visitor, path4);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22027,13 +22027,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path3 = Object.freeze(path3.concat(node));
-          const ck = visit_("key", node.key, visitor, path3);
+          path4 = Object.freeze(path4.concat(node));
+          const ck = visit_("key", node.key, visitor, path4);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path3);
+          const cv = visit_("value", node.value, visitor, path4);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22054,17 +22054,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path3) {
-      const ctrl = await callVisitor(key, node, visitor, path3);
+    async function visitAsync_(key, node, visitor, path4) {
+      const ctrl = await callVisitor(key, node, visitor, path4);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path3, ctrl);
-        return visitAsync_(key, ctrl, visitor, path3);
+        replaceNode(key, path4, ctrl);
+        return visitAsync_(key, ctrl, visitor, path4);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path3 = Object.freeze(path3.concat(node));
+          path4 = Object.freeze(path4.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path3);
+            const ci = await visitAsync_(i, node.items[i], visitor, path4);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -22075,13 +22075,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path3 = Object.freeze(path3.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path3);
+          path4 = Object.freeze(path4.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path4);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path3);
+          const cv = await visitAsync_("value", node.value, visitor, path4);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -22108,23 +22108,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path3) {
+    function callVisitor(key, node, visitor, path4) {
       if (typeof visitor === "function")
-        return visitor(key, node, path3);
+        return visitor(key, node, path4);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path3);
+        return visitor.Map?.(key, node, path4);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path3);
+        return visitor.Seq?.(key, node, path4);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path3);
+        return visitor.Pair?.(key, node, path4);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path3);
+        return visitor.Scalar?.(key, node, path4);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path3);
+        return visitor.Alias?.(key, node, path4);
       return void 0;
     }
-    function replaceNode(key, path3, node) {
-      const parent = path3[path3.length - 1];
+    function replaceNode(key, path4, node) {
+      const parent = path4[path4.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -22741,10 +22741,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path3, value) {
+    function collectionFromPath(schema, path4, value) {
       let v = value;
-      for (let i = path3.length - 1; i >= 0; --i) {
-        const k = path3[i];
+      for (let i = path4.length - 1; i >= 0; --i) {
+        const k = path4[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -22763,7 +22763,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path3) => path3 == null || typeof path3 === "object" && !!path3[Symbol.iterator]().next().done;
+    var isEmptyPath = (path4) => path4 == null || typeof path4 === "object" && !!path4[Symbol.iterator]().next().done;
     var Collection2 = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -22793,11 +22793,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path3, value) {
-        if (isEmptyPath(path3))
+      addIn(path4, value) {
+        if (isEmptyPath(path4))
           this.add(value);
         else {
-          const [key, ...rest] = path3;
+          const [key, ...rest] = path4;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -22811,8 +22811,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path3) {
-        const [key, ...rest] = path3;
+      deleteIn(path4) {
+        const [key, ...rest] = path4;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -22826,8 +22826,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path3, keepScalar) {
-        const [key, ...rest] = path3;
+      getIn(path4, keepScalar) {
+        const [key, ...rest] = path4;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -22845,8 +22845,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path3) {
-        const [key, ...rest] = path3;
+      hasIn(path4) {
+        const [key, ...rest] = path4;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -22856,8 +22856,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path3, value) {
-        const [key, ...rest] = path3;
+      setIn(path4, value) {
+        const [key, ...rest] = path4;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -25396,9 +25396,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path3, value) {
+      addIn(path4, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path3, value);
+          this.contents.addIn(path4, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -25473,14 +25473,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path3) {
-        if (Collection2.isEmptyPath(path3)) {
+      deleteIn(path4) {
+        if (Collection2.isEmptyPath(path4)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path3) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path4) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -25495,10 +25495,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path3, keepScalar) {
-        if (Collection2.isEmptyPath(path3))
+      getIn(path4, keepScalar) {
+        if (Collection2.isEmptyPath(path4))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path3, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path4, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -25509,10 +25509,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path3) {
-        if (Collection2.isEmptyPath(path3))
+      hasIn(path4) {
+        if (Collection2.isEmptyPath(path4))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path3) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path4) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -25529,13 +25529,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path3, value) {
-        if (Collection2.isEmptyPath(path3)) {
+      setIn(path4, value) {
+        if (Collection2.isEmptyPath(path4)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path3), value);
+          this.contents = Collection2.collectionFromPath(this.schema, Array.from(path4), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path3, value);
+          this.contents.setIn(path4, value);
         }
       }
       /**
@@ -27507,9 +27507,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path3) => {
+    visit.itemAtPath = (cst, path4) => {
       let item = cst;
-      for (const [field, index] of path3) {
+      for (const [field, index] of path4) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -27518,23 +27518,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path3) => {
-      const parent = visit.itemAtPath(cst, path3.slice(0, -1));
-      const field = path3[path3.length - 1][0];
+    visit.parentCollection = (cst, path4) => {
+      const parent = visit.itemAtPath(cst, path4.slice(0, -1));
+      const field = path4[path4.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path3, item, visitor) {
-      let ctrl = visitor(item, path3);
+    function _visit(path4, item, visitor) {
+      let ctrl = visitor(item, path4);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path3.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path4.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -27545,10 +27545,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path3);
+            ctrl = ctrl(item, path4);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path3) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path4) : ctrl;
     }
     exports.visit = visit;
   }
@@ -29696,8 +29696,8 @@ var require_utils3 = __commonJS({
       }
       return output;
     };
-    exports.basename = (path3, { windows } = {}) => {
-      const segs = path3.split(windows ? /[\\/]/ : "/");
+    exports.basename = (path4, { windows } = {}) => {
+      const segs = path4.split(windows ? /[\\/]/ : "/");
       const last = segs[segs.length - 1];
       if (last === "") {
         return segs[segs.length - 2];
@@ -31634,8 +31634,8 @@ ${val.stack}`;
     module.exports.__wbindgen_throw = function(arg0, arg1) {
       throw new Error(getStringFromWasm0(arg0, arg1));
     };
-    var path3 = __require("path").join(__dirname, "core_bg.wasm");
-    var bytes = __require("fs").readFileSync(path3);
+    var path4 = __require("path").join(__dirname, "core_bg.wasm");
+    var bytes = __require("fs").readFileSync(path4);
     var wasmModule = new WebAssembly.Module(bytes);
     var wasmInstance = new WebAssembly.Instance(wasmModule, imports);
     wasm = wasmInstance.exports;
@@ -33079,17 +33079,17 @@ var require_shared_lib_core = __commonJS({
     exports.SharedLibCore = void 0;
     var fs = __importStar(__require("fs"));
     var os3 = __importStar(__require("os"));
-    var path3 = __importStar(__require("path"));
+    var path4 = __importStar(__require("path"));
     var errors_1 = require_errors3();
     var find1PasswordLibPath = () => {
       const platform = os3.platform();
-      const appRoot = path3.dirname(process.execPath);
+      const appRoot = path4.dirname(process.execPath);
       let searchPaths = [];
       switch (platform) {
         case "darwin":
           searchPaths = [
             "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib",
-            path3.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
+            path4.join(os3.homedir(), "/Applications/1Password.app/Contents/Frameworks/libop_sdk_ipc_client.dylib")
           ];
           break;
         case "linux":
@@ -33101,10 +33101,10 @@ var require_shared_lib_core = __commonJS({
           break;
         case "win32":
           searchPaths = [
-            path3.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
+            path4.join(os3.homedir(), "/AppData/Local/1Password/op_sdk_ipc_client.dll"),
             "C:/Program Files/1Password/app/8/op_sdk_ipc_client.dll",
             "C:/Program Files (x86)/1Password/app/8/op_sdk_ipc_client.dll",
-            path3.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
+            path4.join(os3.homedir(), "/AppData/Local/1Password/app/8/op_sdk_ipc_client.dll")
           ];
           break;
         default:
@@ -33337,8 +33337,8 @@ var require_context = __commonJS({
           if ((0, fs_1.existsSync)(process.env.GITHUB_EVENT_PATH)) {
             this.payload = JSON.parse((0, fs_1.readFileSync)(process.env.GITHUB_EVENT_PATH, { encoding: "utf8" }));
           } else {
-            const path3 = process.env.GITHUB_EVENT_PATH;
-            process.stdout.write(`GITHUB_EVENT_PATH ${path3} does not exist${os_1.EOL}`);
+            const path4 = process.env.GITHUB_EVENT_PATH;
+            process.stdout.write(`GITHUB_EVENT_PATH ${path4} does not exist${os_1.EOL}`);
           }
         }
         this.eventName = process.env.GITHUB_EVENT_NAME;
@@ -38286,7 +38286,7 @@ import * as fs2 from "fs";
 import { readFileSync as readFileSync3, mkdirSync as mkdirSync2, writeFileSync as writeFileSync2 } from "fs";
 var import_semver = __toESM(require_semver2(), 1);
 var import_yaml = __toESM(require_dist(), 1);
-import * as path4 from "path";
+import * as path3 from "path";
 import { join as join4, dirname as dirname4, relative as relative3, resolve as resolve5 } from "path";
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/index.js
@@ -38782,8 +38782,8 @@ function getErrorMap() {
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.js
 init_esm_shims();
 var makeIssue = (params) => {
-  const { data, path: path3, errorMaps, issueData } = params;
-  const fullPath = [...path3, ...issueData.path || []];
+  const { data, path: path4, errorMaps, issueData } = params;
+  const fullPath = [...path4, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -38903,11 +38903,11 @@ var errorUtil;
 
 // ../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path3, key) {
+  constructor(parent, value, path4, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path3;
+    this._path = path4;
     this._key = key;
   }
   get path() {
@@ -42848,7 +42848,7 @@ var MigrationGraphImpl = class {
         hasIrreversibleStep: false
       };
     }
-    const path3 = findPath(
+    const path4 = findPath(
       normalizedFrom,
       normalizedTo,
       this.adjacencyList,
@@ -42856,10 +42856,10 @@ var MigrationGraphImpl = class {
       this.versionStrategy,
       (from, to) => this.getMigrationKey(from, to)
     );
-    if (!path3) {
+    if (!path4) {
       throw new NoPathError(fromVersion, toVersion);
     }
-    return path3;
+    return path4;
   }
   migrate(data, fromVersion, toVersion, options = {}) {
     const startTime = performance.now();
@@ -42888,12 +42888,12 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path3;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path3 = this.getPath(normalizedFrom, normalizedTo);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path3, pathDuration);
+      this.telemetry?.onPathComputed?.(path4, pathDuration);
     } catch (err) {
       return {
         success: false,
@@ -42903,27 +42903,27 @@ var MigrationGraphImpl = class {
         error: err
       };
     }
-    if (path3.steps.length === 0) {
+    if (path4.steps.length === 0) {
       return {
         success: true,
         data,
-        path: path3,
+        path: path4,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
     }
-    const context = createMigrationContext(path3.steps.length, options.initialStash);
+    const context = createMigrationContext(path4.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path3.steps.length; i++) {
-      const step = path3.steps[i];
+    for (let i = 0; i < path4.steps.length; i++) {
+      const step = path4.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path3.steps.length
+        totalSteps: path4.steps.length
       });
-      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
       const stepStartTime = performance.now();
       try {
         if (step.direction === "up") {
@@ -42948,20 +42948,20 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, step, context);
         return {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: error2
         };
       }
-      if (options.validateIntermediate && i < path3.steps.length - 1) {
+      if (options.validateIntermediate && i < path4.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             return {
               success: false,
-              path: path3,
+              path: path4,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -42985,7 +42985,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(error2, null, context);
         const result2 = {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43005,7 +43005,7 @@ var MigrationGraphImpl = class {
           this.telemetry?.onError?.(error2, null, context);
           const result2 = {
             success: false,
-            path: path3,
+            path: path4,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43021,7 +43021,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path3,
+      path: path4,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43053,11 +43053,11 @@ var MigrationGraphImpl = class {
       }
       data = validation2.data;
     }
-    let path3;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path3 = this.getPath(normalizedFrom, normalizedTo);
-      this.telemetry?.onPathComputed?.(path3, performance.now() - pathStartTime);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
+      this.telemetry?.onPathComputed?.(path4, performance.now() - pathStartTime);
     } catch (err) {
       const result2 = {
         success: false,
@@ -43069,30 +43069,30 @@ var MigrationGraphImpl = class {
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    if (path3.steps.length === 0) {
+    if (path4.steps.length === 0) {
       const result2 = {
         success: true,
         data,
-        path: path3,
+        path: path4,
         stash: { consumed: [], unconsumed: [], lossless: true },
         preservedFields: options.initialStash ?? []
       };
       this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
       return result2;
     }
-    const context = createMigrationContext(path3.steps.length, options.initialStash);
+    const context = createMigrationContext(path4.steps.length, options.initialStash);
     let currentData = data;
-    for (let i = 0; i < path3.steps.length; i++) {
-      const step = path3.steps[i];
+    for (let i = 0; i < path4.steps.length; i++) {
+      const step = path4.steps[i];
       context.setCurrentStep({
         from: step.fromVersion,
         to: step.toVersion,
         direction: step.direction,
         index: i,
-        totalSteps: path3.steps.length
+        totalSteps: path4.steps.length
       });
       const stepStartTime = performance.now();
-      this.telemetry?.onStepStart?.(step, i, path3.steps.length);
+      this.telemetry?.onStepStart?.(step, i, path4.steps.length);
       try {
         if (step.direction === "up") {
           const result2 = step.migration.up(currentData, context);
@@ -43107,7 +43107,7 @@ var MigrationGraphImpl = class {
         this.telemetry?.onError?.(err, step, context);
         const result2 = {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           error: new MigrationError(
@@ -43123,14 +43123,14 @@ var MigrationGraphImpl = class {
         this.telemetry?.onMigrationComplete?.(result2, performance.now() - startTime);
         return result2;
       }
-      if (options.validateIntermediate && i < path3.steps.length - 1) {
+      if (options.validateIntermediate && i < path4.steps.length - 1) {
         const intermediateSchema = this.schemas.get(step.toVersion);
         if (intermediateSchema) {
           const validation2 = intermediateSchema.schema(currentData);
           if (!validation2.success) {
             const result2 = {
               success: false,
-              path: path3,
+              path: path4,
               stash: context.getSummary(),
               preservedFields: context.getPreservedFields(),
               error: new SchemaValidationError(
@@ -43151,7 +43151,7 @@ var MigrationGraphImpl = class {
       if (!validation.success) {
         const result2 = {
           success: false,
-          path: path3,
+          path: path4,
           stash: context.getSummary(),
           preservedFields: context.getPreservedFields(),
           validation,
@@ -43168,7 +43168,7 @@ var MigrationGraphImpl = class {
         if (!validation.success) {
           const result2 = {
             success: false,
-            path: path3,
+            path: path4,
             stash: context.getSummary(),
             preservedFields: context.getPreservedFields(),
             validation,
@@ -43186,7 +43186,7 @@ var MigrationGraphImpl = class {
     const result = {
       success: true,
       data: currentData,
-      path: path3,
+      path: path4,
       stash: context.getSummary(),
       preservedFields: context.getPreservedFields(),
       ...validation !== void 0 && { validation }
@@ -43198,12 +43198,12 @@ var MigrationGraphImpl = class {
   migrateMany(data, fromVersion, toVersion, options = {}) {
     const normalizedFrom = this.normalizeVersion(fromVersion);
     const normalizedTo = this.normalizeVersion(toVersion);
-    let path3;
+    let path4;
     try {
       const pathStartTime = performance.now();
-      path3 = this.getPath(normalizedFrom, normalizedTo);
+      path4 = this.getPath(normalizedFrom, normalizedTo);
       const pathDuration = performance.now() - pathStartTime;
-      this.telemetry?.onPathComputed?.(path3, pathDuration);
+      this.telemetry?.onPathComputed?.(path4, pathDuration);
     } catch {
       return {
         total: 0,
@@ -43229,7 +43229,7 @@ var MigrationGraphImpl = class {
           for (let j = i + 1; j < items.length; j++) {
             results.push({
               success: false,
-              path: path3,
+              path: path4,
               stash: { consumed: [], unconsumed: [], lossless: true },
               preservedFields: [],
               error: new MigrationError(
@@ -43250,7 +43250,7 @@ var MigrationGraphImpl = class {
       succeeded,
       failed,
       results,
-      path: path3
+      path: path4
     };
   }
   getVersions() {
@@ -43330,8 +43330,8 @@ function createMigrationGraph(options) {
 
 // ../../node_modules/.pnpm/@migrex+zod@1.0.0-alpha.1_@migrex+core@0.2.0-alpha.1_zod@3.25.76/node_modules/@migrex/zod/dist/index.js
 init_esm_shims();
-function pathToStringArray(path3) {
-  return path3.map((p) => String(p));
+function pathToStringArray(path4) {
+  return path4.map((p) => String(p));
 }
 function zodErrorToValidationErrors(error2) {
   return error2.issues.map((issue) => ({
@@ -43380,27 +43380,27 @@ import { createRequire } from "module";
 import { basename, dirname, normalize, relative, resolve, sep } from "path";
 import * as nativeFs from "fs";
 var __require2 = /* @__PURE__ */ createRequire(import.meta.url);
-function cleanPath(path3) {
-  let normalized = normalize(path3);
+function cleanPath(path4) {
+  let normalized = normalize(path4);
   if (normalized.length > 1 && normalized[normalized.length - 1] === sep) normalized = normalized.substring(0, normalized.length - 1);
   return normalized;
 }
 var SLASHES_REGEX = /[\\/]/g;
-function convertSlashes(path3, separator) {
-  return path3.replace(SLASHES_REGEX, separator);
+function convertSlashes(path4, separator) {
+  return path4.replace(SLASHES_REGEX, separator);
 }
 var WINDOWS_ROOT_DIR_REGEX = /^[a-z]:[\\/]$/i;
-function isRootDirectory(path3) {
-  return path3 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path3);
+function isRootDirectory(path4) {
+  return path4 === "/" || WINDOWS_ROOT_DIR_REGEX.test(path4);
 }
-function normalizePath(path3, options) {
+function normalizePath(path4, options) {
   const { resolvePaths, normalizePath: normalizePath$1, pathSeparator } = options;
-  const pathNeedsCleaning = process.platform === "win32" && path3.includes("/") || path3.startsWith(".");
-  if (resolvePaths) path3 = resolve(path3);
-  if (normalizePath$1 || pathNeedsCleaning) path3 = cleanPath(path3);
-  if (path3 === ".") return "";
-  const needsSeperator = path3[path3.length - 1] !== pathSeparator;
-  return convertSlashes(needsSeperator ? path3 + pathSeparator : path3, pathSeparator);
+  const pathNeedsCleaning = process.platform === "win32" && path4.includes("/") || path4.startsWith(".");
+  if (resolvePaths) path4 = resolve(path4);
+  if (normalizePath$1 || pathNeedsCleaning) path4 = cleanPath(path4);
+  if (path4 === ".") return "";
+  const needsSeperator = path4[path4.length - 1] !== pathSeparator;
+  return convertSlashes(needsSeperator ? path4 + pathSeparator : path4, pathSeparator);
 }
 function joinPathWithBasePath(filename, directoryPath) {
   return directoryPath + filename;
@@ -43437,8 +43437,8 @@ var pushDirectory = (directoryPath, paths) => {
   paths.push(directoryPath || ".");
 };
 var pushDirectoryFilter = (directoryPath, paths, filters) => {
-  const path3 = directoryPath || ".";
-  if (filters.every((filter) => filter(path3, true))) paths.push(path3);
+  const path4 = directoryPath || ".";
+  if (filters.every((filter) => filter(path4, true))) paths.push(path4);
 };
 var empty$2 = () => {
 };
@@ -43490,26 +43490,26 @@ var empty = () => {
 function build$3(options) {
   return options.group ? groupFiles : empty;
 }
-var resolveSymlinksAsync = function(path3, state, callback$1) {
+var resolveSymlinksAsync = function(path4, state, callback$1) {
   const { queue, fs, options: { suppressErrors } } = state;
   queue.enqueue();
-  fs.realpath(path3, (error2, resolvedPath) => {
+  fs.realpath(path4, (error2, resolvedPath) => {
     if (error2) return queue.dequeue(suppressErrors ? null : error2, state);
     fs.stat(resolvedPath, (error$1, stat3) => {
       if (error$1) return queue.dequeue(suppressErrors ? null : error$1, state);
-      if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return queue.dequeue(null, state);
+      if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return queue.dequeue(null, state);
       callback$1(stat3, resolvedPath);
       queue.dequeue(null, state);
     });
   });
 };
-var resolveSymlinks = function(path3, state, callback$1) {
+var resolveSymlinks = function(path4, state, callback$1) {
   const { queue, fs, options: { suppressErrors } } = state;
   queue.enqueue();
   try {
-    const resolvedPath = fs.realpathSync(path3);
+    const resolvedPath = fs.realpathSync(path4);
     const stat3 = fs.statSync(resolvedPath);
-    if (stat3.isDirectory() && isRecursive(path3, resolvedPath, state)) return;
+    if (stat3.isDirectory() && isRecursive(path4, resolvedPath, state)) return;
     callback$1(stat3, resolvedPath);
   } catch (e) {
     if (!suppressErrors) throw e;
@@ -43519,9 +43519,9 @@ function build$2(options, isSynchronous) {
   if (!options.resolveSymlinks || options.excludeSymlinks) return null;
   return isSynchronous ? resolveSymlinks : resolveSymlinksAsync;
 }
-function isRecursive(path3, resolved, state) {
+function isRecursive(path4, resolved, state) {
   if (state.options.useRealPaths) return isRecursiveUsingRealPaths(resolved, state);
-  let parent = dirname(path3);
+  let parent = dirname(path4);
   let depth = 1;
   while (parent !== state.root && depth < 2) {
     const resolvedPath = state.symlinks.get(parent);
@@ -43529,7 +43529,7 @@ function isRecursive(path3, resolved, state) {
     if (isSameRoot) depth++;
     else parent = dirname(parent);
   }
-  state.symlinks.set(path3, resolved);
+  state.symlinks.set(path4, resolved);
   return depth > 1;
 }
 function isRecursiveUsingRealPaths(resolved, state) {
@@ -43701,19 +43701,19 @@ var Walker = class {
         const filename = this.joinPath(entry.name, directoryPath);
         this.pushFile(filename, files, this.state.counts, filters);
       } else if (entry.isDirectory()) {
-        let path3 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
-        if (exclude && exclude(entry.name, path3)) continue;
-        this.pushDirectory(path3, paths, filters);
-        this.walkDirectory(this.state, path3, path3, depth - 1, this.walk);
+        let path4 = joinDirectoryPath(entry.name, directoryPath, this.state.options.pathSeparator);
+        if (exclude && exclude(entry.name, path4)) continue;
+        this.pushDirectory(path4, paths, filters);
+        this.walkDirectory(this.state, path4, path4, depth - 1, this.walk);
       } else if (this.resolveSymlink && entry.isSymbolicLink()) {
-        let path3 = joinPathWithBasePath(entry.name, directoryPath);
-        this.resolveSymlink(path3, this.state, (stat3, resolvedPath) => {
+        let path4 = joinPathWithBasePath(entry.name, directoryPath);
+        this.resolveSymlink(path4, this.state, (stat3, resolvedPath) => {
           if (stat3.isDirectory()) {
             resolvedPath = normalizePath(resolvedPath, this.state.options);
-            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path3 + pathSeparator)) return;
-            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path3 + pathSeparator, depth - 1, this.walk);
+            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path4 + pathSeparator)) return;
+            this.walkDirectory(this.state, resolvedPath, useRealPaths ? resolvedPath : path4 + pathSeparator, depth - 1, this.walk);
           } else {
-            resolvedPath = useRealPaths ? resolvedPath : path3;
+            resolvedPath = useRealPaths ? resolvedPath : path4;
             const filename = basename(resolvedPath);
             const directoryPath$1 = normalizePath(dirname(resolvedPath), this.state.options);
             resolvedPath = this.joinPath(filename, directoryPath$1);
@@ -43879,7 +43879,7 @@ var Builder = class {
       isMatch = globFn(patterns, ...options);
       this.globCache[patterns.join("\0")] = isMatch;
     }
-    this.options.filters.push((path3) => isMatch(path3));
+    this.options.filters.push((path4) => isMatch(path4));
     return this;
   }
 };
@@ -46200,9 +46200,15 @@ var durationSchema = external_exports.string().refine(
 var gateSchema = external_exports.object({
   name: external_exports.string().min(1, "Gate name cannot be empty"),
   description: external_exports.string().min(1, "Gate description cannot be empty"),
+  // How the gate maps matched files to seals. Omitted = `single` (one combined
+  // fingerprint, one seal) for backward compatibility; `pattern` seals each
+  // matched file independently.
+  kind: external_exports.enum(["single", "pattern"]).optional(),
   authorizedSigners: external_exports.array(external_exports.string().min(1, "Authorized signer slug cannot be empty")).min(1, "At least one authorized signer is required"),
   fingerprint: fingerprintConfigSchema,
-  maxAge: durationSchema
+  // Optional: when omitted the gate never expires (indefinite is the default —
+  // not a large-number sentinel). See GateConfig.maxAge.
+  maxAge: durationSchema.optional()
 }).strict();
 var keyProviderOptionsSchema = external_exports.object({
   privateKeyPath: external_exports.string().optional(),
@@ -46344,6 +46350,10 @@ function versionSchema(version2) {
 }
 var sealSchemaV1 = external_exports.object({
   gateId: external_exports.string().min(1, "Gate ID cannot be empty"),
+  // Present only for per-file seals of a pattern gate; identifies which file
+  // within the gate the seal covers (repo-relative, forward-slash). Additive and
+  // optional so existing single-gate seals validate unchanged.
+  artifactPath: external_exports.string().min(1, "Artifact path cannot be empty").optional(),
   fingerprint: external_exports.string().regex(/^sha256:[a-f0-9]+$/i, "Invalid fingerprint format (expected sha256:<hex>)"),
   timestamp: external_exports.string().datetime({ message: "Invalid ISO 8601 timestamp" }),
   sealedBy: external_exports.string().min(1, "Signer slug cannot be empty"),
@@ -46589,13 +46599,19 @@ function toGateConfig(gate) {
   if (gate.fingerprint.exclude !== void 0) {
     fingerprint2.exclude = gate.fingerprint.exclude;
   }
-  return {
+  const result = {
     name: gate.name,
     description: gate.description,
     authorizedSigners: gate.authorizedSigners,
-    fingerprint: fingerprint2,
-    maxAge: gate.maxAge
+    fingerprint: fingerprint2
   };
+  if (gate.kind !== void 0) {
+    result.kind = gate.kind;
+  }
+  if (gate.maxAge !== void 0) {
+    result.maxAge = gate.maxAge;
+  }
+  return result;
 }
 function toKeyProvider(provider) {
   const result = {
@@ -46879,7 +46895,7 @@ function sortFiles(files) {
   });
 }
 function normalizePath2(filePath) {
-  return filePath.split(path4.sep).join("/");
+  return filePath.split(path3.sep).join("/");
 }
 function computeFinalFingerprint(fileHashes) {
   const sorted = [...fileHashes].sort((a, b) => {
@@ -46925,7 +46941,7 @@ function validateOptions(options) {
   const baseDir = options.baseDir ?? process.cwd();
   for (const p of options.paths) {
     if (!isGlobPattern(p)) {
-      const resolvedPath = path4.resolve(baseDir, p);
+      const resolvedPath = path3.resolve(baseDir, p);
       if (!fs2.existsSync(resolvedPath)) {
         throw new Error(`Path does not exist: ${resolvedPath}`);
       }
@@ -46940,7 +46956,7 @@ async function computeFingerprint(options) {
   const fileHashCache = /* @__PURE__ */ new Map();
   const fileHashInputs = [];
   for (const file of sortedFiles) {
-    const filePath = path4.resolve(baseDir, file);
+    const filePath = path3.resolve(baseDir, file);
     let realPath = filePath;
     let stats = await fs2.promises.lstat(filePath);
     if (stats.isSymbolicLink()) {
@@ -46980,7 +46996,7 @@ function resolvePackagePattern(pkg, baseDir) {
   if (isGlobPattern(pkg)) {
     return pkg;
   }
-  const fullPath = path4.resolve(baseDir, pkg);
+  const fullPath = path3.resolve(baseDir, pkg);
   try {
     const stats = fs2.statSync(fullPath);
     return stats.isFile() ? pkg : `${pkg}/**/*`;
@@ -47116,14 +47132,18 @@ function slugifySegment(input) {
   const prefix = readable.length > 0 ? readable : "seg";
   return `${prefix}-${hash}`;
 }
-function sealRelPath(gateId, sealedBy) {
-  return path4.join(slugifySegment(gateId), slugifySegment(sealedBy) + SEAL_FILE_EXT);
+function sealRelPath(gateId, sealedBy, artifactPath) {
+  const signerFile = slugifySegment(sealedBy) + SEAL_FILE_EXT;
+  if (artifactPath !== void 0) {
+    return path3.join(slugifySegment(gateId), slugifySegment(artifactPath), signerFile);
+  }
+  return path3.join(slugifySegment(gateId), signerFile);
 }
 function resolveSealsRoot(dir, sealsPathOverride) {
   if (sealsPathOverride === void 0) {
-    return path4.join(dir, ".attest-it", "seals");
+    return path3.join(dir, ".attest-it", "seals");
   }
-  const resolved = path4.resolve(dir, sealsPathOverride);
+  const resolved = path3.resolve(dir, sealsPathOverride);
   return resolved.replace(/\.(json|ya?ml)$/i, "");
 }
 function legacyMonolithCandidates(root) {
@@ -47132,6 +47152,10 @@ function legacyMonolithCandidates(root) {
 function serializeSeal(seal2) {
   const ordered = {
     gateId: seal2.gateId,
+    // Emitted immediately after gateId (and only when set) so per-file pattern
+    // seals round-trip; omitted entirely for single-gate seals so their content
+    // stays byte-identical to the pre-pattern format.
+    ...seal2.artifactPath !== void 0 && { artifactPath: seal2.artifactPath },
     fingerprint: seal2.fingerprint,
     timestamp: seal2.timestamp,
     sealedBy: seal2.sealedBy,
@@ -47161,6 +47185,9 @@ function isPreferredOver(candidate, current) {
   }
   return candidate.sealedBy > current.sealedBy;
 }
+function isAggregateSeal(seal2) {
+  return seal2.artifactPath === void 0;
+}
 function pruneEmptyDirsSync(root) {
   let entries;
   try {
@@ -47170,7 +47197,7 @@ function pruneEmptyDirsSync(root) {
   }
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      const child = path4.join(root, entry.name);
+      const child = path3.join(root, entry.name);
       pruneEmptyDirsSync(child);
       try {
         if (fs2.readdirSync(child).length === 0) {
@@ -47211,7 +47238,7 @@ async function listSealFilePaths(root) {
       throw error2;
     }
     for (const entry of entries) {
-      const full = path4.join(dir, entry.name);
+      const full = path3.join(dir, entry.name);
       if (entry.isDirectory()) {
         await walk(full);
       } else if (entry.isFile() && entry.name.endsWith(SEAL_FILE_EXT)) {
@@ -47227,6 +47254,7 @@ async function readSealsFromDir(root) {
   const seals = {};
   for (const p of paths) {
     const seal2 = parseSeal(await fs2.promises.readFile(p, "utf8"), p);
+    if (!isAggregateSeal(seal2)) continue;
     const current = seals[seal2.gateId];
     if (!current || isPreferredOver(seal2, current)) {
       seals[seal2.gateId] = seal2;
@@ -47237,7 +47265,7 @@ async function readSealsFromDir(root) {
 async function writeSealsToDir(root, sealsFile) {
   const desired = /* @__PURE__ */ new Map();
   for (const seal2 of Object.values(sealsFile.seals)) {
-    desired.set(path4.join(root, sealRelPath(seal2.gateId, seal2.sealedBy)), seal2);
+    desired.set(path3.join(root, sealRelPath(seal2.gateId, seal2.sealedBy)), seal2);
   }
   const existing = await listSealFilePaths(root);
   for (const [target, seal2] of desired) {
@@ -47249,16 +47277,23 @@ async function writeSealsToDir(root, sealsFile) {
       prior = void 0;
     }
     if (prior !== content) {
-      await fs2.promises.mkdir(path4.dirname(target), { recursive: true });
+      await fs2.promises.mkdir(path3.dirname(target), { recursive: true });
       await fs2.promises.writeFile(target, content, "utf8");
     }
   }
   for (const p of existing) {
-    if (!desired.has(p)) {
+    if (!desired.has(p) && await isAggregateSealFile(p)) {
       await fs2.promises.rm(p, { force: true });
     }
   }
   pruneEmptyDirsSync(root);
+}
+async function isAggregateSealFile(p) {
+  try {
+    return isAggregateSeal(parseSeal(await fs2.promises.readFile(p, "utf8"), p));
+  } catch {
+    return true;
+  }
 }
 async function migrateMonoliths(dir, root) {
   const candidates = legacyMonolithCandidates(root);
@@ -47392,26 +47427,26 @@ function verifyGateSeal(config, gateId, seals, currentFingerprint) {
       message: `No seal found for gate '${gateId}'`
     };
   }
+  return evaluateSeal({ config, gateId, seal: seal2, currentFingerprint, maxAge: gate.maxAge });
+}
+function evaluateSeal(params) {
+  const { config, gateId, seal: seal2, currentFingerprint, maxAge, artifactPath } = params;
+  const base = artifactPath !== void 0 ? { gateId, artifactPath } : { gateId };
   if (seal2.fingerprint !== currentFingerprint) {
     return {
-      gateId,
+      ...base,
       state: "FINGERPRINT_MISMATCH",
       seal: seal2,
       message: `Fingerprint changed since seal was created`
     };
   }
   if (!config.team) {
-    return {
-      gateId,
-      state: "UNKNOWN_SIGNER",
-      seal: seal2,
-      message: `No team configuration found`
-    };
+    return { ...base, state: "UNKNOWN_SIGNER", seal: seal2, message: `No team configuration found` };
   }
   const teamMember = config.team[seal2.sealedBy];
   if (!teamMember) {
     return {
-      gateId,
+      ...base,
       state: "UNKNOWN_SIGNER",
       seal: seal2,
       message: `Signer '${seal2.sealedBy}' not found in team`
@@ -47420,7 +47455,7 @@ function verifyGateSeal(config, gateId, seals, currentFingerprint) {
   const authorized = isAuthorizedSigner(config, gateId, teamMember.publicKey);
   if (!authorized) {
     return {
-      gateId,
+      ...base,
       state: "UNKNOWN_SIGNER",
       seal: seal2,
       message: `Signer '${seal2.sealedBy}' is not authorized for gate '${gateId}'`
@@ -47429,40 +47464,37 @@ function verifyGateSeal(config, gateId, seals, currentFingerprint) {
   const verificationResult = verifySeal(seal2, config);
   if (!verificationResult.valid) {
     return {
-      gateId,
+      ...base,
       state: "INVALID_SIGNATURE",
       seal: seal2,
       message: verificationResult.error ?? "Signature verification failed"
     };
   }
-  try {
-    const maxAgeMs = parseDuration(gate.maxAge);
-    const sealTimestamp = new Date(seal2.timestamp).getTime();
-    const now = Date.now();
-    const ageMs = now - sealTimestamp;
-    if (ageMs > maxAgeMs) {
-      const ageDays = Math.floor(ageMs / (1e3 * 60 * 60 * 24));
-      const maxAgeDays = Math.floor(maxAgeMs / (1e3 * 60 * 60 * 24));
+  if (maxAge !== void 0) {
+    try {
+      const maxAgeMs = parseDuration(maxAge);
+      const sealTimestamp = new Date(seal2.timestamp).getTime();
+      const ageMs = Date.now() - sealTimestamp;
+      if (ageMs > maxAgeMs) {
+        const ageDays = Math.floor(ageMs / (1e3 * 60 * 60 * 24));
+        const maxAgeDays = Math.floor(maxAgeMs / (1e3 * 60 * 60 * 24));
+        return {
+          ...base,
+          state: "STALE",
+          seal: seal2,
+          message: `Seal is ${ageDays.toString()} days old, exceeds maxAge of ${maxAgeDays.toString()} days`
+        };
+      }
+    } catch (error2) {
       return {
-        gateId,
+        ...base,
         state: "STALE",
         seal: seal2,
-        message: `Seal is ${ageDays.toString()} days old, exceeds maxAge of ${maxAgeDays.toString()} days`
+        message: `Cannot verify freshness: invalid maxAge format: ${error2 instanceof Error ? error2.message : String(error2)}`
       };
     }
-  } catch (error2) {
-    return {
-      gateId,
-      state: "STALE",
-      seal: seal2,
-      message: `Cannot verify freshness: invalid maxAge format: ${error2 instanceof Error ? error2.message : String(error2)}`
-    };
   }
-  return {
-    gateId,
-    state: "VALID",
-    seal: seal2
-  };
+  return { ...base, state: "VALID", seal: seal2 };
 }
 function verifyAllSeals(config, seals, fingerprints) {
   if (!config.gates) {
@@ -47685,8 +47717,8 @@ var VaultKeyProvider = class {
    */
   async getPrivateKey(keyRef) {
     const pemContent = await this.backend.retrieve(keyRef);
-    const tempDir = await fs32.mkdtemp(path4.join(os2.tmpdir(), "attest-it-vk-"));
-    const tempKeyPath = path4.join(tempDir, "private.pem");
+    const tempDir = await fs32.mkdtemp(path3.join(os2.tmpdir(), "attest-it-vk-"));
+    const tempKeyPath = path3.join(tempDir, "private.pem");
     try {
       await fs32.writeFile(tempKeyPath, pemContent, "utf-8");
       await setKeyPermissions(tempKeyPath);
@@ -47741,7 +47773,7 @@ var VaultKeyProvider = class {
       }
     }
     const secretId = `attest-it-${crypto22.randomUUID()}`;
-    await fs32.mkdir(path4.dirname(publicKeyPath), { recursive: true });
+    await fs32.mkdir(path3.dirname(publicKeyPath), { recursive: true });
     if (isSigningBackend(this.backend)) {
       await this.backend.generateSigningKey(secretId, DELEGATED_SIGNING_ALGORITHM);
       const { publicKeyPem } = await this.backend.getPublicKey(secretId);
@@ -47773,7 +47805,7 @@ var VaultKeyProvider = class {
 };
 function resolveLegacyPath(p) {
   if (p === "~" || p.startsWith("~/")) {
-    return path4.join(homedir3(), p.slice(1));
+    return path3.join(homedir3(), p.slice(1));
   }
   return p;
 }

--- a/schemas/v1/policy.schema.json
+++ b/schemas/v1/policy.schema.json
@@ -34,7 +34,7 @@
             },
             "sealsPath": {
               "type": "string",
-              "default": ".attest-it/seals.json"
+              "default": ".attest-it/seals/"
             }
           },
           "additionalProperties": false,
@@ -106,6 +106,10 @@
                 "type": "string",
                 "minLength": 1
               },
+              "kind": {
+                "type": "string",
+                "enum": ["single", "pattern"]
+              },
               "authorizedSigners": {
                 "type": "array",
                 "items": {
@@ -140,7 +144,7 @@
                 "type": "string"
               }
             },
-            "required": ["name", "description", "authorizedSigners", "fingerprint", "maxAge"],
+            "required": ["name", "description", "authorizedSigners", "fingerprint"],
             "additionalProperties": false
           }
         }

--- a/schemas/v1/seals.schema.json
+++ b/schemas/v1/seals.schema.json
@@ -21,6 +21,10 @@
                 "type": "string",
                 "minLength": 1
               },
+              "artifactPath": {
+                "type": "string",
+                "minLength": 1
+              },
               "fingerprint": {
                 "type": "string",
                 "pattern": "^sha256:[a-f0-9]+$"


### PR DESCRIPTION
## Summary

Introduces **per-artifact pattern gates** and makes gate `maxAge` **optional (default: never expires)**, per PRD R2. A gate may now declare `kind: pattern`, under which each file matched by the gate's fingerprint globs is fingerprinted and sealed **independently** — sealing one file says nothing about its siblings, a new matching file simply shows up as unsealed with no `policy.yaml` edit (and therefore no re-seal of unrelated files), and a one-byte change flips only that file. The historical `single` gate (one combined fingerprint, one seal) remains the default and is unchanged.

Refs #69

## Design decisions

- **Gate kind** is a `kind: 'single' | 'pattern'` discriminant on the gate (omitted → `single`), rather than inferring pattern-ness from glob shape. This keeps the model explicit and lets a single-file glob stay a single gate if desired.
- **Per-file fingerprinting** is a new exported `computeFingerprintsPerFile(Sync)` returning one `PerFileFingerprint` per matched file — the existing combined-mode `computeFingerprint` is untouched, so single-gate callers are unaffected. Each per-file fingerprint binds the file's path (`SHA256(normalizedPath + ":" + content)`), so symlink aliases of identical bytes produce **distinct** fingerprints and one file's seal can never authorize another.
- **Seal shape change is additive (minor, not major).** `Seal` gains an optional `artifactPath` identifying which file within a pattern gate a per-file seal covers. Single-gate seals are byte-identical to before (the field is omitted). No breaking change was required, so no major bump.
- **Per-file seals never route through the aggregate `writeSeals` path.** They are written with the low-level per-file writer (`writeSealFile`/`writeSealFileSync`) under an artifact path segment (`<gate>/<artifact>/<signer>.seal`) that **reuses #70's `slugifySegment`** for every segment. The aggregate one-per-gate read/write path deliberately **excludes** any seal carrying an `artifactPath` and **never prunes** those files, so per-file and single-gate seals coexist without the aggregate writer silently deleting them.
- **`status --json` determinism** (PRD Q5): a pattern gate's results are emitted one per matched file, ordered lexicographically by resolved path (the same ordering `computeFingerprint`/`sortFiles` already use), so repeated runs against unchanged state are stable.

## Acceptance criteria to tests

| Criterion (PRD R2 / issue) | Covered by test |
| --- | --- |
| A gate with no `maxAge` never expires (`verify`/`status` never report age-based failure) | `test/seal/verification.test.ts` -> "never reports STALE for a gate with NO maxAge..." (+ contrast test that the same ancient seal IS stale once `maxAge` is set) |
| Pattern gate yields independent per-file seals; sealing A says nothing about B | `test/seal/pattern-gate.test.ts` -> "sealing one file leaves its sibling unsealed (seal -> status -> verify)" |
| Changing one byte of a sealed file flips **only** that file | `test/seal/pattern-gate.test.ts` -> "changing one byte of a sealed file flips ONLY that file to invalid" |
| A new matching file shows as unsealed with **zero** config change | `test/seal/pattern-gate.test.ts` -> "a new file matching the pattern shows as unsealed with ZERO config change" |
| `status --json` deterministic ordering across runs (Q5) | `test/seal/pattern-gate.test.ts` -> "status --json ordering is deterministic across repeated runs" |
| **Regression:** single (non-pattern) gates behave exactly as before | `test/seal/pattern-gate.test.ts` -> "a single gate produces one combined seal with NO artifact segment"; plus the unchanged `test/api/operations.test.ts` suite |
| **Adversarial:** per-file independence cannot be gamed by symlink aliasing | `test/fingerprint.test.ts` -> "ADVERSARIAL: symlink aliases of the same content do NOT share a fingerprint" |
| Case-insensitive-FS distinctness for the **artifact** segment | `test/seal/storage.test.ts` -> "CASE-INSENSITIVE FS: artifact paths differing ONLY in case get DISTINCT files" |
| Per-file fingerprint mode returns one result per matched file, path-bound | `test/fingerprint.test.ts` -> `computeFingerprintsPerFile` suite (ordering, sync/async agreement, equals combined-of-one) |
| Optional `maxAge` / `pattern` kind accepted by schema; unknown kind rejected | `test/config/policy-schema.test.ts` -> "should accept a gate with NO maxAge", "should accept a pattern-kind gate", "should reject an unknown gate kind" |
| Aggregate write must not silently prune per-file seals | `test/seal/storage.test.ts` -> "aggregate write does NOT prune per-file pattern seals"; "aggregate read EXCLUDES per-file pattern seals" |

## Coexistence with #70 / #110 / #119

The #70 file-per-seal storage, root-gate (#110), and delegated-signing (#119) test suites (`conflict-free-merge`, `root-gate`, `delegated-signing`) stay green — per-file pattern seals extend the storage scheme additively with an artifact segment and are kept entirely outside the aggregate lifecycle.

## Docs / packaging

- `docs/configuration.md`: new **Gate Kinds** and **Optional `maxAge`** sections + a pattern-gate example; `kind`/`maxAge` reflected in the Gate Fields table.
- `README.md`: pattern-gate + optional-`maxAge` note in the gate concepts.
- Changeset: `@attest-it/core` (+ re-exporting umbrella `attest-it`) **minor** — additive gate schema, `Seal.artifactPath`, and new exports.
- Regenerated `schemas/v1/policy.schema.json` + `seals.schema.json` and `api-report/core.api.md` for the new surface.

## Verification

- `pnpm build`, `pnpm check` (api-report + eslint + types), and `pnpm test` all green across the workspace (808 tests).

## For the PM

- This lands the core + embeddable-API (`status`/`verifyOne`/`verifyAll`/`seal`/`fingerprint`) surface for pattern gates — the stable, path-keyed contract Toolsmith consumes and the JSON surface. The `attest-it status`/`verify` **CLI table renderer** still treats a pattern gate as one gate-keyed row (optional-`maxAge` already flows through it); wiring per-file rows into the CLI porcelain is a small, separable follow-up and is called out here rather than expanding this gate-model PR's surface.
- No forced breaking `Seal`-shape change was needed — kept additive/minor as instructed.
