### PR TITLE
feat(cli): verify --base <ref> trusted-ref mode + reconcile CI trust-boundary docs

### DIFF
--- a/.changeset/verify-base-trusted-ref.md
+++ b/.changeset/verify-base-trusted-ref.md
@@ -1,0 +1,31 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Add `attest-it verify --base <ref>`: a trusted-ref mode that makes the CLI a
+genuine CI trust boundary for non-GitHub CI.
+
+Without `--base`, `attest-it verify` trusts the working-tree `.attest-it/policy.yaml`
+(a fast local pre-check). A pull request could rewrite its own `rootGate`/`team`,
+re-seal, and still pass — only the GitHub Action caught this, because it loads
+authorization from the pull request's base branch.
+
+`verify --base <ref>` closes that gap. It sources `rootGate`, `team`, and `gates`
+from `<ref>`'s copy of `policy.yaml` (via `git show`) while computing fingerprints
+and reading seals from the working tree — the same base-vs-worktree check the
+Action performs. A branch that self-adds a root signer and re-seals is rejected as
+`UNKNOWN_SIGNER`, because the trusted ref does not list it. `--base` fails **closed**:
+an unreadable ref or a missing policy at the ref is a configuration error with
+actionable guidance, never a silent pass on the working-tree policy.
+
+Non-GitHub CI can now enforce the trust boundary directly:
+
+```bash
+git fetch origin main
+npx attest-it verify --base origin/main
+```
+
+Documentation is reconciled to match: README, getting-started, and the GitHub
+integration guide now state plainly that plain `verify` is a local pre-check, and
+that the CI trust boundary is the GitHub Action (base branch) or `verify --base <ref>`.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,22 @@ npx attest-it init
 # Run tests and seal the gate
 npx attest-it run --suite my-suite
 
-# In CI: verify all seals
+# Locally: fast pre-check (trusts your working-tree policy — NOT a trust gate)
 npx attest-it verify
 ```
+
+> [!IMPORTANT]
+> **Plain `attest-it verify` is a local pre-check, not the CI trust boundary.** It
+> trusts whatever `.attest-it/policy.yaml` is in the working tree, so a pull request
+> can rewrite its own `rootGate`/`team` and re-seal, and plain `verify` still passes.
+> To actually gate CI, enforce trust against a **trusted base**:
+>
+> - **GitHub:** use the [GitHub Action](#github-action) (loads policy from the PR base branch).
+> - **Other CI:** use `attest-it verify --base <ref>` (loads `rootGate`/`team`/`gates`
+>   from `<ref>` while fingerprinting the working tree — a self-added signer is
+>   rejected as `UNKNOWN_SIGNER`).
+>
+> See the [threat model](docs/threat-model.md) for the full trust boundary.
 
 ### Non-interactive (CI, embedders, agents)
 
@@ -47,9 +60,16 @@ npx attest-it team join --gates my-gate < /dev/null
 # Run a suite and auto-confirm the seal
 npx attest-it run --suite my-suite --yes < /dev/null
 
-# In CI: verify all seals (already non-interactive)
+# Local pre-check (non-interactive), NOT a trust gate — trusts the working-tree policy
 npx attest-it verify
+
+# Non-GitHub CI trust gate: anchor authorization to a trusted base ref
+npx attest-it verify --base origin/main
 ```
