### PR TITLE
fix(cli): unauthorized signer run/seal now fails hard instead of reporting success

### DIFF
--- a/.changeset/fix-unauthorized-signer-reports-success.md
+++ b/.changeset/fix-unauthorized-signer-reports-success.md
@@ -1,0 +1,6 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Fix `run`/`seal` reporting success for an unauthorized signer. An unauthorized-signer `attest-it run --suite ... --yes` previously printed `✓ Suite completed!`, exited `0`, and suggested a "To commit" hint for a seal that was never created; `attest-it seal --json` similarly reported `ok: true`. No seal was ever written in either case (verified: this was a reporting bug, not a trust hole — `verify` always correctly reported `MISSING` for the unsealed gate). Both commands now treat an unauthorized-signer attempt as a hard failure: a nonzero exit code, an unambiguous error banner with no `✓`, `ok: false` in `seal --json`, and no "To commit" hint. Authorized signers are unaffected.

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -267,7 +267,17 @@ async function runDirectMode(options: RunOptions): Promise<void> {
   }
 
   // Run the suite
-  await runSingleSuite(options.suite, config, options)
+  const outcome = await runSingleSuite(options.suite, config, options)
+
+  // An unauthorized signer never created a seal -- reporting "Suite
+  // completed!" (and a "To commit" hint for a seal that was never written)
+  // would tell a human or CI script that attestation succeeded when it did
+  // not. See issue #136.
+  if (outcome === 'unauthorized') {
+    log('')
+    error(`Suite '${options.suite}' failed: no seal was created (unauthorized signer)`)
+    process.exit(ExitCode.FAILURE)
+  }
 
   log('')
   success('Suite completed!')
