### PR TITLE
fix(cli): make init --root-signer additive and guard --force against data loss

### DIFF
--- a/.changeset/init-root-signer-additive.md
+++ b/.changeset/init-root-signer-additive.md
@@ -1,0 +1,12 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+`init --root-signer` is now non-destructive, and `init --force` refuses to silently discard a populated config.
+
+Following the CLI's own printed "Next steps" could previously destroy configuration. After `init` → `team join`, the CLI recommends `attest-it init --root-signer <slug>`; if gates/suites already existed, the bare form failed ("Config already exists … Pass --force"), and the suggested `--force` then re-scaffolded `policy.yaml`/`config.yaml` from empty templates — wiping `gates:`/`suites:` and orphaning any existing seal — while still printing "Trust anchor established" and exiting 0.
+
+- **`init --root-signer <slug>` is now additive.** On an already-initialized repo it merges in only the `rootGate` (and the signer's `team` entry) and leaves existing `gates:`, `suites:`, `team:`, and seals untouched. It needs no `--force`.
+- **`init --force` (the full re-scaffold) refuses to silently empty a populated config.** When existing `gates:`/`suites:` would be discarded, it prints exactly what is at stake and requires an explicit confirmation; non-interactively it refuses rather than wiping.
+- **"Next steps" wording updated** so the recommended bootstrap sequence is safe and notes the root-signer step is non-destructive.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -279,6 +279,25 @@ async function runInit(options: InitOptions): Promise<void> {
     const policyPath = path.join(configDir, 'policy.yaml')
     const operationalPath = path.join(configDir, 'config.yaml')
 
+    // Additive trust-anchor bootstrap. Establishing a root signer on a repo
+    // that has already been initialized must NEVER re-scaffold from the empty
+    // template — doing so wipes existing `gates:`/`suites:` and orphans any
+    // seal, silently, while still printing "Trust anchor established" (issue
+    // #127). When --root-signer targets an existing policy.yaml, take a
+    // dedicated path that merges in only the rootGate + signer and leaves
+    // everything else untouched. This path needs no --force.
+    if (options.rootSigner !== undefined && fs.existsSync(policyPath)) {
+      await establishRootSignerOnExistingConfig(options.rootSigner, policyPath)
+      return
+    }
+
+    // Full (re-)scaffold path — fresh init, or an explicit --force overwrite.
+    // Guard first: the full re-scaffold writes empty templates, so it must
+    // refuse to silently discard a populated config. If existing gates/suites
+    // would be lost, print exactly what is at stake and require an explicit
+    // confirmation (never a silent wipe, even with --force). See issue #127.
+    await guardAgainstDestructiveRescaffold(options, policyPath, operationalPath)
+
     if (!(await confirmOverwrite(policyPath, options.force))) {
       error('Init cancelled')
       process.exit(ExitCode.CANCELLED)
@@ -326,8 +345,12 @@ async function runInit(options: InitOptions): Promise<void> {
     } else {
       log("  2. Run: attest-it identity create  (if you haven't already)")
       log('  3. Run: attest-it team join')
-      log('  4. Bootstrap the trust anchor: attest-it init --root-signer <your-identity-slug>')
-      log(`  5. Edit ${policyPath} to define your gates, and ${operationalPath} to define suites`)
+      log(`  4. Edit ${policyPath} to define your gates, and ${operationalPath} to define suites`)
+      log('  5. Bootstrap the trust anchor: attest-it init --root-signer <your-identity-slug>')
+      log(
+        '     (safe to run at any time — it merges in the root gate and leaves your ' +
+          'existing gates, suites, and seals untouched)',
+      )
     }
 
     // Offer to install shell completions
@@ -335,6 +358,143 @@ async function runInit(options: InitOptions): Promise<void> {
   } catch (err) {
     handlePromptableError(err, ExitCode.CONFIG_ERROR)
   }
+}
+
+/**
+ * Read the keys of a top-level map section (e.g. `gates`, `suites`) from a
+ * YAML config file, returning `[]` when the file is absent, unparseable, or the
+ * section is missing/empty. Used to detect whether a re-scaffold would discard
+ * real user data. See issue #127.
+ *
+ * @param filePath - Absolute path to the YAML config file.
+ * @param section - Top-level map key to inspect (a fixed literal, never user input).
+ */
+function readSectionKeys(filePath: string, section: 'gates' | 'suites'): string[] {
+  if (!fs.existsSync(filePath)) {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = parseYaml(fs.readFileSync(filePath, 'utf8'))
+  } catch {
+    // A malformed existing file has no recoverable sections to protect.
+    return []
+  }
+  if (!isPlainRecord(parsed)) {
+    return []
+  }
+  // `section` is one of two hard-coded literals, not attacker-controlled.
+  // eslint-disable-next-line security/detect-object-injection
+  const value = parsed[section]
+  return isPlainRecord(value) ? Object.keys(value) : []
+}
+
+/**
+ * Refuse to let the full re-scaffold silently empty a populated config.
+ *
+ * The default `init` path (and `init --force`) overwrites `policy.yaml` and
+ * `config.yaml` with empty templates. If either file already defines
+ * `gates:`/`suites:`, that overwrite is destructive: it wipes trust/operational
+ * data and orphans any seal. This guard detects that case, prints exactly what
+ * would be lost, and requires an explicit confirmation — a `--force` flag alone
+ * is never enough to discard real data non-interactively. See issue #127.
+ *
+ * @throws Error when a populated config would be discarded and no interactive
+ * terminal is available to confirm the destructive overwrite.
+ */
+async function guardAgainstDestructiveRescaffold(
+  options: InitOptions,
+  policyPath: string,
+  operationalPath: string,
+): Promise<void> {
+  const gateKeys = readSectionKeys(policyPath, 'gates')
+  const suiteKeys = readSectionKeys(operationalPath, 'suites')
+  if (gateKeys.length === 0 && suiteKeys.length === 0) {
+    return
+  }
+
+  warn('Re-scaffolding from the empty template would DISCARD existing configuration:')
+  if (gateKeys.length > 0) {
+    log(`  policy.yaml gates:  ${gateKeys.join(', ')}`)
+  }
+  if (suiteKeys.length > 0) {
+    log(`  config.yaml suites: ${suiteKeys.join(', ')}`)
+  }
+  log('')
+  log('To establish a root signer without touching this config, run the non-destructive path:')
+  log('  attest-it init --root-signer <your-identity-slug>')
+  log('')
+
+  if (!isInteractiveTTY()) {
+    throw new Error(
+      'Refusing to re-scaffold over a populated config: this would discard the gates/suites ' +
+        'listed above and orphan any seal. Re-run in an interactive terminal to confirm the ' +
+        'overwrite, or use "attest-it init --root-signer <slug>" to establish a root signer ' +
+        'non-destructively.',
+    )
+  }
+
+  const confirmed = await confirmAction({
+    message: 'Overwrite and permanently discard the gates/suites listed above',
+    default: false,
+  })
+  if (!confirmed) {
+    error('Init cancelled')
+    process.exit(ExitCode.CANCELLED)
+  }
+}
+
+/**
+ * Resolve and validate the active local identity that will act as root signer.
+ *
+ * The bootstrapping signer must be the operator's active local identity, since
+ * only that identity's private key can create the anchoring seal. Throws with an
+ * actionable message when no active identity exists or when `rootSigner` names a
+ * different identity.
+ */
+function resolveBootstrapIdentity(rootSigner: string): {
+  identity: Identity
+  identitySlug: string
+} {
+  const localConfig = loadLocalConfigSync()
+  const identity = localConfig ? getActiveIdentity(localConfig) : undefined
+  const identitySlug = localConfig?.activeIdentity
+  if (!identity || !identitySlug) {
+    throw new Error(
+      'Cannot bootstrap the root gate: no active local identity found. ' +
+        'Run "attest-it identity create" first.',
+    )
+  }
+  if (rootSigner !== identitySlug) {
+    throw new Error(
+      `--root-signer '${rootSigner}' does not match your active identity ` +
+        `'${identitySlug}'. The bootstrapping signer must be an identity you hold the ` +
+        'private key for, so that it can create the anchoring seal.',
+    )
+  }
+  return { identity, identitySlug }
+}
+
+/**
+ * Establish a root signer on an already-initialized repository, additively.
+ *
+ * This is the non-destructive counterpart to the full scaffold: it merges only
+ * the `rootGate` (and the signer's `team` entry) into the existing
+ * `policy.yaml` and creates the anchoring seal, leaving existing `gates:`,
+ * `suites:`, `team:`, and any prior seals untouched. It requires no `--force`.
+ * See issue #127.
+ */
+async function establishRootSignerOnExistingConfig(
+  rootSigner: string,
+  policyPath: string,
+): Promise<void> {
+  const { identity, identitySlug } = resolveBootstrapIdentity(rootSigner)
+  await bootstrapRootGate(identity, identitySlug, policyPath)
+
+  log('')
+  log('Next steps:')
+  log(`  1. Review the updated ${policyPath} and commit it on your default branch`)
+  log('  2. Run: attest-it verify')
 }
 
 /**
@@ -355,20 +515,8 @@ async function maybeBootstrapRootGate(options: InitOptions, policyPath: string):
 
   // Explicit flag path.
   if (options.rootSigner !== undefined) {
-    if (!identity || !identitySlug) {
-      throw new Error(
-        'Cannot bootstrap the root gate: no active local identity found. ' +
-          'Run "attest-it identity create" first.',
-      )
-    }
-    if (options.rootSigner !== identitySlug) {
-      throw new Error(
-        `--root-signer '${options.rootSigner}' does not match your active identity ` +
-          `'${identitySlug}'. The bootstrapping signer must be an identity you hold the ` +
-          'private key for, so that it can create the anchoring seal.',
-      )
-    }
-    await bootstrapRootGate(identity, identitySlug, policyPath)
+    const resolved = resolveBootstrapIdentity(options.rootSigner)
+    await bootstrapRootGate(resolved.identity, resolved.identitySlug, policyPath)
     return true
   }
 

--- a/packages/cli/test/integration/init-root-signer-additive.integration.test.ts
+++ b/packages/cli/test/integration/init-root-signer-additive.integration.test.ts
@@ -1,0 +1,279 @@
+/**
+ * End-to-end UAT for the non-destructive `init --root-signer` path and the
+ * `init --force` data-loss guard (issue #127).
+ *
+ * Drives the real, built CLI as subprocesses with stdin fully closed
+ * (mirroring `< /dev/null`), reproducing the exact DX wave-1 sequence that
+ * caused silent data loss:
+ *
+ *   identity create -> init -> team join -> hand-add a gate + suite ->
+ *   run --suite --yes (seal) -> init --root-signer <slug>
+ *
+ * Before the fix, the final step required `--force` and then re-scaffolded
+ * `policy.yaml`/`config.yaml` from empty templates — wiping `gates:`/`suites:`
+ * and orphaning the seal — while printing "Trust anchor established" and
+ * exiting 0. This suite asserts the corrected behavior: the root-signer step
+ * succeeds WITHOUT `--force` and leaves gates, suites, and the seal intact, and
+ * a full `--force` re-scaffold refuses to silently discard a populated config.
+ *
+ * @see Issue #127 acceptance criteria
+ * @see docs/getting-started.md (the walkthrough this sequence mirrors)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+
+const CLI_CALL_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run the built CLI as a real subprocess with stdin closed and a hard timeout.
+ * A hang here would mean an undocumented prompt slipped through despite there
+ * being no TTY — exactly the failure mode this issue also guards against.
+ */
+function runCliNonInteractive(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(CLI_CALL_TIMEOUT_MS)}ms — likely an ` +
+            `undocumented prompt with no TTY available: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+async function runGit(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', args, { cwd, stdio: 'ignore' })
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`git ${args.join(' ')} exited with code ${String(code)}`))
+      }
+    })
+    child.on('error', reject)
+  })
+}
+
+function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/** Parse `<project>/.attest-it/<file>` and return it as a record. */
+function readAttestConfig(projectDir: string, file: string): Record<string, unknown> {
+  const parsed: unknown = parseYaml(
+    fs.readFileSync(path.join(projectDir, '.attest-it', file), 'utf8'),
+  )
+  if (!isRecordOfUnknown(parsed)) {
+    throw new Error(`Expected ${file} to parse to an object`)
+  }
+  return parsed
+}
+
+/**
+ * Drive the shared setup: a real git repo, a `file`-backed identity, `init`, a
+ * hand-added gate + suite, `team join`, a commit, and a real seal via
+ * `run --suite`. Returns the project dir left in the trust-anchored-but-for-the
+ * -root-gate state that the reported repro reaches just before the destructive
+ * `init --root-signer` call.
+ */
+async function scaffoldSealedProject(projectDir: string, env: NodeJS.ProcessEnv): Promise<void> {
+  await fs.promises.writeFile(
+    path.join(projectDir, 'package.json'),
+    JSON.stringify({ dependencies: {} }, null, 2),
+  )
+  await fs.promises.mkdir(path.join(projectDir, 'src'), { recursive: true })
+  await fs.promises.writeFile(path.join(projectDir, 'src', 'index.ts'), 'export const x = 1\n')
+  await runGit(['init'], projectDir)
+  await runGit(['config', 'user.email', 'test@example.com'], projectDir)
+  await runGit(['config', 'user.name', 'Test User'], projectDir)
+
+  const createResult = await runCliNonInteractive(
+    ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+    projectDir,
+    env,
+  )
+  expect(createResult.exitCode).toBe(0)
+
+  const initResult = await runCliNonInteractive(['init'], projectDir, env)
+  expect(initResult.exitCode).toBe(0)
+
+  // Hand-add a gate (policy.yaml) and a suite (config.yaml) — the documented
+  // manual-edit step of the getting-started walkthrough.
+  const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+  await fs.promises.writeFile(
+    policyPath,
+    stringifyYaml({
+      version: 1,
+      settings: { maxAgeDays: 30 },
+      team: {},
+      gates: {
+        smoke: {
+          name: 'Smoke Test',
+          description: 'A trivial gate for the getting-started flow',
+          authorizedSigners: ['test-user'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      },
+    }),
+    'utf8',
+  )
+  const configPath = path.join(projectDir, '.attest-it', 'config.yaml')
+  await fs.promises.writeFile(
+    configPath,
+    stringifyYaml({
+      version: 1,
+      settings: {},
+      suites: { smoke: { gate: 'smoke', command: 'true' } },
+    }),
+    'utf8',
+  )
+
+  const joinResult = await runCliNonInteractive(
+    ['team', 'join', '--gates', 'smoke'],
+    projectDir,
+    env,
+  )
+  expect(joinResult.exitCode).toBe(0)
+
+  await runGit(['add', '.'], projectDir)
+  await runGit(['commit', '-m', 'configure gate, suite, and team'], projectDir)
+
+  const runResult = await runCliNonInteractive(
+    ['run', '--suite', 'smoke', '--yes'],
+    projectDir,
+    env,
+  )
+  expect(runResult.exitCode).toBe(0)
+  expect(runResult.stdout).toContain("Seal created for gate 'smoke'")
+}
+
+describe('init --root-signer is additive; init --force refuses silent data loss (issue #127)', () => {
+  let projectDir: string
+  let homeDir: string
+  let env: NodeJS.ProcessEnv
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-127-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-127-home-'))
+    // Isolate both attest-it's home and VaultKeeper's `file` backend to the
+    // temp home so the real `~/.config` is never touched (issue #114).
+    env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  it(
+    'AC1: init --root-signer on a populated repo succeeds WITHOUT --force and leaves ' +
+      'gates, suites, and the existing seal intact, with verify passing',
+    async () => {
+      await scaffoldSealedProject(projectDir, env)
+
+      // The reported repro's failing step: the CLI's own "Next steps" tells the
+      // user to run exactly this. Pre-fix it exited non-zero ("Pass --force")
+      // and, with --force, wiped gates/suites. Post-fix it must succeed as-is.
+      const rootSignerResult = await runCliNonInteractive(
+        ['init', '--root-signer', 'test-user'],
+        projectDir,
+        env,
+      )
+      expect(rootSignerResult.exitCode).toBe(0)
+      expect(rootSignerResult.stdout).toContain('Trust anchor established')
+
+      // Gates survived in policy.yaml.
+      const policy = readAttestConfig(projectDir, 'policy.yaml')
+      expect(isRecordOfUnknown(policy.gates) && 'smoke' in policy.gates).toBe(true)
+      // The root gate was merged in additively.
+      expect(isRecordOfUnknown(policy.rootGate)).toBe(true)
+      // The pre-existing team member survived.
+      expect(isRecordOfUnknown(policy.team) && 'test-user' in policy.team).toBe(true)
+
+      // Suites survived in config.yaml.
+      const config = readAttestConfig(projectDir, 'config.yaml')
+      expect(isRecordOfUnknown(config.suites) && 'smoke' in config.suites).toBe(true)
+
+      // The smoke seal survived (it was NOT orphaned by a re-scaffold). Seals
+      // live one file per (gate, signer) under `<seals>/<gateSlug>/<signer>.seal`
+      // where each path segment is `<readable>-<hash>`, so match by prefix.
+      const sealsDir = path.join(projectDir, '.attest-it', 'seals')
+      const gateDirs = fs.readdirSync(sealsDir)
+      expect(gateDirs.some((d) => d.startsWith('smoke-'))).toBe(true)
+
+      // The end state the reported repro never reached: verify passes.
+      const verifyResult = await runCliNonInteractive(['verify'], projectDir, env)
+      expect(verifyResult.exitCode).toBe(0)
+      expect(verifyResult.stdout).toContain('All gate seals valid')
+    },
+    CLI_CALL_TIMEOUT_MS * 8,
+  )
+
+  it(
+    'AC2: init --force refuses to silently discard a non-empty gates:/suites: config',
+    async () => {
+      await scaffoldSealedProject(projectDir, env)
+
+      // A full re-scaffold with --force must NOT silently empty the populated
+      // config. Non-interactively (no TTY to confirm), it must refuse.
+      const forceResult = await runCliNonInteractive(['init', '--force'], projectDir, env)
+      expect(forceResult.exitCode).not.toBe(0)
+      expect(forceResult.stderr).toMatch(/Refusing to re-scaffold over a populated config/)
+
+      // The config was left completely untouched — this is the whole point.
+      const policy = readAttestConfig(projectDir, 'policy.yaml')
+      expect(isRecordOfUnknown(policy.gates) && 'smoke' in policy.gates).toBe(true)
+      const config = readAttestConfig(projectDir, 'config.yaml')
+      expect(isRecordOfUnknown(config.suites) && 'smoke' in config.suites).toBe(true)
+    },
+    CLI_CALL_TIMEOUT_MS * 8,
+  )
+})


### PR DESCRIPTION
## Summary

Following the CLI's own printed "Next steps" could **silently destroy configuration**. After `init` -> `team join`, the CLI recommends `attest-it init --root-signer <slug>`. If gates/suites already existed, the bare form failed (`Config already exists ... Pass --force`), and the suggested `--force` then **re-scaffolded `policy.yaml`/`config.yaml` from empty templates** -- wiping `gates:`/`suites:` and orphaning any existing seal -- while still printing `Trust anchor established`, exiting 0, with no warning. `verify`/`status` then failed exit 3 (`suites: At least one suite must be defined`).

This PR takes the additive path (the right one) and hardens `--force`.

## Behavior change

- **`init --root-signer <slug>` is now additive and needs no `--force`.** On an already-initialized repo it merges in only the `rootGate` (and the signer's `team` entry) and leaves existing `gates:`, `suites:`, `team:`, and seals untouched. Bootstrapping a root signer never re-scaffolds existing config. When `policy.yaml` does not yet exist, `--root-signer` still scaffolds + bootstraps as before.
- **`init --force` (the full re-scaffold) refuses to silently empty a populated config.** When existing `gates:`/`suites:` would be discarded it prints exactly what is at stake and requires an explicit confirmation; non-interactively (no TTY) it **refuses** rather than wiping, and points at the non-destructive `--root-signer` path.
- **"Next steps" wording updated** so the recommended sequence is non-destructive (defines gates/suites before the root-signer bootstrap, and notes the bootstrap is safe to run at any time).

### `init` on a populated config (before -> after)

```diff
- $ attest-it init --root-signer x --force
- Trust anchor established: 'x' is the root signer      # exit 0, gates/suites WIPED
+ $ attest-it init --root-signer x
+ Trust anchor established: 'x' is the root signer      # exit 0, gates/suites/seal INTACT, no --force needed
+
+ $ attest-it init --force            # (full re-scaffold over a populated config)
+ Re-scaffolding from the empty template would DISCARD existing configuration:
+   policy.yaml gates:  smoke
+   config.yaml suites: smoke
+ Error: Refusing to re-scaffold over a populated config ...   # exit non-zero, config untouched
```

## Note on scaffold `sealsPath`

The task also called for changing the init scaffold's default `sealsPath` from `.attest-it/seals.json` to the directory form `.attest-it/seals/`. That change already landed on `main` in #121 (commit `39b3f22`) -- `init.ts` and the policy schema default are already `.attest-it/seals/`, and no `.attest-it/seals.json` remains in the init scaffold. No further change was needed here. (The doc examples are handled separately in #132.)

## Acceptance criteria -> tests

New UAT suite `packages/cli/test/integration/init-root-signer-additive.integration.test.ts` drives the **real, built CLI as subprocesses** with a temp `ATTEST_IT_HOME` and an isolated VaultKeeper `file` dir, reproducing the exact reported sequence.

- **Criterion 1** (establishing a root signer is non-destructive; needs no `--force`) -- covered by test `AC1: init --root-signer on a populated repo succeeds WITHOUT --force and leaves gates, suites, and the existing seal intact, with verify passing`. Runs `identity create -> init -> team join -> hand-add gate + suite -> run --suite --yes (seal) -> init --root-signer <slug>` and asserts exit 0, gates/suites/team/rootGate/seal all intact, and `verify` passing.
- **Criterion 2** (`init --force` refuses to discard a non-empty `gates:`/`suites:`) -- covered by test `AC2: init --force refuses to silently discard a non-empty gates:/suites: config`, which asserts non-zero exit, the refusal message, and that the config is left intact.
- **Criterion 3** ("Next steps" no longer steers into the destructive path) -- the recommended `init --root-signer` is now the additive path (Criterion 1), and the printed wording was reordered/annotated accordingly.
- **Criterion 4** (CLI-layer regression test: the full sequence ends with gates/suites intact and `verify` passing) -- this is exactly what test AC1 asserts.

Both new tests **fail against pre-fix code** (verified by reverting `init.ts` to `origin/main`) and pass with the fix. Full CLI suite: 810 passing.

## Owner gate

PM-review before merge (touches init/config and the trust bootstrap). **Do not merge** without PM sign-off.

Refs #127