+
+On GitHub, prefer the [GitHub Action](#github-action) as the CI gate — it loads
+policy from the PR base branch automatically. See the callout in
+[Quick Start](#quick-start) for why plain `verify` is not a trust boundary.
 
 To encrypt a file-backed private key, pipe a passphrase in via `--passphrase-stdin`:
 
@@ -76,7 +96,7 @@ The primary threat is an AI assistant creating a fake attestation. attest-it pre
 - **Secure storage**: Keys stored in 1Password, macOS Keychain, YubiKey, or encrypted files
 - **Team authorization**: Each gate specifies who can sign
 - **Fingerprinting**: Code changes invalidate seals
-- **Sealed root gate**: `policy.yaml` (the trust data itself) is a sealed artifact — a pull request can't add itself to `team`/`gates` and pass verification. See [threat model](docs/threat-model.md).
+- **Sealed root gate**: `policy.yaml` (the trust data itself) is a sealed artifact — at the trust boundary, a pull request can't add itself to `team`/`gates` and pass verification. That guarantee holds where authorization is anchored to a **trusted base**: the [GitHub Action](#github-action) (base branch) or `attest-it verify --base <ref>`. Plain local `verify` trusts the working-tree policy and is only a pre-check. See [threat model](docs/threat-model.md).
 
 ## Configuration
 
@@ -169,12 +189,12 @@ See [Configuration Reference](docs/configuration.md) for all options.
 
 ### Sealing and Verification
 
-| Command             | Description                                                                                             |
-| ------------------- | ------------------------------------------------------------------------------------------------------- |
-| `seal [gates...]`   | Create seals for specified gates                                                                        |
-| `verify [gates...]` | Verify seals -- **use this to gate CI**; exits non-zero on invalid gates                                |
-| `status`            | Show seal status for all gates -- informational; exits 0 on gate results, fails closed on config errors |
-| `run --suite`       | Run tests and optionally seal                                                                           |
+| Command             | Description                                                                                                                                                                                                                                                |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `seal [gates...]`   | Create seals for specified gates                                                                                                                                                                                                                           |
+| `verify [gates...]` | Verify seals. Plain `verify` is a fast **local pre-check** (trusts the working-tree policy), _not_ a CI trust gate. Add `--base <ref>` to gate CI against a trusted base ref (or use the [GitHub Action](#github-action)); exits non-zero on invalid gates |
+| `status`            | Show seal status for all gates -- informational; exits 0 on gate results, fails closed on config errors                                                                                                                                                    |
+| `run --suite`       | Run tests and optionally seal                                                                                                                                                                                                                              |
 
 ### Project Setup
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -226,9 +226,17 @@ npx attest-it run --suite desktop
 # Check status
 npx attest-it status
 
-# Verify in CI
+# Local pre-check (trusts the working-tree policy — NOT the CI trust gate)
 npx attest-it verify
+
+# CI trust gate off GitHub: anchor authorization to a trusted base ref
+git fetch origin main
+npx attest-it verify --base origin/main
 ```
+
+> On GitHub, use the [GitHub Action](../github-integration.md) as the CI gate — it
+> loads policy from the PR base branch. Plain `verify` trusts the working-tree
+> policy and is only a pre-check.
 
 ## Package.json Template
 
@@ -276,7 +284,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
       - run: npm ci
-      - run: npx attest-it verify
+      # Base-branch-anchored trust gate (not a bare `attest-it verify`, which would
+      # only pre-check the PR's own working-tree policy).
+      - uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 ```
 
 ## Tips and Best Practices

--- a/docs/examples/vitest-example.md
+++ b/docs/examples/vitest-example.md
@@ -385,7 +385,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
       - run: npm ci
-      - run: npx attest-it verify # Verify desktop tests were attested
+      # Base-branch-anchored trust gate. A bare `attest-it verify` would only
+      # pre-check the PR's own working-tree policy, not the trusted base.
+      - uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 ```
 
 ## Best Practices

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -353,7 +353,21 @@ The `.attest-it/` directory structure:
 
 ## Step 6: Set Up CI Verification
 
-Add verification to your CI pipeline:
+> [!IMPORTANT]
+> **Plain `attest-it verify` is a local pre-check, not the CI trust boundary.** It
+> trusts the working-tree `.attest-it/policy.yaml`, so a pull request that adds
+> itself to `team`/`rootGate` and re-seals will still pass a bare `verify`. To
+> enforce trust in CI you must anchor authorization to a **trusted base**:
+>
+> - **On GitHub:** use the GitHub Action below — it loads `policy.yaml` from the PR
+>   **base branch** automatically.
+> - **On other CI:** use `attest-it verify --base <ref>` — it loads
+>   `rootGate`/`team`/`gates` from `<ref>` (e.g. `origin/main`) while fingerprinting
+>   the working tree, so a self-added signer is rejected as `UNKNOWN_SIGNER`.
+>
+> See the [threat model](threat-model.md) for the full trust boundary.
+
+On GitHub, enforce seals with the GitHub Action (the canonical, base-branch-anchored gate):
 
 ```yaml
 # .github/workflows/ci.yml
@@ -370,16 +384,25 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - run: npx attest-it verify
+      # Loads policy from the PR base branch — the trusted source.
+      - uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 ```
 
-Or use the GitHub Action:
+On non-GitHub CI, use the CLI in trusted-ref mode. Fetch the base ref first (shallow
+clones may not have it), then verify against it:
 
 ```yaml
-- uses: attest-it/github-action@v1
-  with:
-    fail-on-missing: 'true'
+# Example (non-GitHub CI)
+- run: npm ci
+- run: git fetch origin main
+  # Anchors rootGate/team/gates to origin/main; a PR can't self-authorize.
+- run: npx attest-it verify --base origin/main
 ```
+
+A bare `npx attest-it verify` (no `--base`) is still useful as a fast **local**
+pre-check before pushing, but must not be relied on as the CI gate.
 
 See [GitHub Integration Guide](github-integration.md) for more options.
 
@@ -410,7 +433,8 @@ Overall: All gates valid
 **`status` is informational and exits `0` when it successfully reports gate results** --
 even when a gate is `MISSING`, `FINGERPRINT_MISMATCH`, or otherwise invalid, it reports what
 it finds rather than enforcing it. Don't wire `status` into CI expecting it to fail the build
-on a bad gate; use `attest-it verify` for that (see [Step 6](#step-6-set-up-ci-verification)).
+on a bad gate; use the trusted CI gate for that — the GitHub Action or
+`attest-it verify --base <ref>` (see [Step 6](#step-6-set-up-ci-verification)).
 `status` still fails closed on the configuration itself, though: it exits `CONFIG_ERROR` on a
 missing/unreadable config and `NO_WORK` when the config defines zero gates -- see
 [Exit Codes](configuration.md#exit-codes).

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -2,9 +2,27 @@
 
 Complete guide to integrating attest-it with GitHub Actions and workflows.
 
+> [!IMPORTANT]
+> **The CI trust gate is the GitHub Action, not bare `npx attest-it verify`.**
+> Plain `attest-it verify` is a fast **local pre-check**: it trusts whatever
+> `.attest-it/policy.yaml` is in the checked-out working tree. A pull request can
+> rewrite its own `rootGate`/`team`, re-seal, and pass a bare `verify` (see the
+> [threat model](threat-model.md)). Only a **base-anchored** check is a real trust
+> boundary:
+>
+> - **On GitHub, use `attest-it/github-action@v1`** (below). It loads `policy.yaml`
+>   from the PR **base branch**, so a PR cannot grant itself signers or gates.
+> - **On non-GitHub CI, use `attest-it verify --base <ref>`** — see
+>   [Non-GitHub CI](#non-github-ci-verify---base). It anchors `rootGate`/`team`/`gates`
+>   to `<ref>` while fingerprinting the working tree.
+>
+> The YAML examples in this guide use the Action for exactly this reason. Where a
+> snippet shows bare `npx attest-it verify`, treat it as a **local** pre-check only.
+
 ## Quick Start
 
-Add seal verification to your CI pipeline:
+Add seal verification to your CI pipeline with the GitHub Action (the trusted,
+base-branch-anchored gate):
 
 ```yaml
 # .github/workflows/ci.yml
@@ -25,9 +43,28 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # The Action loads policy.yaml from the PR base branch — the trusted source.
       - name: Verify seals
-        run: npx attest-it verify
+        uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 ```
+
+### Non-GitHub CI: `verify --base`
+
+Off GitHub (GitLab CI, CircleCI, Jenkins, …) there is no Action, so use the CLI in
+**trusted-ref mode**. Fetch the base ref, then anchor verification to it:
+
+```bash
+# The base ref must be present locally; shallow clones often need an explicit fetch.
+git fetch origin main
+# Loads rootGate/team/gates from origin/main (trusted) while fingerprinting the
+# working tree. A PR that self-adds a signer and re-seals is rejected as UNKNOWN_SIGNER.
+npx attest-it verify --base origin/main
+```
+
+Without `--base`, `verify` trusts the working-tree policy and is only a local
+pre-check — never rely on it to gate untrusted proposal branches.
 
 ## GitHub Action
 
@@ -107,12 +144,13 @@ jobs:
 
 ### Strategy 1: Block on Missing Seals
 
-Fail CI if seals are missing or invalid:
+Fail CI if seals are missing or invalid (the Action fails the job on a non-`valid` result):
 
 ```yaml
 - name: Verify seals
-  run: npx attest-it verify
-  # CI fails if exit code is non-zero
+  uses: attest-it/github-action@v1
+  with:
+    fail-on-missing: 'true'
 ```
 
 **Use when**:
@@ -123,16 +161,18 @@ Fail CI if seals are missing or invalid:
 
 ### Strategy 2: Warn on Missing Seals
 
-Allow CI to pass but report status:
+Allow CI to pass but report status. Use the Action with `continue-on-error` and read
+its `valid` output (a bare `npx attest-it verify` here would only pre-check the PR's
+own working-tree policy, not the trusted base):
 
 ```yaml
 - name: Verify seals
   id: verify
-  run: npx attest-it verify || echo "SEAL_FAILED=true" >> $GITHUB_OUTPUT
+  uses: attest-it/github-action@v1
   continue-on-error: true
 
 - name: Comment on PR
-  if: steps.verify.outputs.SEAL_FAILED == 'true'
+  if: steps.verify.outputs.valid == 'false'
   uses: actions/github-script@v7
   with:
     script: |
@@ -152,17 +192,22 @@ Allow CI to pass but report status:
 
 ### Strategy 3: Verify Specific Gates
 
-Only verify critical gates in PR checks:
+Only verify critical gates in PR checks (the Action's `suite` input scopes the
+base-anchored check to one gate):
 
 ```yaml
 # Verify desktop tests in PRs
 - name: Verify desktop tests
-  run: npx attest-it verify desktop-tests
+  uses: attest-it/github-action@v1
+  with:
+    suite: desktop-tests
 
 # Verify all gates before deploy
 - name: Verify all seals
-  run: npx attest-it verify
   if: github.ref == 'refs/heads/main'
+  uses: attest-it/github-action@v1
+  with:
+    fail-on-missing: 'true'
 ```
 
 **Use when**:
@@ -193,7 +238,9 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - run: npx attest-it verify
+      - uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 ```
 
 **Advantages**:
@@ -229,7 +276,9 @@ jobs:
 
       # Block deploy if seals invalid
       - name: Verify seals
-        run: npx attest-it verify
+        uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 
       - name: Deploy
         run: npm run deploy
@@ -267,7 +316,7 @@ jobs:
 
       # Warn but don't fail
       - name: Verify seals
-        run: npx attest-it verify
+        uses: attest-it/github-action@v1
         continue-on-error: true
 ```
 
@@ -288,7 +337,9 @@ jobs:
 
       # Must pass to deploy
       - name: Verify seals
-        run: npx attest-it verify
+        uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 
       - name: Deploy
         run: npm run deploy
@@ -303,11 +354,11 @@ If seals are missing, provide clear instructions:
 ```yaml
 - name: Verify seals
   id: verify
-  run: npx attest-it verify
+  uses: attest-it/github-action@v1
   continue-on-error: true
 
 - name: Report failure
-  if: steps.verify.outcome == 'failure'
+  if: steps.verify.outputs.valid == 'false'
   run: |
     echo "::error::Seals are invalid or missing"
     echo "To fix:"
@@ -324,10 +375,11 @@ Create an issue when seals fail on main:
 ```yaml
 - name: Verify seals
   id: verify
-  run: npx attest-it verify || echo "failed=true" >> $GITHUB_OUTPUT
+  uses: attest-it/github-action@v1
+  continue-on-error: true
 
 - name: Create issue on failure
-  if: steps.verify.outputs.failed == 'true' && github.ref == 'refs/heads/main'
+  if: steps.verify.outputs.valid == 'false' && github.ref == 'refs/heads/main'
   uses: actions/github-script@v7
   with:
     script: |
@@ -397,7 +449,9 @@ jobs:
       - run: npm ci
 
       - name: Verify all gates
-        run: npx attest-it verify
+        uses: attest-it/github-action@v1
+        with:
+          fail-on-missing: 'true'
 ```
 
 ### Verify Per Package
@@ -438,7 +492,9 @@ jobs:
       - run: npm ci
 
       - name: Verify ${{ matrix.package }}
-        run: npx attest-it verify ${{ matrix.package }}
+        uses: attest-it/github-action@v1
+        with:
+          suite: ${{ matrix.package }}
 ```
 
 ## Security Considerations
@@ -491,9 +547,11 @@ Forks can't access secrets. For public repos:
 
 ```yaml
 - name: Verify seals
-  # Skip on forks
+  # Skip on forks (the Action needs a token to read the base-branch policy)
   if: github.event.pull_request.head.repo.full_name == github.repository
-  run: npx attest-it verify
+  uses: attest-it/github-action@v1
+  with:
+    fail-on-missing: 'true'
 ```
 
 ### Stale Seals

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -117,6 +117,15 @@ policy load + CODEOWNERS + post-merge re-verify) covers the threat. If the PRD
 owner decides the Action should self-verify its own invocation, that is tracked
 as a follow-up.
 
+_CLI-native equivalent for non-GitHub CI:_ `attest-it verify --base <ref>` performs
+the same base-vs-worktree check off GitHub — authorization comes from `<ref>`, so a
+self-added root signer is rejected as `UNKNOWN_SIGNER`.
+
+_Adversarial tests (run in CI):_
+`packages/cli/test/integration/root-gate.integration.test.ts`
+("verify --base … ADVERSARIAL (Scenario B)", "POSITIVE", "FAIL-CLOSED") exercise the
+CLI trusted-ref boundary end-to-end against a self-rewritten, self-resealed policy.
+
 ### T3 — An agent replays a seal against different content
 
 _Threat:_ a proposal branch reuses a previously-valid seal for content that has
@@ -144,12 +153,22 @@ noted here so the boundary is explicit rather than assumed.
 
 ## Residual risks and boundaries
 
-- **Local `attest-it verify` trusts the local policy.** On a developer's own
-  machine there is no trusted base branch to compare against, so a locally-edited
-  `policy.yaml` that is re-anchored locally will verify locally. The enforcement
-  boundary that matters is the **merge gate** (the Action, which loads policy from
-  the base branch) plus branch protection / CODEOWNERS. Local verification is a
-  fast pre-check, not the trust boundary.
+- **Plain `attest-it verify` trusts the local policy.** With no `--base`, `verify`
+  evaluates against the working-tree `policy.yaml`, so a locally-edited policy that
+  is re-anchored locally will verify. That is a fast pre-check, **not** the trust
+  boundary. The enforcement boundaries that matter are:
+  - the **GitHub Action** (the merge gate — loads policy from the PR base branch),
+    plus branch protection / CODEOWNERS; and
+  - **`attest-it verify --base <ref>`** for non-GitHub CI, which sources
+    `rootGate`/`team`/`gates` from `<ref>` while fingerprinting and reading seals
+    from the working tree. A branch that self-adds a root signer and re-seals is
+    rejected as `UNKNOWN_SIGNER`, exactly as the Action rejects it — because the
+    authorized signer set comes from the trusted ref, not the working tree.
+
+  `--base` fails **closed**: if the ref or its `policy.yaml` cannot be read (e.g. a
+  shallow clone missing the ref), it errors rather than falling back to the
+  untrusted working-tree policy.
+
 - **attest-it proves existence of a valid seal, never permission.** Usage grants,
   session scoping, and human-presence enforcement are the key backend's / the
   toolsmith's responsibility; attest-it verifies the resulting signatures.

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -10,6 +10,7 @@ import {
   verifyRootGate,
   isBlockingRootGateState,
   SplitConfigNotFoundError,
+  type AttestItConfig,
   type VerificationState,
   type SealVerificationResult,
   type RootGateVerificationResult,
@@ -25,13 +26,26 @@ import {
   type TableRow,
 } from '../utils/output.js'
 import { ExitCode } from '../utils/exit-codes.js'
+import { readPolicyFromRef, GitRefPolicyError } from '../utils/git-policy.js'
 
 export const verifyCommand = new Command('verify')
   .description(
-    'Verify gate seals against the local policy (fast local pre-check, not a CI trust gate)',
+    'Verify gate seals. Without --base this is a fast LOCAL pre-check (trusts the ' +
+      'working-tree policy), NOT a CI trust gate. Pass --base <ref> to make it the ' +
+      'CI-safe trust boundary: authorization (rootGate/team/gates) is loaded from ' +
+      '<ref>, mirroring the GitHub Action.',
   )
   .argument('[gates...]', 'Verify specific gates only')
   .option('--json', 'Output JSON for machine parsing')
+  .option(
+    '--base <ref>',
+    'Load trust-critical policy (rootGate, team, gates) from this git ref instead ' +
+      'of the working tree, while fingerprinting and reading seals from the working ' +
+      'tree. This is the CI-safe trust boundary for non-GitHub CI — a PR that ' +
+      'self-adds a signer and re-seals cannot pass, because authorization comes from ' +
+      '<ref>. Mirrors the GitHub Action, which loads policy from the PR base branch. ' +
+      'The ref must already be present locally (fetch it first in a shallow clone).',
+  )
   .action(async (gates: string[], options: VerifyOptions, command: Command) => {
     const configPath = command.parent?.opts<{ config?: string }>().config
     await runVerify(gates, options, configPath)
@@ -39,6 +53,7 @@ export const verifyCommand = new Command('verify')
 
 interface VerifyOptions {
   json?: boolean
+  base?: string
 }
 
 /**
@@ -48,21 +63,24 @@ interface VerifyOptions {
  * gates, and (when the policy is trust-anchored) checks the root-gate seal over
  * `policy.yaml` first.
  *
- * ## This is a local pre-check, NOT the CI trust boundary
+ * ## Plain `verify` is a local pre-check; `--base` is the CI trust boundary
  *
- * Local `verify` evaluates everything against the **working tree's** policy:
- * `rootGate`, `team`, and `gates` are read from the local `policy.yaml`. That is
- * correct for a developer checking their own tree, but it is **not** safe as a
- * pull-request gate. A branch can rewrite its own `rootGate.authorizedSigners` to
- * a key it controls and re-seal the policy; local `verify` trusts that local
+ * Without `--base`, `verify` evaluates everything against the **working tree's**
+ * policy: `rootGate`, `team`, and `gates` are read from the local `policy.yaml`.
+ * That is correct for a developer checking their own tree, but it is **not** safe
+ * as a pull-request gate. A branch can rewrite its own `rootGate.authorizedSigners`
+ * to a key it controls and re-seal the policy; plain `verify` trusts that local
  * anchor and reports VALID by design (see the "Scenario B" regression test in
  * `packages/cli/test/integration/root-gate.integration.test.ts`).
  *
- * The trust boundary is the **GitHub Action** (`@attest-it/github-action`), which
- * sources `rootGate`/`team`/`gates` from the **base branch**, so a self-added root
- * signer is rejected as `UNKNOWN_SIGNER`. For CI, use the Action. A CLI-native
- * base-vs-worktree mode (`verify --base <ref>`) is planned in #115; until it
- * lands, do not rely on plain local `verify` to gate untrusted proposal branches.
+ * `verify --base <ref>` closes that gap: it sources `rootGate`/`team`/`gates` from
+ * `<ref>`'s copy of `policy.yaml` (the trusted base) while computing fingerprints
+ * and reading seals from the working tree — the SAME base-vs-worktree check the
+ * **GitHub Action** (`@attest-it/github-action`) performs. A self-added root signer
+ * is then rejected as `UNKNOWN_SIGNER`, because the base ref does not list it. Use
+ * the Action on GitHub, or `verify --base <ref>` for non-GitHub CI. `--base` fails
+ * **closed**: an unreadable/missing ref or policy is a `CONFIG_ERROR`, never a
+ * silent pass on the working-tree policy.
  *
  * Exits {@link ExitCode.CONFIG_ERROR} — never {@link ExitCode.SUCCESS} — when no
  * configuration can be found at all (no `.attest-it/policy.yaml` discoverable, or an
@@ -80,15 +98,44 @@ async function runVerify(
   options: VerifyOptions,
   configPath?: string,
 ): Promise<void> {
+  const projectRoot = process.cwd()
+
   try {
-    // Load split config (policy + operational, merged). An explicit --config path
-    // overrides policy auto-detection; otherwise policy/operational are auto-detected.
-    const config = await loadSplitConfig(
-      configPath ? { policySource: { type: 'filesystem', path: configPath } } : {},
-    )
+    // Resolve the working-tree policy path up front: even in --base mode we
+    // fingerprint and read seals from the working tree, and we need this path to
+    // locate the same file at the base ref.
+    const workingTreePolicyPath = configPath ?? findPolicyPath(projectRoot)
+
+    // Load split config (policy + operational, merged). The trust-critical policy
+    // (rootGate/team/gates) comes from either:
+    //   --base <ref>: <ref>'s committed policy.yaml — the trusted source, mirroring
+    //     the GitHub Action's base-branch load. This makes verify a genuine CI trust
+    //     boundary: a working-tree edit that self-adds a signer cannot pass.
+    //   default: the working-tree policy.yaml (fast local pre-check).
+    // The operational config (suites) is always read from the working tree in both
+    // modes — suites carry no authorization, matching the Action.
+    let config: AttestItConfig
+    if (options.base !== undefined) {
+      if (!workingTreePolicyPath) {
+        // --base requires a working-tree policy to fingerprint against. Fail closed
+        // rather than silently skipping the trust check.
+        error(
+          'No policy file found to verify. --base loads authorization from the ref ' +
+            'but still fingerprints the working-tree .attest-it/policy.yaml, which is missing.',
+        )
+        process.exit(ExitCode.CONFIG_ERROR)
+      }
+      const refPolicy = readPolicyFromRef(options.base, workingTreePolicyPath, projectRoot)
+      config = await loadSplitConfig({
+        policySource: { type: 'content', content: refPolicy.content, format: refPolicy.format },
+      })
+    } else {
+      config = await loadSplitConfig(
+        configPath ? { policySource: { type: 'filesystem', path: configPath } } : {},
+      )
+    }
 
     // Read seals (needed for both the root-gate pre-step and gate evaluation).
-    const projectRoot = process.cwd()
     const sealsFile = readSealsSync(projectRoot, config.settings.sealsPath)
 
     // MANDATORY PRE-STEP: verify the config's OWN seal chain against the root
@@ -96,11 +143,22 @@ async function runVerify(
     // against a policy whose own root-gate seal did not verify. Repositories that
     // have not run the bootstrap ceremony define no rootGate; there is no trust
     // anchor to check, so evaluation proceeds unchanged (backward compatibility).
+    //
+    // In --base mode the authorized signer set comes from the trusted ref, so a
+    // working-tree policy that self-adds a root signer and re-seals is rejected as
+    // UNKNOWN_SIGNER (the ref does not list it) — the same rejection the Action makes.
     if (config.rootGate) {
-      const policyPath = configPath ?? findPolicyPath(projectRoot)
+      const policyPath = workingTreePolicyPath
       if (policyPath) {
         const policyFingerprint = computePolicyFingerprintSync(projectRoot, policyPath)
-        const rootResult = verifyRootGate({ config, policyFingerprint, seals: sealsFile })
+        const rootResult = verifyRootGate({
+          config,
+          policyFingerprint,
+          seals: sealsFile,
+          ...(options.base !== undefined && {
+            trustedSourceLabel: `root signers from ${options.base}`,
+          }),
+        })
 
         if (isBlockingRootGateState(rootResult.state)) {
           if (options.json) {
@@ -193,7 +251,11 @@ async function runVerify(
       process.exit(ExitCode.SUCCESS)
     }
   } catch (err) {
-    if (err instanceof SplitConfigNotFoundError) {
+    if (err instanceof GitRefPolicyError) {
+      // --base could not read the trusted policy from the ref. Fail CLOSED: an
+      // unreadable base ref is an indeterminate trust state, never a silent pass.
+      error(err.message)
+    } else if (err instanceof SplitConfigNotFoundError) {
       // No discoverable config (or an unreadable --config path): fail closed with
       // a legible, actionable message rather than exiting 0 on an indeterminate state.
       error(err.message)

--- a/packages/cli/src/utils/git-policy.ts
+++ b/packages/cli/src/utils/git-policy.ts
@@ -1,0 +1,102 @@
+/**
+ * Read the trust-critical policy file from a git ref (a trusted base), so the
+ * CLI's `verify --base <ref>` can enforce the SAME base-vs-worktree trust check
+ * the GitHub Action performs.
+ *
+ * The Action sources `rootGate`/`team`/`gates` from the pull request's base
+ * branch (via the GitHub API) while fingerprinting and reading seals from the
+ * PR working tree. Off GitHub there is no API, but the base ref is normally
+ * present locally (a checkout or a fetched ref), so we read the base copy of
+ * `policy.yaml` with `git show`. The trust mechanism itself (root-gate
+ * verification against the trusted config) is unchanged and lives in
+ * `@attest-it/core`; this module only supplies the trusted policy bytes.
+ *
+ * @packageDocumentation
+ */
+
+import { spawnSync } from 'node:child_process'
+import { relative } from 'node:path'
+
+/**
+ * Error thrown when the base ref's policy file cannot be read. `verify --base`
+ * must fail **closed** on any such error (missing ref, missing file, no git),
+ * never fall open to the untrusted working-tree policy — so callers treat this
+ * as a configuration error with an actionable message.
+ * @public
+ */
+export class GitRefPolicyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'GitRefPolicyError'
+  }
+}
+
+/**
+ * The policy content read from a git ref, plus the parse format inferred from
+ * the policy file's extension.
+ * @public
+ */
+export interface RefPolicy {
+  /** Raw policy file content as committed at the ref. */
+  content: string
+  /** Parse format, inferred from the policy path extension. */
+  format: 'yaml' | 'json'
+}
+
+/**
+ * Read `policy.yaml` (or `.yml`/`.json`) as it exists at a git ref.
+ *
+ * Uses `git show <ref>:./<path-relative-to-cwd>` so it resolves correctly even
+ * when the CLI is invoked from a subdirectory of the repository. The ref must
+ * already be present locally — fetching it is the caller's / CI's job; a missing
+ * ref fails closed with guidance rather than silently trusting the working tree.
+ *
+ * @param ref - Git ref (branch, tag, or commit SHA) providing the trusted policy.
+ * @param policyPathAbs - Absolute path to the working-tree policy file, used to
+ *   locate the same path at the ref and to infer the parse format.
+ * @param cwd - Working directory git resolves the relative path against. Defaults
+ *   to `process.cwd()`.
+ * @returns The policy content at the ref and its parse format.
+ * @throws {@link GitRefPolicyError} If git is unavailable, the ref is missing, or
+ *   the policy file does not exist at the ref.
+ * @public
+ */
+export function readPolicyFromRef(
+  ref: string,
+  policyPathAbs: string,
+  cwd: string = process.cwd(),
+): RefPolicy {
+  // git's `<ref>:./path` spelling resolves `path` relative to cwd, so this works
+  // from a repository subdirectory. Normalize to forward slashes for git on any OS.
+  const relFromCwd = relative(cwd, policyPathAbs).split('\\').join('/')
+  const spec = `${ref}:./${relFromCwd}`
+
+  const result = spawnSync('git', ['show', spec], {
+    cwd,
+    encoding: 'utf8',
+    // Policy files are small; a generous cap still guards against pathological input.
+    maxBuffer: 16 * 1024 * 1024,
+  })
+
+  if (result.error) {
+    // git could not be spawned at all (most commonly: not installed / not on PATH).
+    // Fail closed with an actionable message rather than trusting the working tree.
+    throw new GitRefPolicyError(
+      `Cannot read policy from ref '${ref}': failed to run git (${result.error.message}). ` +
+        '`verify --base` requires git on PATH to read the trusted base policy.',
+    )
+  }
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim()
+    throw new GitRefPolicyError(
+      `Cannot read '${relFromCwd}' from ref '${ref}'. ` +
+        'Ensure the ref exists locally (a shallow CI clone may need ' +
+        `\`git fetch origin ${ref}\`) and that the policy file exists there.` +
+        (stderr ? `\n  git: ${stderr}` : ''),
+    )
+  }
+
+  const format: 'yaml' | 'json' = policyPathAbs.endsWith('.json') ? 'json' : 'yaml'
+  return { content: result.stdout, format }
+}

--- a/packages/cli/test/integration/root-gate.integration.test.ts
+++ b/packages/cli/test/integration/root-gate.integration.test.ts
@@ -27,6 +27,7 @@ import {
   verifyRootGate,
   ROOT_GATE_ID,
   type AttestItConfig,
+  type Seal,
   type SealsFile,
 } from '@attest-it/core'
 
@@ -334,6 +335,142 @@ describe('root gate — CLI verify against tampered/valid policy.yaml (#72)', ()
       seals: { version: 1, seals: { [ROOT_GATE_ID]: rootSeal } },
     })
     expect(baseResult.state).toBe('UNKNOWN_SIGNER')
+  })
+})
+
+describe('verify --base <ref> — CLI trusted-ref mode is a genuine CI trust boundary (#115)', () => {
+  let dir: string
+  let ownerPrivateKey: string
+  let ownerPublicKey: string
+
+  // Seal the current on-disk policy under the root gate with the given signer/key.
+  function sealRootWith(signer: string, privateKey: string): Seal {
+    const policyPath = path.join(dir, '.attest-it', 'policy.yaml')
+    return createRootSeal({
+      policyFingerprint: computePolicyFingerprintSync(dir, policyPath),
+      sealedBy: signer,
+      privateKey,
+    })
+  }
+
+  async function gateFingerprint(gate: string): Promise<string> {
+    const statusJson = await runCli(['status', gate, '--json'], dir)
+    return (JSON.parse(statusJson.stdout) as { currentFingerprint: string }[])[0]!
+      .currentFingerprint
+  }
+
+  beforeEach(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-verify-base-'))
+    await copyDir(FIXTURE_PATH, dir)
+
+    const kp = generateEd25519KeyPair()
+    ownerPrivateKey = kp.privateKey
+    ownerPublicKey = kp.publicKey
+
+    // Trusted base state: test-user (alice) is the SOLE root signer and team member.
+    editPolicy(dir, (policy) => {
+      policy.rootGate = { authorizedSigners: ['test-user'] }
+      const team = policy.team as Record<string, { publicKey: string }>
+      team['test-user'].publicKey = ownerPublicKey
+    })
+
+    await runGit(['init'], dir)
+    await runGit(['config', 'user.email', 'test@example.com'], dir)
+    await runGit(['config', 'user.name', 'Test User'], dir)
+    await runGit(['add', '.'], dir)
+    // This commit (HEAD) is the TRUSTED base ref: policy lists only test-user.
+    await runGit(['commit', '-m', 'anchor trusted policy on base'], dir)
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(dir, { recursive: true, force: true })
+  })
+
+  it('ADVERSARIAL (Scenario B): a self-rewritten + self-resealed rootGate FAILS `verify --base HEAD`, while plain `verify` (local pre-check) still passes', async () => {
+    // Attacker "eve" is NOT a signer on the trusted base (HEAD). In the WORKING
+    // TREE she rewrites the policy: adds herself to team + rootGate.authorizedSigners,
+    // authorizes herself on the example gate, then re-seals BOTH the root gate and
+    // the example gate with her own key over the tampered working-tree policy.
+    const eve = generateEd25519KeyPair()
+    editPolicy(dir, (policy) => {
+      policy.rootGate = { authorizedSigners: ['eve'] }
+      const team = policy.team as Record<string, unknown>
+      team.eve = { name: 'Eve', publicKey: eve.publicKey }
+      const gates = policy.gates as Record<string, { authorizedSigners: string[] }>
+      gates['example-gate'].authorizedSigners = ['eve']
+    })
+
+    const rootSeal = sealRootWith('eve', eve.privateKey)
+    const gateSeal = createSeal({
+      gateId: 'example-gate',
+      fingerprint: await gateFingerprint('example-gate'),
+      sealedBy: 'eve',
+      privateKey: eve.privateKey,
+    })
+    writeSeals(dir, { version: 1, seals: { [ROOT_GATE_ID]: rootSeal, 'example-gate': gateSeal } })
+    // The tamper stays in the WORKING TREE (uncommitted): HEAD remains the trusted
+    // base that `--base HEAD` reads authorization from.
+
+    // BY DESIGN: plain local verify trusts the working-tree anchor -> PASSES.
+    const local = await runCli(['verify', 'example-gate'], dir)
+    expect(local.exitCode).toBe(0)
+    expect(local.stdout).toContain('VALID')
+
+    // TRUST BOUNDARY: `--base HEAD` sources rootGate/team from the trusted base
+    // (only test-user), so eve's self-seal is rejected as UNKNOWN_SIGNER. The
+    // failure NAMES the untrusted policy change rather than emitting a generic error.
+    const gated = await runCli(['verify', 'example-gate', '--base', 'HEAD'], dir)
+    expect(gated.exitCode).toBe(1)
+    const combined = gated.stdout + gated.stderr
+    expect(combined).toContain('.attest-it/policy.yaml')
+    expect(combined.toLowerCase()).toContain('root signer')
+
+    // Machine-readable proof of the exact state for JSON consumers.
+    const gatedJson = await runCli(['verify', 'example-gate', '--base', 'HEAD', '--json'], dir)
+    expect(gatedJson.exitCode).toBe(1)
+    const parsed = JSON.parse(gatedJson.stdout) as { gateId: string; state: string }[]
+    expect(parsed[0]?.state).toBe('UNKNOWN_SIGNER')
+  })
+
+  it('POSITIVE: a working-tree policy change re-sealed by a genuine base-branch root signer verifies under `--base HEAD`', async () => {
+    // A legitimate change: the base root signer (test-user) adds a new dev to the
+    // team in the WORKING TREE and RE-SEALS the root gate with their OWN key. Because
+    // test-user IS a root signer on the trusted base, `--base HEAD` accepts it.
+    const dev = generateEd25519KeyPair()
+    editPolicy(dir, (policy) => {
+      const team = policy.team as Record<string, unknown>
+      team.dev = { name: 'Dev', publicKey: dev.publicKey }
+    })
+
+    const rootSeal = sealRootWith('test-user', ownerPrivateKey)
+    const gateSeal = createSeal({
+      gateId: 'example-gate',
+      fingerprint: await gateFingerprint('example-gate'),
+      sealedBy: 'test-user',
+      privateKey: ownerPrivateKey,
+    })
+    writeSeals(dir, { version: 1, seals: { [ROOT_GATE_ID]: rootSeal, 'example-gate': gateSeal } })
+
+    const result = await runCli(['verify', 'example-gate', '--base', 'HEAD'], dir)
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('VALID')
+    expect(result.stdout + result.stderr).not.toContain('Untrusted')
+  })
+
+  it('FAIL-CLOSED: `--base` against a nonexistent ref errors with actionable guidance, never a silent pass', async () => {
+    // Even with a perfectly valid working tree, an unreadable base ref is an
+    // indeterminate trust state and must fail closed (CONFIG_ERROR = 3), not exit 0.
+    const rootSeal = sealRootWith('test-user', ownerPrivateKey)
+    writeSeals(dir, { version: 1, seals: { [ROOT_GATE_ID]: rootSeal } })
+
+    const result = await runCli(
+      ['verify', 'example-gate', '--base', 'refs/heads/does-not-exist'],
+      dir,
+    )
+    expect(result.exitCode).toBe(3)
+    expect(result.stdout + result.stderr).toContain('does-not-exist')
+    // Actionable: points the user at fetching the ref.
+    expect((result.stdout + result.stderr).toLowerCase()).toContain('fetch')
   })
 })
 


