### PR TITLE
feat(core): enforce root gate in embeddable verifyOne/verifyAll

### DIFF
--- a/.changeset/embeddable-root-gate-enforcement.md
+++ b/.changeset/embeddable-root-gate-enforcement.md
@@ -1,0 +1,33 @@
+---
+'@attest-it/core': minor
+'attest-it': minor
+---
+
+Enforce the root gate in the embeddable API (`verifyOne`/`verifyAll`).
+
+Previously the embeddable `@attest-it/core` surface performed only per-gate seal
+verification and skipped root-gate trust anchoring entirely — so an embedder
+(the surface used for custom / non-GitHub CI) got no protection against a policy
+that self-authorizes by rewriting `rootGate.authorizedSigners`/`team` and
+self-sealing. Only the CLI `verify` and the GitHub Action wired in the root-gate
+pre-step.
+
+`verifyOne`/`verifyAll` now run the same mandatory root-gate pre-step before
+evaluating any gate: they verify the working-tree policy's own root seal against
+a caller-supplied **trusted** policy source and fail closed with an
+`untrusted-config` result when that seal does not verify (e.g. a self-added root
+signer → `UNKNOWN_SIGNER`; an unsealed policy change → `FINGERPRINT_MISMATCH`).
+
+- New `VerifyOptions` (a superset of `ApiOptions`) carries the trusted source:
+  `trustedConfig` (a pre-loaded base-branch `AttestItConfig`, takes precedence)
+  or `trustedPolicyPath` (a path to a trusted policy file). `verifyOne`/
+  `verifyAll` now accept `VerifyOptions`.
+- **Fail closed:** if the working-tree policy defines a `rootGate` but no trusted
+  source is supplied, verification returns `untrusted-config` rather than
+  silently trusting the working-tree anchor.
+- Un-anchored repositories (no `rootGate`) verify unchanged — no trusted source
+  is required (backward compatible).
+
+Additive and backward-compatible: `VerifyOptions` extends `ApiOptions`, so
+existing `{ baseDir }` callers keep working. The `untrusted-config` failure class
+(previously a documented stub) is now returned at runtime.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -18,27 +18,41 @@ contract**: see [Schema versioning](#schema-versioning-and-breaking-changes).
 All operations are asynchronous and accept an optional `{ baseDir }` (defaulting
 to `process.cwd()`) so an embedder can point them at a checked-out worktree.
 
-| Operation     | Signature                                | Returns                             |
-| ------------- | ---------------------------------------- | ----------------------------------- |
-| `listGates`   | `listGates(options?)`                    | `ListGatesResult \| ApiFailure`     |
-| `status`      | `status(paths?, options?)`               | `StatusResult \| ApiFailure`        |
-| `fingerprint` | `fingerprint(path, options?)`            | `FingerprintResultOk \| ApiFailure` |
-| `seal`        | `seal(path, { identity }, options?)`     | `SealResult \| ApiFailure`          |
-| `verifyOne`   | `verifyOne(path, options?)`              | `VerificationSuccess \| ApiFailure` |
-| `verifyAll`   | `verifyAll({ changedSince? }, options?)` | `VerifyAllResult \| ApiFailure`     |
+| Operation     | Signature                                      | Returns                             |
+| ------------- | ---------------------------------------------- | ----------------------------------- |
+| `listGates`   | `listGates(options?)`                          | `ListGatesResult \| ApiFailure`     |
+| `status`      | `status(paths?, options?)`                     | `StatusResult \| ApiFailure`        |
+| `fingerprint` | `fingerprint(path, options?)`                  | `FingerprintResultOk \| ApiFailure` |
+| `seal`        | `seal(path, { identity }, options?)`           | `SealResult \| ApiFailure`          |
+| `verifyOne`   | `verifyOne(path, verifyOptions?)`              | `VerificationSuccess \| ApiFailure` |
+| `verifyAll`   | `verifyAll({ changedSince? }, verifyOptions?)` | `VerifyAllResult \| ApiFailure`     |
+
+> `verifyOne`/`verifyAll` take a `VerifyOptions` (a superset of `ApiOptions`)
+> that also carries the **trusted policy source** for root-gate enforcement — see
+> [Root-gate trust anchoring](#root-gate-trust-anchoring-required-for-anchored-repos).
 
 ```ts
-import { listGates, seal, verifyOne } from '@attest-it/core'
+import { listGates, seal, verifyOne, loadSplitConfig } from '@attest-it/core'
 
 const opts = { baseDir: '/path/to/repo' }
 
 const gates = await listGates(opts)
 const sealed = await seal('src/tool.ts', { identity: 'alice' }, opts)
-const verdict = await verifyOne('src/tool.ts', opts)
+
+// Trust-anchored verify: supply the TRUSTED policy source (see below) so the
+// root gate is enforced. An embedder owns git, so it loads the base-branch
+// policy however it likes and passes it as `trustedConfig`.
+const trustedConfig = await loadSplitConfig({ baseDir: '/path/to/base-branch-checkout' })
+const verdict = await verifyOne('src/tool.ts', { ...opts, trustedConfig })
 if (verdict.ok) {
-  // validly attested
+  // validly attested against a trust-anchored policy
 } else {
   switch (verdict.failureClass) {
+    case 'untrusted-config':
+      // the working-tree policy's own root seal did not verify against the
+      // trusted anchor (e.g. a branch self-added a root signer), OR a rootGate
+      // is present but no trusted source was supplied. Fail closed.
+      break
     case 'unsealed':
       /* … */ break
     // …
@@ -61,6 +75,52 @@ A path governed by **no** gate, or by **more than one** gate, is reported as a
 `malformed` failure (the request cannot be unambiguously satisfied). In a
 well-formed configuration each governed artifact belongs to exactly one gate.
 
+## Root-gate trust anchoring (required for anchored repos)
+
+`verifyOne`/`verifyAll` enforce the **root gate** before evaluating any gate —
+the same trust-anchored authorization the GitHub Action enforces. A repository
+that has run the `attest-it init` bootstrap ceremony has a top-level `rootGate`
+that seals `.attest-it/policy.yaml` itself: the trust-critical policy (team and
+gate authorization) can only change under a seal from an existing **root
+signer**. This is what stops a branch (or an agent) from self-authorizing by
+rewriting `rootGate.authorizedSigners`/`team` to a key it controls and
+self-sealing.
+
+Unlike the Action, an in-process embedder has no implicit "base branch", so it
+must name the **trusted policy source** the root gate is evaluated against, via
+`VerifyOptions`:
+
+| Field               | Meaning                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `trustedConfig`     | A pre-loaded, trusted `AttestItConfig` (e.g. the base-branch policy the embedder loaded). Takes precedence. |
+| `trustedPolicyPath` | Filesystem path to a trusted policy file (e.g. a base-branch checkout's `.attest-it/policy.yaml`).          |
+
+The working-tree policy's root seal is verified against the trusted source's
+`rootGate.authorizedSigners`/`team`. A branch that self-added a root signer is
+rejected `untrusted-config` (`UNKNOWN_SIGNER` — the trusted anchor does not list
+it); a policy changed without a fresh root seal is rejected `untrusted-config`
+(`FINGERPRINT_MISMATCH`). Once the root seal verifies, gates evaluate against the
+now-trusted working-tree config.
+
+**Fail closed:** if the working-tree policy defines a `rootGate` and **neither**
+`trustedConfig` nor `trustedPolicyPath` is supplied, verification returns an
+`untrusted-config` failure — it never silently trusts the working-tree anchor. A
+repository with **no** `rootGate` (not yet bootstrapped) needs no trusted source
+and verifies unchanged (backward compatible).
+
+```ts
+import { verifyAll, loadSplitConfig } from '@attest-it/core'
+
+// The embedder loads the trusted base-branch policy however it likes (it owns
+// git); attest-it never shells out to git itself.
+const trustedConfig = await loadSplitConfig({ baseDir: '/checkout/of/base' })
+
+const result = await verifyAll({}, { baseDir: '/checkout/of/pr', trustedConfig })
+if (!result.ok && result.failureClass === 'untrusted-config') {
+  // The PR's policy is not authorized by a trusted root signer — reject.
+}
+```
+
 ## The result envelope
 
 Every result is a discriminated union on `ok`, and every result carries a
@@ -77,14 +137,14 @@ pattern-match rather than catch.
 
 ## Failure taxonomy
 
-| Class                  | Meaning                                                                                                                                           |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `unsealed`             | The artifact is governed by a gate, but no seal exists for it.                                                                                    |
-| `fingerprint-mismatch` | A seal exists, but the artifact's content changed since it was sealed.                                                                            |
-| `unauthorized-signer`  | The seal's signer is not authorized for the gate, or the signature does not verify against an authorized key.                                     |
-| `untrusted-config`     | The policy/config defining trust is not itself anchored to a trusted root. _(See the stub note below.)_                                           |
-| `expired`              | A valid seal exists but is older than the gate's `maxAge`.                                                                                        |
-| `malformed`            | The input or on-disk state cannot be interpreted: an unparseable config, a structurally-invalid seal, or a path governed by no gate (or several). |
+| Class                  | Meaning                                                                                                                                                                                                                                             |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `unsealed`             | The artifact is governed by a gate, but no seal exists for it.                                                                                                                                                                                      |
+| `fingerprint-mismatch` | A seal exists, but the artifact's content changed since it was sealed.                                                                                                                                                                              |
+| `unauthorized-signer`  | The seal's signer is not authorized for the gate, or the signature does not verify against an authorized key.                                                                                                                                       |
+| `untrusted-config`     | The working-tree policy defines a `rootGate` but its own root seal does not verify against the supplied trusted anchor, or no trusted source was supplied. See [Root-gate trust anchoring](#root-gate-trust-anchoring-required-for-anchored-repos). |
+| `expired`              | A valid seal exists but is older than the gate's `maxAge`.                                                                                                                                                                                          |
+| `malformed`            | The input or on-disk state cannot be interpreted: an unparseable config, a structurally-invalid seal, or a path governed by no gate (or several).                                                                                                   |
 
 This reconciles the lower-level `VerificationState` enum
 (`VALID`/`MISSING`/`STALE`/`FINGERPRINT_MISMATCH`/`INVALID_SIGNATURE`/`UNKNOWN_SIGNER`)
@@ -93,15 +153,6 @@ into the taxonomy: `MISSING → unsealed`, `STALE → expired`,
 `UNKNOWN_SIGNER → unauthorized-signer` (a signature that does not verify cannot
 establish an authorized human signer). The original state is preserved on the
 failure as `underlyingState`.
-
-### `untrusted-config` is a documented stub
-
-Root-gate trust anchoring is not yet implemented. The `untrusted-config` class,
-its documented shape, and the wiring that would return it are in place now so
-the contract is stable, but the underlying check currently treats every
-successfully-loaded config as trusted, so the class is never returned at runtime
-yet. Completing the trust-anchoring work fills in the check **without changing
-this contract**.
 
 ## Non-interactive by construction
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -102,11 +102,18 @@ it); a policy changed without a fresh root seal is rejected `untrusted-config`
 (`FINGERPRINT_MISMATCH`). Once the root seal verifies, gates evaluate against the
 now-trusted working-tree config.
 
+**The trusted anchor — not the working tree — decides whether the root gate is
+enforced.** If the supplied trusted policy defines a `rootGate`, the pre-step runs
+regardless of what the working-tree policy declares. A branch cannot escape
+enforcement by **deleting** `rootGate` from its own `policy.yaml` and
+self-authorizing a gate: with no matching root seal over the tampered policy, the
+pre-step rejects it `untrusted-config` (`MISSING`/`FINGERPRINT_MISMATCH`).
+
 **Fail closed:** if the working-tree policy defines a `rootGate` and **neither**
 `trustedConfig` nor `trustedPolicyPath` is supplied, verification returns an
 `untrusted-config` failure — it never silently trusts the working-tree anchor. A
-repository with **no** `rootGate` (not yet bootstrapped) needs no trusted source
-and verifies unchanged (backward compatible).
+repository with **no** `rootGate` and no trusted source (not yet bootstrapped)
+needs no anchor and verifies unchanged (backward compatible).
 
 ```ts
 import { verifyAll, loadSplitConfig } from '@attest-it/core'

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -1200,7 +1200,7 @@ export interface VerificationSuccess extends ApiResultBase {
 export function verify(options: CryptoVerifyOptions): Promise<boolean>;
 
 // @public
-export function verifyAll(params?: VerifyAllParams, options?: ApiOptions): Promise<ApiFailure | VerifyAllResult>;
+export function verifyAll(params?: VerifyAllParams, options?: VerifyOptions): Promise<ApiFailure | VerifyAllResult>;
 
 // @public
 export interface VerifyAllParams {
@@ -1223,7 +1223,13 @@ export function verifyEd25519(data: Buffer | string, signature: string, publicKe
 export function verifyGateSeal(config: AttestItConfig, gateId: string, seals: SealsFile, currentFingerprint: string): SealVerificationResult;
 
 // @public
-export function verifyOne(artifactPath: string, options?: ApiOptions): Promise<ArtifactVerification>;
+export function verifyOne(artifactPath: string, options?: VerifyOptions): Promise<ArtifactVerification>;
+
+// @public
+export interface VerifyOptions extends ApiOptions {
+    trustedConfig?: AttestItConfig;
+    trustedPolicyPath?: string;
+}
 
 // @public
 export function verifyPatternArtifactSeal(config: AttestItConfig, gateId: string, artifactPath: string, seal: Seal | undefined, currentFingerprint: string, maxAge: string | undefined): SealVerificationResult;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -19,6 +19,7 @@ export {
   type ApiResultBase,
   type ApiFailure,
   type ApiOptions,
+  type VerifyOptions,
   type GateDescriptor,
   type ListGatesResult,
   type FingerprintResultOk,

--- a/packages/core/src/api/operations.ts
+++ b/packages/core/src/api/operations.ts
@@ -130,41 +130,68 @@ async function resolveTrustedConfig(
  * may proceed, or an {@link ApiFailure} (`untrusted-config`, or `malformed` for
  * an unreadable seal/policy state) that the caller must surface as the verdict.
  *
+ * The enforcement decision is gated on the **trusted** anchor, never on the
+ * untrusted working-tree config. If we short-circuited on the working tree's own
+ * `rootGate`, an attacker could simply **delete** `rootGate` from their branch's
+ * `policy.yaml`, self-authorize a gate, and skip enforcement entirely — a trust
+ * bypass. So we resolve the trusted source first and let *its* `rootGate` decide
+ * whether the pre-step runs, regardless of what the working tree still declares.
+ *
  * Fail-closed semantics:
- * - Working-tree policy defines **no** `rootGate` → the repository predates the
- *   bootstrap ceremony; there is no trust anchor to check, so evaluation
- *   proceeds unchanged (backward compatible), exactly as the CLI/Action treat
- *   an un-anchored repo (`NOT_ANCHORED`, non-blocking).
- * - Working-tree policy defines a `rootGate` but no trusted source was supplied
- *   → `untrusted-config` (never a silent pass).
- * - The working-tree policy's root seal does not verify against the trusted
- *   anchor (e.g. a branch self-added a root signer and self-sealed → the trusted
- *   anchor does not list it → `UNKNOWN_SIGNER`; or the policy changed without a
- *   fresh root seal → `FINGERPRINT_MISMATCH`) → `untrusted-config`, carrying the
- *   precise, non-generic root-gate message that NAMES the untrusted change.
- * - The root seal verifies (`VALID`/`STALE`) → proceed; gates then evaluate
- *   against the now-trusted working-tree config.
+ * - No trusted source supplied **and** the working-tree policy has no `rootGate`
+ *   → a genuinely un-anchored repo (predates the bootstrap ceremony); there is
+ *   nothing to verify, so evaluation proceeds unchanged (backward compatible),
+ *   exactly as the CLI/Action treat an un-anchored repo (`NOT_ANCHORED`,
+ *   non-blocking). This is the ONLY skip path when no trusted source is given.
+ * - No trusted source supplied **but** the working-tree policy declares a
+ *   `rootGate` → we cannot verify that claim against a trusted root →
+ *   `untrusted-config` (never a silent pass).
+ * - Trusted source supplied and its policy defines a `rootGate` → verify the
+ *   working-tree policy's root seal against the trusted anchor REGARDLESS of
+ *   whether the working tree still declares a `rootGate`. A working tree that
+ *   deleted `rootGate` (or changed the policy) has no matching root seal →
+ *   `MISSING`/`FINGERPRINT_MISMATCH`; a self-added signer → `UNKNOWN_SIGNER` —
+ *   all `untrusted-config`, carrying the precise root-gate message.
+ * - Trusted source supplied but its policy has no `rootGate` → the trusted
+ *   anchor itself is not anchored; there is nothing to protect, so evaluation
+ *   proceeds (mirrors the Action skipping the pre-step when the base branch has
+ *   no `rootGate`).
+ * - The working-tree root seal verifies (`VALID`/`STALE`) → proceed; gates then
+ *   evaluate against the now-trusted working-tree config.
  */
 async function enforceRootGate(
   config: AttestItConfig,
   baseDir: string,
   options: VerifyOptions,
 ): Promise<ApiFailure | null> {
-  // Un-anchored repo: nothing to anchor against. Proceed (backward compatible).
-  if (!config.rootGate) {
+  const trustedSourceSupplied =
+    options.trustedConfig !== undefined || options.trustedPolicyPath !== undefined
+
+  // The ONLY skip path: no trusted source AND a working tree that never claimed
+  // to be anchored. Everything else must resolve the trusted anchor first — the
+  // untrusted working-tree config never gets to decide whether enforcement runs.
+  if (!trustedSourceSupplied && !config.rootGate) {
     return null
   }
 
-  // A rootGate is present: enforcement requires a trusted policy source.
+  // Resolve the trusted anchor. With no trusted source this returns the
+  // fail-closed `untrusted-config` failure (the working tree declares a
+  // `rootGate` we cannot verify).
   const trusted = await resolveTrustedConfig(baseDir, options)
   if (isApiFailure(trusted)) {
     return trusted
   }
 
+  // The TRUSTED anchor decides enforcement. If it defines no `rootGate`, it is
+  // not itself anchored — nothing to protect — so evaluation proceeds.
+  if (!trusted.rootGate) {
+    return null
+  }
+
   // The root seal and the policy fingerprint come from the WORKING TREE; the
   // authorized root signers come from the TRUSTED config — so a self-added
-  // signer or an unsealed policy change is rejected here, before any gate is
-  // trusted.
+  // signer, an unsealed policy change, or a deleted `rootGate` (no matching root
+  // seal) is rejected here, before any gate is trusted.
   let seals: SealsFile
   try {
     seals = await readSeals(baseDir, config.settings.sealsPath)

--- a/packages/core/src/api/operations.ts
+++ b/packages/core/src/api/operations.ts
@@ -16,7 +16,13 @@
 import { stat } from 'node:fs/promises'
 import * as path from 'node:path'
 import type { AttestItConfig, GateConfig } from '../types.js'
-import { loadSplitConfig } from '../config/index.js'
+import {
+  loadSplitConfig,
+  findPolicyPath,
+  computePolicyFingerprint,
+  verifyRootGate,
+  isBlockingRootGateState,
+} from '../config/index.js'
 import { computeFingerprint, computeFingerprintsPerFile, listPackageFiles } from '../fingerprint.js'
 import { loadLocalConfigSync } from '../identity/index.js'
 import {
@@ -56,6 +62,7 @@ import {
   type StatusResult,
   type VerifyAllParams,
   type VerifyAllResult,
+  type VerifyOptions,
 } from './types.js'
 
 /**
@@ -70,6 +77,132 @@ async function loadConfigOrFail(baseDir: string): Promise<AttestItConfig | ApiFa
   } catch (error) {
     return fail('malformed', error instanceof Error ? error.message : String(error))
   }
+}
+
+/**
+ * Resolve the caller-supplied **trusted** policy source into an
+ * {@link AttestItConfig}, or an {@link ApiFailure} if none was supplied or it
+ * could not be loaded.
+ *
+ * The trusted config supplies the authorized root signers and team the
+ * working-tree policy's own root seal is checked against — the in-process analog
+ * of the Action's base branch. Precedence: an explicit {@link VerifyOptions.trustedConfig}
+ * wins; otherwise a {@link VerifyOptions.trustedPolicyPath} is loaded from disk.
+ * When neither is supplied we fail closed with `untrusted-config` rather than
+ * trusting the working-tree anchor.
+ */
+async function resolveTrustedConfig(
+  baseDir: string,
+  options: VerifyOptions,
+): Promise<AttestItConfig | ApiFailure> {
+  if (options.trustedConfig) {
+    return options.trustedConfig
+  }
+  if (options.trustedPolicyPath !== undefined) {
+    try {
+      return await loadSplitConfig({
+        baseDir,
+        policySource: { type: 'filesystem', path: options.trustedPolicyPath },
+      })
+    } catch (error) {
+      return fail(
+        'malformed',
+        `Failed to load trusted policy from '${options.trustedPolicyPath}': ` +
+          (error instanceof Error ? error.message : String(error)),
+      )
+    }
+  }
+  return fail(
+    'untrusted-config',
+    'Policy defines a rootGate but no trusted policy source was supplied. ' +
+      'Pass `trustedConfig` (a pre-loaded base-branch config) or `trustedPolicyPath` ' +
+      "(a path to the trusted policy file) so the working-tree policy's root seal can be " +
+      'verified against a trusted anchor. Refusing to trust the working-tree anchor.',
+  )
+}
+
+/**
+ * The MANDATORY root-gate pre-step for the embeddable verify operations.
+ *
+ * Mirrors the CLI `verify` and GitHub Action pre-step: BEFORE any gate is
+ * evaluated, verify the working-tree policy's own root seal against a
+ * caller-supplied **trusted** policy source. Returns `null` when gate evaluation
+ * may proceed, or an {@link ApiFailure} (`untrusted-config`, or `malformed` for
+ * an unreadable seal/policy state) that the caller must surface as the verdict.
+ *
+ * Fail-closed semantics:
+ * - Working-tree policy defines **no** `rootGate` → the repository predates the
+ *   bootstrap ceremony; there is no trust anchor to check, so evaluation
+ *   proceeds unchanged (backward compatible), exactly as the CLI/Action treat
+ *   an un-anchored repo (`NOT_ANCHORED`, non-blocking).
+ * - Working-tree policy defines a `rootGate` but no trusted source was supplied
+ *   → `untrusted-config` (never a silent pass).
+ * - The working-tree policy's root seal does not verify against the trusted
+ *   anchor (e.g. a branch self-added a root signer and self-sealed → the trusted
+ *   anchor does not list it → `UNKNOWN_SIGNER`; or the policy changed without a
+ *   fresh root seal → `FINGERPRINT_MISMATCH`) → `untrusted-config`, carrying the
+ *   precise, non-generic root-gate message that NAMES the untrusted change.
+ * - The root seal verifies (`VALID`/`STALE`) → proceed; gates then evaluate
+ *   against the now-trusted working-tree config.
+ */
+async function enforceRootGate(
+  config: AttestItConfig,
+  baseDir: string,
+  options: VerifyOptions,
+): Promise<ApiFailure | null> {
+  // Un-anchored repo: nothing to anchor against. Proceed (backward compatible).
+  if (!config.rootGate) {
+    return null
+  }
+
+  // A rootGate is present: enforcement requires a trusted policy source.
+  const trusted = await resolveTrustedConfig(baseDir, options)
+  if (isApiFailure(trusted)) {
+    return trusted
+  }
+
+  // The root seal and the policy fingerprint come from the WORKING TREE; the
+  // authorized root signers come from the TRUSTED config — so a self-added
+  // signer or an unsealed policy change is rejected here, before any gate is
+  // trusted.
+  let seals: SealsFile
+  try {
+    seals = await readSeals(baseDir, config.settings.sealsPath)
+  } catch (error) {
+    return fail('malformed', error instanceof Error ? error.message : String(error))
+  }
+
+  const policyPath = findPolicyPath(baseDir)
+  if (policyPath === null) {
+    return fail(
+      'malformed',
+      'Policy file not found for root-gate verification (expected .attest-it/policy.yaml)',
+    )
+  }
+
+  let policyFingerprint: string
+  try {
+    policyFingerprint = await computePolicyFingerprint(baseDir, policyPath)
+  } catch (error) {
+    return fail('malformed', error instanceof Error ? error.message : String(error))
+  }
+
+  const rootResult = verifyRootGate({
+    config: trusted,
+    policyFingerprint,
+    seals,
+    trustedSourceLabel: options.trustedPolicyPath
+      ? `root signers from ${options.trustedPolicyPath}`
+      : 'root signers from the supplied trusted config',
+  })
+
+  if (isBlockingRootGateState(rootResult.state)) {
+    return fail('untrusted-config', rootResult.message, { gateId: rootResult.gateId })
+  }
+
+  // VALID, STALE (a warning, not a failure), or NOT_ANCHORED (the trusted source
+  // itself is not anchored — nothing to protect): gate evaluation may proceed.
+  return null
 }
 
 /**
@@ -641,13 +774,14 @@ export async function seal(
  * `untrusted-config`, or `malformed`). Expected failure states are never thrown.
  *
  * @param artifactPath - The artifact path.
- * @param options - {@link ApiOptions}
+ * @param options - {@link VerifyOptions} (the trusted policy source for
+ *   root-gate enforcement, plus {@link ApiOptions.baseDir}).
  * @returns The verification outcome.
  * @public
  */
 export async function verifyOne(
   artifactPath: string,
-  options: ApiOptions = {},
+  options: VerifyOptions = {},
 ): Promise<ArtifactVerification> {
   const baseDir = options.baseDir ?? process.cwd()
   const config = await loadConfigOrFail(baseDir)
@@ -656,11 +790,12 @@ export async function verifyOne(
   }
   const loaded = config
 
-  const trust = evaluateConfigTrust(loaded, baseDir)
-  if (!trust.trusted) {
-    return fail('untrusted-config', trust.reason ?? 'Configuration is not trust-anchored', {
-      path: artifactPath,
-    })
+  // MANDATORY PRE-STEP: verify the config's OWN root seal against the trusted
+  // anchor before any gate is trusted. Fails closed on a blocking root-gate
+  // state or an absent trusted source (see {@link enforceRootGate}).
+  const rootFailure = await enforceRootGate(loaded, baseDir, options)
+  if (rootFailure) {
+    return { ...rootFailure, path: artifactPath }
   }
 
   const gateId = await resolveSingleGateOrFail(loaded, artifactPath, baseDir)
@@ -714,15 +849,16 @@ async function gateChangedSince(
  *
  * @param params - {@link VerifyAllParams}; `changedSince` (ISO-8601) filters to
  *   gates with at least one file modified at/after that time (by fs mtime).
- * @param options - {@link ApiOptions}
+ * @param options - {@link VerifyOptions} (the trusted policy source for
+ *   root-gate enforcement, plus {@link ApiOptions.baseDir}).
  * @returns Per-gate {@link ArtifactVerification} outcomes, or a top-level
- *   {@link ApiFailure} if config load, trust evaluation, or a bad
+ *   {@link ApiFailure} if config load, root-gate enforcement, or a bad
  *   `changedSince` value fails.
  * @public
  */
 export async function verifyAll(
   params: VerifyAllParams = {},
-  options: ApiOptions = {},
+  options: VerifyOptions = {},
 ): Promise<VerifyAllResult | ApiFailure> {
   const baseDir = options.baseDir ?? process.cwd()
   const config = await loadConfigOrFail(baseDir)
@@ -731,9 +867,12 @@ export async function verifyAll(
   }
   const loaded = config
 
-  const trust = evaluateConfigTrust(loaded, baseDir)
-  if (!trust.trusted) {
-    return fail('untrusted-config', trust.reason ?? 'Configuration is not trust-anchored')
+  // MANDATORY PRE-STEP: verify the config's OWN root seal against the trusted
+  // anchor before any gate is trusted. Fails closed on a blocking root-gate
+  // state or an absent trusted source (see {@link enforceRootGate}).
+  const rootFailure = await enforceRootGate(loaded, baseDir, options)
+  if (rootFailure) {
+    return rootFailure
   }
 
   let since: Date | undefined

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -9,6 +9,7 @@
  * @packageDocumentation
  */
 
+import type { AttestItConfig } from '../types.js'
 import type { VerificationState } from '../seal/verification.js'
 
 /**
@@ -42,8 +43,12 @@ export type ApiSchemaVersion = typeof API_SCHEMA_VERSION
  * - `unauthorized-signer` — the seal's signer is not authorized for the gate, or
  *   the signature does not cryptographically verify against an authorized key.
  * - `untrusted-config` — the policy/config defining trust is not itself anchored
- *   to a trusted root. Reserved for the root-gate trust work; it is shipped as a
- *   documented stub and is not returned at runtime until that work lands.
+ *   to a trusted root. Returned by {@link verifyOne}/{@link verifyAll} when the
+ *   working-tree policy defines a `rootGate` but its own root seal does not
+ *   verify against the caller-supplied **trusted** policy source (e.g. a branch
+ *   that self-added a root signer and self-sealed), or when a `rootGate` is
+ *   present and **no** trusted source was supplied (fail closed — never a silent
+ *   pass). See {@link VerifyOptions}.
  * - `expired` — a valid seal exists but is older than the gate's `maxAge`.
  * - `malformed` — the input or on-disk state cannot be interpreted: an
  *   unparseable config, an unreadable/structurally-invalid seal, or a path that
@@ -247,6 +252,43 @@ export interface ApiOptions {
    * directory, so an embedder can point the API at a checked-out worktree.
    */
   baseDir?: string
+}
+
+/**
+ * Options for the trust-anchored verify operations ({@link verifyOne} and
+ * {@link verifyAll}).
+ *
+ * Extends {@link ApiOptions} with the **trusted policy source** the root gate is
+ * evaluated against. An in-process embedder — unlike the GitHub Action — has no
+ * implicit "base branch", so when the working-tree policy defines a `rootGate`
+ * the caller must name a trusted source for the root-gate pre-step. The trusted
+ * source supplies the authorized **root signers** and **team** the working-tree
+ * policy's own root seal is checked against, mirroring how the Action sources
+ * `rootGate`/`team` from the base branch (and aligning with the CLI's planned
+ * `--base <ref>`).
+ *
+ * Fail-closed contract: if the working-tree policy defines a `rootGate` and
+ * **neither** `trustedConfig` nor `trustedPolicyPath` is supplied, the verify
+ * operation returns an `untrusted-config` {@link ApiFailure} rather than
+ * silently trusting the working-tree anchor. A repository with no `rootGate`
+ * (not yet bootstrapped) needs no trusted source and verifies unchanged.
+ *
+ * @public
+ */
+export interface VerifyOptions extends ApiOptions {
+  /**
+   * A pre-loaded, trusted {@link AttestItConfig} (e.g. the base-branch policy
+   * the embedder loaded itself). Its `rootGate.authorizedSigners` and `team`
+   * are the trust anchor the working-tree policy's root seal is verified
+   * against. Takes precedence over {@link VerifyOptions.trustedPolicyPath}.
+   */
+  trustedConfig?: AttestItConfig
+  /**
+   * Filesystem path to a trusted policy file (e.g. a checkout of the base
+   * branch's `.attest-it/policy.yaml`). Loaded to supply the trusted
+   * `rootGate`/`team`. Ignored when {@link VerifyOptions.trustedConfig} is supplied.
+   */
+  trustedPolicyPath?: string
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,6 +222,7 @@ export {
   type ApiResultBase,
   type ApiFailure,
   type ApiOptions,
+  type VerifyOptions,
   type GateDescriptor,
   type ListGatesResult,
   type FingerprintResultOk,

--- a/packages/core/test/integration/embedder-root-gate.test.ts
+++ b/packages/core/test/integration/embedder-root-gate.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Root-gate trust anchoring through the REAL embeddable surface (#131).
+ *
+ * These tests are a small consumer that imports the public `@attest-it/core`
+ * surface (`verifyAll`/`verifyOne`, plus the root-gate primitives) exactly as an
+ * embedder (e.g. a wrapping CLI for custom / non-GitHub CI) would, and drives it
+ * against fixtures on disk. They are the programmatic analog of the CLI/Action
+ * root-gate integration tests: an embedder must get the SAME trust-anchored
+ * authorization the GitHub Action enforces (#110), not seal-only verification.
+ *
+ * Each test maps to an issue #131 acceptance criterion:
+ *   - (a) adversarial: a working-tree policy that self-adds a root signer and
+ *     self-seals is REJECTED (`untrusted-config`) when a trusted base config is
+ *     supplied — the programmatic analog of #110's adversarial test.
+ *   - fail-closed: a policy with a `rootGate` but NO trusted source supplied is
+ *     REJECTED (`untrusted-config`), never a silent pass.
+ *   - (b) positive: a policy legitimately re-sealed by a trusted root signer
+ *     verifies (`ok: true`) and gates evaluate against the new config.
+ *   - (c) backward-compatible: an un-anchored repo (no `rootGate`) still
+ *     verifies (NOT_ANCHORED, non-blocking) with no trusted source.
+ *
+ * All four assertions FAIL against pre-fix code, which skipped the root gate in
+ * the embeddable API entirely (evaluateConfigTrust was a no-op stub).
+ *
+ * @see Issue #131 acceptance criteria
+ * @see Issue #110 — trust-anchored authorization ("an agent can't self-authorize")
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { stringify as stringifyYaml } from 'yaml'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  verifyAll,
+  verifyOne,
+  generateEd25519KeyPair,
+  createRootSeal,
+  createSeal,
+  computePolicyFingerprintSync,
+  computeFingerprintSync,
+  ROOT_GATE_ID,
+  type AttestItConfig,
+  type SealsFile,
+} from '../../src/index.js'
+
+/** Ed25519 key pair as returned by {@link generateEd25519KeyPair}. */
+interface KeyPair {
+  publicKey: string
+  privateKey: string
+}
+
+/** A team member entry in policy YAML. */
+interface TeamEntry {
+  name: string
+  publicKey: string
+}
+
+/** A scaffolded, on-disk attest-it project the embeddable API is pointed at. */
+interface Fixture {
+  baseDir: string
+}
+
+const GATE_ID = 'tools'
+const GATE_PATHS = ['src/**']
+const POLICY_REL = join('.attest-it', 'policy.yaml')
+const SEALS_REL = join('.attest-it', 'seals.json')
+
+const dirsToClean: string[] = []
+
+afterEach(() => {
+  for (const dir of dirsToClean.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/**
+ * Scaffold a project on disk with the given policy, operational config, and
+ * seals, and return the base directory the embeddable API is pointed at.
+ */
+function scaffold(policy: Record<string, unknown>, seals: SealsFile): Fixture {
+  const baseDir = mkdtempSync(join(tmpdir(), 'attest-embedder-rootgate-'))
+  dirsToClean.push(baseDir)
+  mkdirSync(join(baseDir, '.attest-it'), { recursive: true })
+  mkdirSync(join(baseDir, 'src', 'lib'), { recursive: true })
+  writeFileSync(join(baseDir, 'src', 'lib', 'tool.ts'), 'export const tool = () => 42\n', 'utf8')
+
+  const operational = { version: 1, suites: { build: { gate: GATE_ID } } }
+  writeFileSync(join(baseDir, POLICY_REL), stringifyYaml(policy), 'utf8')
+  writeFileSync(join(baseDir, '.attest-it', 'config.yaml'), stringifyYaml(operational), 'utf8')
+  writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+  return { baseDir }
+}
+
+/** Build a policy object with a `rootGate` anchored to the given signers. */
+function anchoredPolicy(
+  team: Record<string, TeamEntry>,
+  rootSigners: string[],
+): Record<string, unknown> {
+  return {
+    version: 1,
+    team,
+    rootGate: { authorizedSigners: rootSigners, maxAge: '365d' },
+    gates: {
+      [GATE_ID]: {
+        name: 'Tools',
+        description: 'Forged tool scripts',
+        authorizedSigners: ['alice'],
+        fingerprint: { paths: GATE_PATHS },
+        maxAge: '365d',
+      },
+    },
+  }
+}
+
+/** Build an un-anchored policy (no `rootGate`). */
+function unanchoredPolicy(team: Record<string, TeamEntry>): Record<string, unknown> {
+  return {
+    version: 1,
+    team,
+    gates: {
+      [GATE_ID]: {
+        name: 'Tools',
+        description: 'Forged tool scripts',
+        authorizedSigners: ['alice'],
+        fingerprint: { paths: GATE_PATHS },
+        maxAge: '365d',
+      },
+    },
+  }
+}
+
+/**
+ * The trusted, pre-loaded base-branch config an embedder would supply as the
+ * root-of-trust anchor: only `alice` is a root signer and team member.
+ */
+function trustedBaseConfig(alice: KeyPair): AttestItConfig {
+  return {
+    version: 1,
+    settings: {
+      maxAgeDays: 365,
+      publicKeyPath: '.attest-it/pubkey.pem',
+      attestationsPath: '.attest-it/attestations.json',
+      sealsPath: SEALS_REL,
+    },
+    rootGate: { authorizedSigners: ['alice'], maxAge: '365d' },
+    team: { alice: { name: 'Alice Developer', publicKey: alice.publicKey } },
+    suites: {},
+  }
+}
+
+/** Seal the policy file at `baseDir` under the root gate with `signer`'s key. */
+function rootSealOver(baseDir: string, signerSlug: string, signer: KeyPair) {
+  return createRootSeal({
+    policyFingerprint: computePolicyFingerprintSync(baseDir, join(baseDir, POLICY_REL)),
+    sealedBy: signerSlug,
+    privateKey: signer.privateKey,
+  })
+}
+
+/** Seal the `tools` gate over `src/**` with `signer`'s key. */
+function gateSealOver(baseDir: string, signerSlug: string, signer: KeyPair) {
+  return createSeal({
+    gateId: GATE_ID,
+    fingerprint: computeFingerprintSync({ paths: GATE_PATHS, baseDir }).fingerprint,
+    sealedBy: signerSlug,
+    privateKey: signer.privateKey,
+  })
+}
+
+describe('embeddable API root-gate enforcement (#131)', () => {
+  it('(a) REJECTS a working-tree policy that self-adds a root signer and self-seals when a trusted base config is supplied', async () => {
+    const alice = generateEd25519KeyPair()
+    const mallory = generateEd25519KeyPair()
+
+    // Working tree: mallory has added herself to the team AND to the root
+    // signers, then self-sealed the tampered policy with her own key.
+    const policy = anchoredPolicy(
+      {
+        alice: { name: 'Alice Developer', publicKey: alice.publicKey },
+        mallory: { name: 'Mallory', publicKey: mallory.publicKey },
+      },
+      ['alice', 'mallory'],
+    )
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} })
+
+    // Self-seal the tampered policy under the root gate, and keep a genuine,
+    // valid gate seal by alice so that pre-fix code (which skips the root gate)
+    // would report the gate VALID — isolating the root-gate check as the only
+    // thing that rejects this tampered config.
+    const seals: SealsFile = {
+      version: 1,
+      seals: {
+        [ROOT_GATE_ID]: rootSealOver(baseDir, 'mallory', mallory),
+        [GATE_ID]: gateSealOver(baseDir, 'alice', alice),
+      },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    const trustedConfig = trustedBaseConfig(alice)
+
+    // verifyAll: top-level untrusted-config failure that names the change.
+    const all = await verifyAll({}, { baseDir, trustedConfig })
+    expect(all.ok).toBe(false)
+    if (all.ok) return
+    expect(all.failureClass).toBe('untrusted-config')
+    expect(all.message).toContain('.attest-it/policy.yaml')
+    expect(all.message.toLowerCase()).toContain('root signer')
+
+    // verifyOne: same rejection, since the pre-step runs before gate evaluation.
+    const one = await verifyOne('src/lib/tool.ts', { baseDir, trustedConfig })
+    expect(one.ok).toBe(false)
+    if (one.ok) return
+    expect(one.failureClass).toBe('untrusted-config')
+    expect(one.path).toBe('src/lib/tool.ts')
+  })
+
+  it('fails closed: a policy with a rootGate but NO trusted source supplied is rejected (never a silent pass)', async () => {
+    const alice = generateEd25519KeyPair()
+    const policy = anchoredPolicy(
+      { alice: { name: 'Alice Developer', publicKey: alice.publicKey } },
+      ['alice'],
+    )
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} })
+    const seals: SealsFile = {
+      version: 1,
+      seals: {
+        [ROOT_GATE_ID]: rootSealOver(baseDir, 'alice', alice),
+        [GATE_ID]: gateSealOver(baseDir, 'alice', alice),
+      },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    // No trustedConfig / trustedPolicyPath: enforcement cannot proceed, so the
+    // API must fail closed rather than trust the working-tree anchor.
+    const result = await verifyAll({}, { baseDir })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.failureClass).toBe('untrusted-config')
+    expect(result.message.toLowerCase()).toContain('trusted policy source')
+  })
+
+  it('(b) VERIFIES a policy legitimately re-sealed by a trusted root signer, and gates evaluate against the new config', async () => {
+    const alice = generateEd25519KeyPair()
+    const dev = generateEd25519KeyPair()
+
+    // alice (a trusted root signer) legitimately added `dev` to the team and
+    // re-sealed the new policy under the root gate with her own key.
+    const policy = anchoredPolicy(
+      {
+        alice: { name: 'Alice Developer', publicKey: alice.publicKey },
+        dev: { name: 'Dev', publicKey: dev.publicKey },
+      },
+      ['alice'],
+    )
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} })
+    const seals: SealsFile = {
+      version: 1,
+      seals: {
+        [ROOT_GATE_ID]: rootSealOver(baseDir, 'alice', alice),
+        [GATE_ID]: gateSealOver(baseDir, 'alice', alice),
+      },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    const trustedConfig = trustedBaseConfig(alice)
+    const result = await verifyAll({}, { baseDir, trustedConfig })
+
+    // The root pre-step passed, so gate evaluation proceeded against the new
+    // (trusted) working-tree config and the gate is validly sealed.
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.results).toHaveLength(1)
+    const gate = result.results[0]
+    expect(gate?.ok).toBe(true)
+    if (!gate?.ok) return
+    expect(gate.gateId).toBe(GATE_ID)
+    expect(gate.sealedBy).toBe('alice')
+  })
+
+  it('(b) also accepts a trusted source supplied as a filesystem policy path', async () => {
+    const alice = generateEd25519KeyPair()
+    const policy = anchoredPolicy(
+      { alice: { name: 'Alice Developer', publicKey: alice.publicKey } },
+      ['alice'],
+    )
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} })
+    const seals: SealsFile = {
+      version: 1,
+      seals: {
+        [ROOT_GATE_ID]: rootSealOver(baseDir, 'alice', alice),
+        [GATE_ID]: gateSealOver(baseDir, 'alice', alice),
+      },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    // The trusted policy file is the same on-disk policy (a stand-in for a
+    // base-branch checkout whose root signers still list only alice).
+    const result = await verifyAll({}, { baseDir, trustedPolicyPath: join(baseDir, POLICY_REL) })
+    expect(result.ok).toBe(true)
+  })
+
+  it('(c) verifies an un-anchored repo (no rootGate) with no trusted source (backward compatible)', async () => {
+    const alice = generateEd25519KeyPair()
+    const policy = unanchoredPolicy({
+      alice: { name: 'Alice Developer', publicKey: alice.publicKey },
+    })
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} })
+    const seals: SealsFile = {
+      version: 1,
+      seals: { [GATE_ID]: gateSealOver(baseDir, 'alice', alice) },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    // No rootGate → no trust anchor to check → verifies unchanged, and never
+    // reports untrusted-config.
+    const result = await verifyAll({}, { baseDir })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.results[0]?.ok).toBe(true)
+  })
+})

--- a/packages/core/test/integration/embedder-root-gate.test.ts
+++ b/packages/core/test/integration/embedder-root-gate.test.ts
@@ -114,8 +114,11 @@ function anchoredPolicy(
   }
 }
 
-/** Build an un-anchored policy (no `rootGate`). */
-function unanchoredPolicy(team: Record<string, TeamEntry>): Record<string, unknown> {
+/** Build an un-anchored policy (no `rootGate`) with the given gate signers. */
+function unanchoredPolicy(
+  team: Record<string, TeamEntry>,
+  gateSigners: string[] = ['alice'],
+): Record<string, unknown> {
   return {
     version: 1,
     team,
@@ -123,7 +126,7 @@ function unanchoredPolicy(team: Record<string, TeamEntry>): Record<string, unkno
       [GATE_ID]: {
         name: 'Tools',
         description: 'Forged tool scripts',
-        authorizedSigners: ['alice'],
+        authorizedSigners: gateSigners,
         fingerprint: { paths: GATE_PATHS },
         maxAge: '365d',
       },
@@ -214,6 +217,52 @@ describe('embeddable API root-gate enforcement (#131)', () => {
     if (one.ok) return
     expect(one.failureClass).toBe('untrusted-config')
     expect(one.path).toBe('src/lib/tool.ts')
+  })
+
+  it('(a2) REJECTS a working-tree that DELETES rootGate and self-authorizes a gate, when a trusted anchored base config is supplied', async () => {
+    // Trust-bypass regression (#131 adversarial review): an attacker cannot
+    // escape enforcement by simply removing `rootGate` from their branch's
+    // policy. The enforcement decision is gated on the TRUSTED anchor, not on the
+    // untrusted working-tree config, so a deleted rootGate → no matching root
+    // seal over the tampered policy → MISSING → untrusted-config.
+    const alice = generateEd25519KeyPair()
+    const mallory = generateEd25519KeyPair()
+
+    // Working tree: NO rootGate at all, and mallory has added herself to the team
+    // and authorized herself on the `tools` gate, then self-sealed that gate.
+    const policy = unanchoredPolicy(
+      {
+        alice: { name: 'Alice Developer', publicKey: alice.publicKey },
+        mallory: { name: 'Mallory', publicKey: mallory.publicKey },
+      },
+      ['alice', 'mallory'],
+    )
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} })
+
+    // A genuine, valid gate seal by mallory (self-authorized). No root seal
+    // exists — the attacker removed the root gate entirely. Pre-fix code skipped
+    // the root gate whenever the WORKING-TREE policy had none, so it would report
+    // this gate VALID (ok:true) — the exact bypass.
+    const seals: SealsFile = {
+      version: 1,
+      seals: { [GATE_ID]: gateSealOver(baseDir, 'mallory', mallory) },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    // The trusted base is still anchored to alice: its rootGate decides that
+    // enforcement MUST run, regardless of the working tree deleting its own.
+    const trustedConfig = trustedBaseConfig(alice)
+
+    const all = await verifyAll({}, { baseDir, trustedConfig })
+    expect(all.ok).toBe(false)
+    if (all.ok) return
+    expect(all.failureClass).toBe('untrusted-config')
+    expect(all.message).toContain('.attest-it/policy.yaml')
+
+    const one = await verifyOne('src/lib/tool.ts', { baseDir, trustedConfig })
+    expect(one.ok).toBe(false)
+    if (one.ok) return
+    expect(one.failureClass).toBe('untrusted-config')
   })
 
   it('fails closed: a policy with a rootGate but NO trusted source supplied is rejected (never a silent pass)', async () => {


### PR DESCRIPTION
## Summary

The embeddable `@attest-it/core` API — the surface an embedder (e.g. a wrapping
CLI for custom / non-GitHub CI) codes against — performed only per-gate seal
verification and had **zero** root-gate trust anchoring. `verifyOne`/`verifyAll`
called only `verifyGateSeal`; only the CLI `verify` and the GitHub Action wired
in the root-gate pre-step. So an embedder got seal verification but **not** the
trust-anchored authorization #110 established — the "an agent can't
self-authorize" property was silent through the programmatic surface.

This wires the mandatory root-gate pre-step into `verifyOne`/`verifyAll`,
mirroring the CLI/Action, and reusing the existing root-gate primitives
(`computePolicyFingerprint`, `verifyRootGate`, `isBlockingRootGateState`) — no
reimplementation.

## How the pre-step is wired into `verifyOne`/`verifyAll`

A new internal `enforceRootGate(config, baseDir, options)` runs **before** any
gate is evaluated, right after config load:

1. **Un-anchored repo** (working-tree policy has no `rootGate`) → returns `null`,
   evaluation proceeds unchanged (`NOT_ANCHORED`, non-blocking — backward
   compatible, exactly as the CLI/Action treat it).
2. **Anchored** (working-tree policy has a `rootGate`) → resolve the caller's
   **trusted policy source** (`resolveTrustedConfig`). Absent one → fail closed
   `untrusted-config` (never a silent pass).
3. Read the working-tree seals, compute the working-tree policy fingerprint, and
   `verifyRootGate({ config: trusted, policyFingerprint, seals })` — the trusted
   source supplies the authorized root signers/team, the working tree supplies
   the seal + fingerprint (the in-process analog of the Action's base branch).
4. `isBlockingRootGateState(state)` → return an `untrusted-config` `ApiFailure`
   carrying the precise root-gate message that NAMES the untrusted change; the
   API's structured `{ ok, failureClass, ... }` contract is preserved (nothing is
   thrown). Otherwise (`VALID`/`STALE`/`NOT_ANCHORED`) evaluation proceeds and
   gates evaluate against the now-trusted working-tree config.

Because an in-process embedder has no implicit "base branch", the trusted source
is caller-supplied via a new **`VerifyOptions`** (a superset of `ApiOptions`):
`trustedConfig` (a pre-loaded base-branch `AttestItConfig`, takes precedence) or
`trustedPolicyPath` (a path to a trusted policy file). `verifyOne`/`verifyAll`
now accept `VerifyOptions`; existing `{ baseDir }` callers are unaffected.

## Acceptance criteria → tests

New integration test `packages/core/test/integration/embedder-root-gate.test.ts`
imports the public `@attest-it/core` surface and drives it against on-disk
fixtures (runs in CI's core build/test job):

- **AC1 — root gate enforced, fail closed** — covered by
  `(a) REJECTS a working-tree policy that self-adds a root signer and self-seals …`
  and `fails closed: a policy with a rootGate but NO trusted source supplied …`.
- **AC2 — `verifyRootGate` + trusted-config plumbing in the public surface** —
  `VerifyOptions` (`trustedConfig`/`trustedPolicyPath`) is exported from
  `@attest-it/core`; `verifyRootGate`/`isBlockingRootGateState`/
  `computePolicyFingerprint` were already exported. Regenerated `api-report`
  captures the new surface.
- **AC3 — docs** — `docs/embedding.md` now shows the trust-anchored verify path
  and a "Root-gate trust anchoring" section; the old `untrusted-config`-is-a-stub
  note is removed.
- **AC4 — adversarial embedder test** — the `(a)` case is the programmatic analog
  of #110's adversarial test (self-added signer, self-seal → `untrusted-config`
  `UNKNOWN_SIGNER` against a supplied trusted base config).
- **AC5 — api-report + changeset** — `api-report/core.api.md` regenerated;
  changeset `@attest-it/core` **minor** (additive API + fixed enforcement gap),
  plus the `attest-it` umbrella (re-exports the new surface).

Positive `(b)` (legitimate root-signer re-seal → `ok: true`, gates evaluate) and
backward-compatible `(c)` (un-anchored repo verifies with no trusted source) are
also covered. The two rejection assertions **fail against pre-fix code**
(verified by temporarily reverting `operations.ts`), which skipped the root gate
entirely.

## Verification

- `@attest-it/core` full suite (629 tests) green; CLI + github-action suites
  (808 tests) green; `nx run-many --target=build` green; `check:api-report`,
  `prettier --check`, eslint, `tsc --noEmit` all clean.

## Scope note (#137)

#137 also touches `api/operations.ts` (suites-optional). This change is scoped to
the root-gate pre-step and the new `VerifyOptions`; no overlap with suite
handling. `status` intentionally retains its existing `evaluateConfigTrust` stub
(this PR is scoped to `verifyOne`/`verifyAll` per the issue).

Refs #131