@@ -322,7 +332,15 @@ async function runAllPending(options: RunOptions): Promise<void> {
 
   // Run each suite using existing direct mode logic
   for (const suite of suitesToRun) {
-    await runSingleSuite(suite.name, config, options)
+    const outcome = await runSingleSuite(suite.name, config, options)
+
+    // Same reasoning as runDirectMode: an unauthorized signer wrote no seal,
+    // so the run must not be reported as complete/successful. See issue #136.
+    if (outcome === 'unauthorized') {
+      log('')
+      error(`Suite '${suite.name}' failed: no seal was created (unauthorized signer)`)
+      process.exit(ExitCode.FAILURE)
+    }
   }
 
   log('')
@@ -331,18 +349,36 @@ async function runAllPending(options: RunOptions): Promise<void> {
 }
 
 /**
+ * Outcome of {@link runSingleSuite}'s seal-creation step, used by its callers
+ * to decide whether the overall command may report success.
+ *
+ * Only `'unauthorized'` suppresses the "Suite completed!" success banner and
+ * forces a nonzero exit -- an unauthorized signer's attempt writes no seal at
+ * all, so reporting success would tell the caller (human or CI script) a seal
+ * exists when it does not. See issue #136.
+ *
+ * The other skip reasons inside `promptForSeal` (no local identity
+ * configured, active identity not found, or the seal-creation call itself
+ * throwing) intentionally keep their pre-existing "warn and continue"
+ * behavior -- they are a distinct, non-security reporting gap tracked
+ * separately and are out of scope for this fix.
+ */
+type SealAttemptOutcome = 'sealed' | 'unauthorized' | 'not-attempted'
+
+/**
  * Run a single suite's tests and optionally create an attestation.
  *
  * @param suiteName - Name of the suite to run
  * @param config - Configuration object
  * @param options - Run options
+ * @returns The outcome of the suite's seal-creation attempt
  * @public
  */
 async function runSingleSuite(
   suiteName: string,
   config: AttestItConfig,
   options: RunOptions,
-): Promise<void> {
+): Promise<SealAttemptOutcome> {
   // eslint-disable-next-line security/detect-object-injection -- suiteName is from validated config keys
   const suiteConfig = config.suites[suiteName]
   if (!suiteConfig) {
@@ -388,13 +424,13 @@ async function runSingleSuite(
   // Skip sealing if --no-attest
   if (options.attest === false) {
     log('Skipping seal creation (--no-attest)')
-    return
+    return 'not-attempted'
   }
 
   // A successful run authorizes creating a seal for the suite's gate. The seal
   // is the single cryptographic record of the passing run (the legacy
   // attestations file has been retired).
-  await promptForSeal(suiteName, suiteConfig.gate, config, options.yes)
+  return await promptForSeal(suiteName, suiteConfig.gate, config, options.yes)
 }
 
 /**
@@ -412,17 +448,23 @@ async function runSingleSuite(
  * and a CI script must be able to tell a declined seal apart from
  * `SUCCESS` (0). See issue #100.
  *
+ * An unauthorized signer is reported the same way: it returns `'unauthorized'`
+ * (never writes a seal) so the caller can turn the whole command into a hard
+ * failure instead of the previous "warn and report success" behavior. See
+ * issue #136.
+ *
  * @param suiteName - Name of the suite that was executed
  * @param gateId - ID of the gate linked to the suite
  * @param config - Configuration object
  * @param autoConfirm - Skip the confirmation prompt and seal automatically (from `--yes`)
+ * @returns The outcome of the seal-creation attempt
  */
 async function promptForSeal(
   suiteName: string,
   gateId: string,
   config: AttestItConfig,
   autoConfirm?: boolean,
-): Promise<void> {
+): Promise<SealAttemptOutcome> {
   log('')
   log(`Suite '${suiteName}' is linked to gate '${gateId}'`)
 
@@ -431,21 +473,30 @@ async function promptForSeal(
   if (!localConfig) {
     warn('No local identity configuration found - cannot create seal')
     warn('Run "attest-it identity create" to set up your identity')
-    return
+    return 'not-attempted'
   }
 
   // Get active identity
   const identity = getActiveIdentity(localConfig)
   if (!identity) {
     warn(`Active identity '${localConfig.activeIdentity}' not found in local config`)
-    return
+    return 'not-attempted'
   }
 
-  // Check if user is authorized to seal this gate
+  // Check if user is authorized to seal this gate. Nothing has been signed or
+  // written yet, so refusing here is purely a reporting decision -- but it is
+  // the one that matters: reporting success (or even a soft warning) for an
+  // unauthorized attempt would tell the caller a seal exists when none was
+  // ever created. See issue #136.
   const authorized = isAuthorizedSigner(config, gateId, identity.publicKey)
   if (!authorized) {
-    warn(`You are not authorized to seal gate '${gateId}'`)
-    return
+    // eslint-disable-next-line security/detect-object-injection -- gateId is from validated config
+    const authorizedSigners = config.gates?.[gateId]?.authorizedSigners ?? []
+    error(
+      `Not authorized to seal gate '${gateId}' ` +
+        `(authorized signers: ${authorizedSigners.join(', ') || 'none'}). No seal was created.`,
+    )
+    return 'unauthorized'
   }
 
   // Resolve seal confirmation: --yes skips the prompt; interactively without
@@ -478,7 +529,7 @@ async function promptForSeal(
     // Get gate config
     if (!config.gates?.[gateId]) {
       error(`Gate '${gateId}' not found in configuration`)
-      return
+      return 'not-attempted'
     }
 
     // eslint-disable-next-line security/detect-object-injection
@@ -523,12 +574,14 @@ async function promptForSeal(
     success(`Seal created for gate '${gateId}'`)
     log(`  Sealed by: ${identitySlug} (${identity.name})`)
     log(`  Timestamp: ${seal.timestamp}`)
+    return 'sealed'
   } catch (err) {
     if (err instanceof Error) {
       error(`Failed to create seal: ${err.message}`)
     } else {
       error('Failed to create seal: Unknown error')
     }
+    return 'not-attempted'
   }
 }
 

--- a/packages/cli/src/commands/seal.ts
+++ b/packages/cli/src/commands/seal.ts
@@ -187,11 +187,19 @@ async function runSeal(gates: string[], options: SealOptions): Promise<void> {
       writeSealsSync(projectRoot, sealsFile, config.settings.sealsPath)
     }
 
+    // An unauthorized-signer attempt must never be reported as success: no seal
+    // was written for that gate, so `ok`/the exit code must reflect a hard
+    // failure rather than the generic "skipped" bucket (which also holds
+    // benign, non-failing skips like "already has a valid seal"). See #136.
+    const hasUnauthorizedSkip = summary.skipped.some(
+      (skip) => skip.failureClass === 'unauthorized-signer',
+    )
+
     // Output summary
     if (json) {
       outputJson({
         schemaVersion: API_SCHEMA_VERSION,
-        ok: summary.failed.length === 0,
+        ok: summary.failed.length === 0 && !hasUnauthorizedSkip,
         dryRun: options.dryRun ?? false,
         ...summary,
       })
@@ -200,7 +208,7 @@ async function runSeal(gates: string[], options: SealOptions): Promise<void> {
     }
 
     // Exit with appropriate code
-    if (summary.failed.length > 0) {
+    if (summary.failed.length > 0 || hasUnauthorizedSkip) {
       process.exit(ExitCode.FAILURE)
     } else if (summary.sealed.length === 0 && summary.skipped.length === 0) {
       process.exit(ExitCode.NO_WORK)
@@ -467,10 +475,27 @@ function displaySummary(summary: SealSummary, dryRun?: boolean): void {
     success(`${prefix} ${String(summary.sealed.length)} gate(s): ${gateNames}`)
   }
 
-  if (summary.skipped.length > 0) {
+  // An unauthorized-signer skip is a hard failure (nothing was sealed for
+  // that gate) and is rendered distinctly from benign skips (e.g. "already
+  // has a valid seal") so the banner is unambiguous -- no reader should be
+  // able to mistake "unauthorized" for an informational skip. See #136.
+  const unauthorizedSkips = summary.skipped.filter(
+    (skip) => skip.failureClass === 'unauthorized-signer',
+  )
+  const benignSkips = summary.skipped.filter((skip) => skip.failureClass !== 'unauthorized-signer')
+
+  if (benignSkips.length > 0) {
     log('')
-    warn(`Skipped ${String(summary.skipped.length)} gate(s):`)
-    for (const skip of summary.skipped) {
+    warn(`Skipped ${String(benignSkips.length)} gate(s):`)
+    for (const skip of benignSkips) {
+      log(`  ${skip.gate}: ${skip.reason}`)
+    }
+  }
+
+  if (unauthorizedSkips.length > 0) {
+    log('')
+    error(`Refused to seal ${String(unauthorizedSkips.length)} gate(s) (unauthorized signer):`)
+    for (const skip of unauthorizedSkips) {
       log(`  ${skip.gate}: ${skip.reason}`)
     }
   }

--- a/packages/cli/test/integration/unauthorized-signer.integration.test.ts
+++ b/packages/cli/test/integration/unauthorized-signer.integration.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Regression tests for issue #136: an unauthorized-signer `seal`/`run`
+ * reported success (`✓ Suite completed!`, exit 0, `ok:true` in `--json`)
+ * instead of failing, and printed a "To commit" hint for a seal that was
+ * never created.
+ *
+ * These drive the real, built `attest-it` binary (not an in-process
+ * approximation) through the exact repro from the issue: a gate authorizing
+ * only one team member, a second identity that is NOT authorized attempting
+ * to seal/run against it non-interactively (`--yes`, stdin closed).
+ *
+ * Verified pre-fix: both commands exited 0 with a success banner/`ok:true`
+ * and wrote no seal file (confirmed separately that `verify` reports
+ * `MISSING` afterwards) -- i.e. this was a reporting bug, not a trust hole.
+ * These tests fail against that pre-fix behavior (exit 0) and pass once the
+ * unauthorized outcome is a hard failure.
+ *
+ * @see https://github.com/mike-north/attest-it/issues/136
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+const CLI_CALL_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run the built CLI as a real subprocess with stdin closed (`< /dev/null`)
+ * and a hard timeout, matching the non-interactive-setup integration tests'
+ * convention: if the CLI ever falls back to a prompt, the test fails loudly
+ * instead of hanging.
+ */
+function runCliNonInteractive(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(CLI_CALL_TIMEOUT_MS)}ms: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+async function runGit(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', args, { cwd, stdio: 'ignore' })
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`git ${args.join(' ')} exited with code ${String(code)}`))
+      }
+    })
+    child.on('error', reject)
+  })
+}
+
+function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/** Read the public key attest-it just wrote for `slug` under a temp ATTEST_IT_HOME. */
+async function readCreatedPublicKey(homeDir: string, slug: string): Promise<string> {
+  const content = await fs.promises.readFile(path.join(homeDir, 'config.yaml'), 'utf8')
+  const parsed: unknown = parseYaml(content)
+  if (!isRecordOfUnknown(parsed) || !isRecordOfUnknown(parsed.identities)) {
+    throw new Error('Expected local config to contain an identities map')
+  }
+  const identity = parsed.identities[slug]
+  if (!isRecordOfUnknown(identity) || typeof identity.publicKey !== 'string') {
+    throw new Error(`Expected identity "${slug}" to have a string publicKey`)
+  }
+  return identity.publicKey
+}
+
+describe('unauthorized signer seal/run reporting (issue #136)', () => {
+  let projectDir: string
+  let homeDir: string
+  let env: NodeJS.ProcessEnv
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-136-project-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-136-home-'))
+    env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
+
+    // A trivial source file so fingerprinting has something to hash.
+    await fs.promises.mkdir(path.join(projectDir, 'src'), { recursive: true })
+    await fs.promises.writeFile(path.join(projectDir, 'src', 'index.ts'), 'export const x = 1\n')
+
+    await runGit(['init'], projectDir)
+    await runGit(['config', 'user.email', 'test@example.com'], projectDir)
+    await runGit(['config', 'user.name', 'Test User'], projectDir)
+    await runGit(['add', '.'], projectDir)
+    await runGit(['commit', '-m', 'initial commit'], projectDir)
+
+    // Two identities: alice is the only authorized signer for gate "g"; bob
+    // is a legitimate team member with no signing rights for it -- the exact
+    // repro from the issue.
+    const createAlice = await runCliNonInteractive(
+      ['identity', 'create', '--name', 'Alice', '--slug', 'alice', '--storage', 'file'],
+      projectDir,
+      env,
+    )
+    expect(createAlice.exitCode).toBe(0)
+    const createBob = await runCliNonInteractive(
+      ['identity', 'create', '--name', 'Bob', '--slug', 'bob', '--storage', 'file'],
+      projectDir,
+      env,
+    )
+    expect(createBob.exitCode).toBe(0)
+
+    const alicePublicKey = await readCreatedPublicKey(homeDir, 'alice')
+    const bobPublicKey = await readCreatedPublicKey(homeDir, 'bob')
+
+    const initResult = await runCliNonInteractive(['init'], projectDir, env)
+    expect(initResult.exitCode).toBe(0)
+
+    const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+    const policy = {
+      version: 1,
+      settings: { maxAgeDays: 30 },
+      team: {
+        alice: { name: 'Alice', publicKey: alicePublicKey, publicKeyAlgorithm: 'ed25519' },
+        bob: { name: 'Bob', publicKey: bobPublicKey, publicKeyAlgorithm: 'ed25519' },
+      },
+      gates: {
+        g: {
+          name: 'Gate G',
+          description: 'Regression gate for issue 136',
+          authorizedSigners: ['alice'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      },
+    }
+    await fs.promises.writeFile(policyPath, stringifyYaml(policy), 'utf8')
+
+    const configPath = path.join(projectDir, '.attest-it', 'config.yaml')
+    const operationalConfig = {
+      version: 1,
+      settings: {},
+      suites: {
+        'g-suite': {
+          description: 'Regression suite for issue 136',
+          gate: 'g',
+          command: 'echo "tests passed"',
+        },
+      },
+    }
+    await fs.promises.writeFile(configPath, stringifyYaml(operationalConfig), 'utf8')
+
+    await runGit(['add', '.'], projectDir)
+    await runGit(['commit', '-m', 'configure gate g / suite g-suite'], projectDir)
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  it(
+    '`run --suite ... --yes` as an unauthorized signer fails hard: nonzero exit, ' +
+      'no ✓, no "To commit" hint, and no seal file is written',
+    async () => {
+      const useBob = await runCliNonInteractive(['identity', 'use', 'bob'], projectDir, env)
+      expect(useBob.exitCode).toBe(0)
+
+      const runResult = await runCliNonInteractive(
+        ['run', '--suite', 'g-suite', '--yes'],
+        projectDir,
+        env,
+      )
+
+      // Pre-fix this was exitCode 0 with "✓ Suite completed!" -- the
+      // regression this test guards against.
+      expect(runResult.exitCode).not.toBe(0)
+      expect(runResult.stdout + runResult.stderr).not.toContain('✓ Suite completed!')
+      expect(runResult.stdout + runResult.stderr).not.toContain('To commit:')
+      expect(runResult.stdout + runResult.stderr).toMatch(/not authorized|unauthorized/i)
+
+      expect(fs.existsSync(path.join(projectDir, '.attest-it', 'seals'))).toBe(false)
+
+      // verify must independently confirm nothing was sealed -- proves the
+      // unauthorized attempt never produced anything a verifier would accept.
+      const verifyResult = await runCliNonInteractive(['verify', 'g', '--json'], projectDir, env)
+      const verifyJson: unknown = JSON.parse(verifyResult.stdout)
+      expect(Array.isArray(verifyJson)).toBe(true)
+      const [gateStatus] = verifyJson as unknown[]
+      expect(isRecordOfUnknown(gateStatus) && gateStatus.state).toBe('MISSING')
+    },
+    CLI_CALL_TIMEOUT_MS * 6,
+  )
+
+  it(
+    '`seal --json` as an unauthorized signer reports ok:false with a nonzero exit ' +
+      'and writes no seal file',
+    async () => {
+      const useBob = await runCliNonInteractive(['identity', 'use', 'bob'], projectDir, env)
+      expect(useBob.exitCode).toBe(0)
+
+      const sealResult = await runCliNonInteractive(['seal', 'g', '--json'], projectDir, env)
+
+      // Pre-fix this was exitCode 0 with `ok: true` -- the regression this
+      // test guards against.
+      expect(sealResult.exitCode).not.toBe(0)
+      const json: unknown = JSON.parse(sealResult.stdout)
+      if (!isRecordOfUnknown(json)) {
+        throw new Error('Expected seal --json output to be an object')
+      }
+      expect(json.ok).toBe(false)
+      expect(Array.isArray(json.sealed) && json.sealed).toHaveLength(0)
+
+      expect(fs.existsSync(path.join(projectDir, '.attest-it', 'seals'))).toBe(false)
+    },
+    CLI_CALL_TIMEOUT_MS * 3,
+  )
+
+  it(
+    '`run --suite ... --yes` as the authorized signer still succeeds and writes a seal',
+    async () => {
+      // alice is already the active identity from `identity create` above.
+      const runResult = await runCliNonInteractive(
+        ['run', '--suite', 'g-suite', '--yes'],
+        projectDir,
+        env,
+      )
+
+      expect(runResult.exitCode).toBe(0)
+      expect(runResult.stdout).toContain('Suite completed!')
+      expect(runResult.stdout).toContain("Seal created for gate 'g'")
+      expect(fs.existsSync(path.join(projectDir, '.attest-it', 'seals'))).toBe(true)
+
+      const verifyResult = await runCliNonInteractive(['verify', 'g', '--json'], projectDir, env)
+      expect(verifyResult.exitCode).toBe(0)
+      const verifyJson: unknown = JSON.parse(verifyResult.stdout)
+      const [gateStatus] = verifyJson as unknown[]
+      expect(isRecordOfUnknown(gateStatus) && gateStatus.state).toBe('VALID')
+    },
+    CLI_CALL_TIMEOUT_MS * 6,
+  )
+
+  it(
+    '`seal --json` as the authorized signer still succeeds and writes a seal',
+    async () => {
+      const sealResult = await runCliNonInteractive(['seal', 'g', '--json'], projectDir, env)
+
+      expect(sealResult.exitCode).toBe(0)
+      const json: unknown = JSON.parse(sealResult.stdout)
+      if (!isRecordOfUnknown(json)) {
+        throw new Error('Expected seal --json output to be an object')
+      }
+      expect(json.ok).toBe(true)
+      expect(Array.isArray(json.sealed) && json.sealed).toHaveLength(1)
+      expect(fs.existsSync(path.join(projectDir, '.attest-it', 'seals'))).toBe(true)
+    },
+    CLI_CALL_TIMEOUT_MS * 3,
+  )
+})

--- a/packages/cli/test/seal.test.ts
+++ b/packages/cli/test/seal.test.ts
@@ -109,7 +109,12 @@ describe('seal --json', () => {
   beforeEach(() => vi.clearAllMocks())
   afterEach(() => vi.clearAllMocks())
 
-  it('reports an unauthorized identity as unauthorized-signer and writes no seal', async () => {
+  it('reports an unauthorized identity as unauthorized-signer, writes no seal, and exits non-zero with ok:false (regression for #136)', async () => {
+    // Regression test for #136: an unauthorized signer used to be reported as
+    // a benign "skip" with exit 0 and `ok: true`, which told a CI script that
+    // sealing succeeded when no seal was ever written. Pre-fix, this test
+    // asserted `mockProcessExit` was called with `0` and made no assertion on
+    // `ok` -- it now asserts the corrected hard-failure behavior.
     const config = mockConfig()
     vi.mocked(loadSplitConfig).mockResolvedValue(config)
     vi.mocked(loadLocalConfigSync).mockReturnValue(mockLocalConfig('mallory'))
@@ -130,10 +135,11 @@ describe('seal --json', () => {
     const printed = mockConsoleLog.mock.calls.map((c) => String(c[0])).join('\n')
     expect(printed).toContain('"schemaVersion"')
     expect(printed).toContain('unauthorized-signer')
+    expect(printed).toContain('"ok": false')
     // No seal file was written.
     expect(writeSealsSync).not.toHaveBeenCalled()
-    // Skips (but no failures) exit successfully.
-    expect(mockProcessExit).toHaveBeenCalledWith(0)
+    // An unauthorized-signer attempt is a hard failure, not a benign skip.
+    expect(mockProcessExit).toHaveBeenCalledWith(1)
   })
 
   // Regression: `seal` used to skip resealing whenever *any* seal existed for


### PR DESCRIPTION
## Summary

Fixes a P1 reporting bug: an **unauthorized signer**'s `attest-it run --suite ... --yes` printed `✓ Suite completed!`, exited `0`, and suggested a "To commit" hint for a seal that was never created. `attest-it seal --json` similarly reported `ok: true` for the same case. Both commands now treat an unauthorized-signer attempt as a **hard failure**.

## Trust verification (required pre-work, per issue #136)

Before making any change, I re-confirmed in source and via a live repro that this is a **reporting bug, not a trust hole**:

- In both `packages/cli/src/commands/run.ts` (`promptForSeal`) and `packages/cli/src/commands/seal.ts` (`processSingleGate`), the `isAuthorizedSigner(...)` check runs **before** any call to `createSealWithProvider`/`writeSealsSync`. The unauthorized branch returns/skips immediately — no seal is ever signed or written to disk.
- Live repro (gate `g`, `authorizedSigners: [alice]`, suite `g-suite -> g`; `identity use bob` (unauthorized)):
  - `run --suite g-suite --yes </dev/null` (pre-fix): `✓ Suite completed!`, exit `0`, **no** `.attest-it/seals/` created.
  - `seal g --json` (pre-fix): `"ok": true`, `"sealed": []`, **no** seal file.
  - `verify g` after either: `MISSING`, exit `1` — a verifier (and the Action) would never accept anything from the unauthorized attempt, because nothing was ever produced.
- **Conclusion: no trust hole.** An unauthorized signer cannot produce a seal that `verify` (or the Action) would accept. This is purely a success/failure *reporting* defect, so I proceeded with the messaging/exit-code fix per the issue's guidance.

## Fix

- `packages/cli/src/commands/run.ts`: `promptForSeal`/`runSingleSuite` now return a `SealAttemptOutcome` (`'sealed' | 'unauthorized' | 'not-attempted'`) instead of `void`. `runDirectMode`/`runAllPending` check the outcome and, on `'unauthorized'`, print an unambiguous `✗` error banner and `process.exit(ExitCode.FAILURE)` **before** ever reaching the `"Suite completed!"` success banner or the `"To commit"` hint.
- `packages/cli/src/commands/seal.ts`: an `unauthorized-signer` skip now forces `ok: false` in `--json` output and `process.exit(ExitCode.FAILURE)`, and is rendered in a separate `✗ Refused to seal ... (unauthorized signer)` banner (via `error()`) instead of being lumped into the generic `⚠ Skipped` bucket that also holds benign skips like "already has a valid seal."
- Authorized signers are unaffected — verified with regression tests below and the existing full CLI suite (812 tests, all green).

**Out of scope (intentionally, narrowly matching the issue's acceptance criteria):** two other early-return paths inside `promptForSeal` — "no local identity configured" and "seal creation itself throws" — have the same *shape* of reporting gap (silently `warn`+continue, letting the caller print success) but are not the `unauthorized-signer` security case this issue targets. Left unchanged and called out with a code comment (`SealAttemptOutcome`'s doc comment) for a possible follow-up.

## Acceptance criteria → tests

All three acceptance criteria are covered by `packages/cli/test/integration/unauthorized-signer.integration.test.ts` (spawns the real, built `attest-it` binary — not an in-process approximation):

1. **"An unauthorized-signer seal/run is a hard failure: distinct nonzero exit code, unambiguous banner with no surrounding ✓, ok:false in --json, and no 'To commit' hint (nothing was sealed)."**
   - Covered by `` `run --suite ... --yes` as an unauthorized signer fails hard: nonzero exit, no ✓, no "To commit" hint, and no seal file is written `` and `` `seal --json` as an unauthorized signer reports ok:false with a nonzero exit and writes no seal file ``.
2. **"An authorized signer's seal/run continues to succeed unchanged."**
   - Covered by `` `run --suite ... --yes` as the authorized signer still succeeds and writes a seal `` and `` `seal --json` as the authorized signer still succeeds and writes a seal ``.
3. **"Regression test at the CLI/UAT layer (real subprocess) ... Must fail against pre-fix code (which exits 0)."**
   - Verified manually: reverted `run.ts`/`seal.ts` to pre-fix content (`git stash`), rebuilt, reran the two unauthorized-signer tests — both failed with `expected +0 not to be +0` (i.e. exit code was `0` pre-fix), confirming the tests catch the regression. Restored the fix and reran — all 4 tests pass.

Also updated the pre-existing unit test in `packages/cli/test/seal.test.ts` that had encoded the buggy exit-0/no-`ok`-assertion behavior as expected — it now asserts `ok: false` and exit `1`.

## Changeset

`@attest-it/cli`/`attest-it`: **minor** (`.changeset/fix-unauthorized-signer-reports-success.md`), matching this repo's convention for CLI-only behavior fixes (e.g. `fix-cancelled-exit-code-reachability.md`, `seal-status-behavior-fixes.md`).

## Verification

- `pnpm run build` — green (all packages)
- `pnpm run check` — green (0 lint errors; only pre-existing `security/detect-object-injection` warnings, none newly introduced by this diff — confirmed each touched warning line already existed pre-fix)
- `pnpm run test` — green, 812/812 CLI tests + core/github-action suites pass
- `pnpm exec prettier --check .` — green

## Non-goals

Per the issue: this does not change the authorization model itself, only the unauthorized-signer *reporting* outcome.

Refs #136