### PR DESCRIPTION
## Summary

Ships two paired, P0 security / trust-boundary changes together:

- **#115 (code):** a new `attest-it verify --base <ref>` trusted-ref mode that makes the CLI a genuine CI trust boundary for non-GitHub CI.
- **#128 (docs):** reconciles every doc that recommended bare `attest-it verify` as the CI gate to the real boundary (the GitHub Action, or `verify --base <ref>`).

### The problem

Plain `attest-it verify` evaluates the root gate and all gates against the **working-tree** `.attest-it/policy.yaml`. That is correct for a fast local pre-check, but it means a self-bootstrapping tamper — rewrite `rootGate.authorizedSigners` to an attacker key, re-seal the policy with that key — passes local `verify` with exit 0. Only the GitHub Action caught this, because it sources `rootGate`/`team`/`gates` from the PR **base branch** while fingerprinting the working tree. The README, however, marketed "a PR can't add itself to team/gates and pass verification" and showed bare `npx attest-it verify` as THE CI gate — an unbacked guarantee.

## #115 — how `--base` loads the trusted ref

`verify --base <ref>` reuses the Action's exact trust mechanism (`verifyRootGate` in `@attest-it/core`), not a second one. It only changes **where the trusted policy bytes come from**:

- New `packages/cli/src/utils/git-policy.ts` reads `policy.yaml` as committed at `<ref>` via `git show <ref>:./<path>` (the `:./` spelling resolves from the cwd, so it works from a subdirectory). The Action reads the base policy over the GitHub API; off GitHub the base ref is normally present locally, so we read it with git.
- `packages/cli/src/commands/verify.ts` then loads `rootGate`/`team`/`gates` from that ref content (`loadSplitConfig` with a `content` policy source), while computing the policy fingerprint and reading seals from the **working tree** — mirroring `packages/github-action/src/index.ts`. Operational config (suites) is still read from the working tree in both modes (suites carry no authorization).
- Because authorization comes from the ref, a working-tree policy that self-adds a root signer and re-seals is rejected as `UNKNOWN_SIGNER`.
- `--base` fails **closed**: an unreadable ref or a missing policy at the ref is a `CONFIG_ERROR` (exit 3) with actionable guidance (`git fetch origin <ref>`), never a silent pass on the working-tree policy. Default (no-flag) `verify` behavior is unchanged.

## #128 — docs reconciled

A prominent "local `verify` is a fast pre-check, NOT the trust boundary" warning now sits next to every CI snippet, and every CI recipe that showed bare `verify` as the gate points at the Action or `verify --base`:

- `README.md` — Quick Start callout, non-interactive CI section, CLI-table `verify` wording (now matches `--help`), and the "sealed root gate" security bullet made precise.
- `docs/getting-started.md` — Step 6 warning + Action-first recipe + a non-GitHub `--base` recipe; the status-vs-verify note points at the trusted gate.
- `docs/github-integration.md` — top banner + a dedicated "Non-GitHub CI: `verify --base`" section; every workflow snippet (Quick Start, Strategies 1–3, PR/Deploy/Hybrid gating, failure handling, monorepo, fork PRs) now uses the base-anchored Action.
- `docs/threat-model.md` — residual-risks bullet documents `--base` (and its fail-closed behavior); T2 cross-references the new CLI adversarial tests.
- `docs/examples/README.md`, `docs/examples/vitest-example.md` — CI templates updated to the Action; local `verify` labeled as a pre-check.

## Acceptance criteria → tests

All new tests are in `packages/cli/test/integration/root-gate.integration.test.ts` and drive the real built CLI binary.

**#115**

- `--base` sources authorization from the ref while fingerprinting/reading seals from the working tree — covered by both `--base` tests (they only pass because authorization is base-anchored).
- Adversarial "Scenario B" (self-rewrite `rootGate.authorizedSigners` + re-seal → `UNKNOWN_SIGNER` under `--base`, while plain `verify` still passes) — covered by **"ADVERSARIAL (Scenario B): a self-rewritten + self-resealed rootGate FAILS `verify --base HEAD`, while plain `verify` (local pre-check) still passes"**. Asserts the `--base` run exits 1, names `.attest-it/policy.yaml` + "root signer", and `--json` reports state `UNKNOWN_SIGNER`; and that bare `verify` exits 0.
- Positive: a legitimately root-sealed change verifies under `--base` — covered by **"POSITIVE: a working-tree policy change re-sealed by a genuine base-branch root signer verifies under `--base HEAD`"**.
- Missing/unreadable ref fails closed with an actionable message — covered by **"FAIL-CLOSED: `--base` against a nonexistent ref errors with actionable guidance, never a silent pass"** (exit 3, names the ref, mentions fetch).
- Help text presents `--base` as the CI-safe mode and cross-references the Action — command description + `--base` option help.
- JSON output/exit codes follow the existing contract — asserted via `--json` in the adversarial test.

The adversarial test is meaningfully red against pre-fix code: `--base` did not exist, so the assertions on the untrusted-change message cannot pass.

**#128**

- Every bare-`verify` CI recipe replaced/annotated; warning beside every `verify` mention; README CLI-table reconciled with `--help`; anti-self-modification guarantee stated as holding at the Action / `--base` boundary; #115 cross-linked as the CLI-native path. (Docs change; verified by inspection — no bare `run: npx attest-it verify` gate recipes remain.)

## Verification

- `nx run-many --target=build` (required gate): green.
- `@attest-it/cli` and `@attest-it/core` `check` (lint + typecheck + api-report): green (0 errors; pre-existing security/detect-object-injection warnings only).
- `@attest-it/cli` test: 811 passed; `@attest-it/core` test: 624 passed. (A first run tripped the known VaultKeeper test-isolation guard from unrelated identity tests; a clean re-run is fully green.)
- `prettier --check .`: clean.

## Changeset

`.changeset/verify-base-trusted-ref.md` — `@attest-it/cli` and the `attest-it` umbrella (ships the CLI binary) at **minor**. (The overall release is already major due to pre-existing changesets on `main`; this change adds no major bump of its own.)

## Owner gate

Both issues are PM-gated (security-doc + trust-boundary messaging). **Do not merge without PM review.**

Refs #115 #128
