### PR TITLE
fix(core): isolate VaultKeeper key material under ATTEST_IT_HOME

### DIFF
--- a/.changeset/vaultkeeper-home-isolation.md
+++ b/.changeset/vaultkeeper-home-isolation.md
@@ -1,0 +1,13 @@
+---
+'@attest-it/core': minor
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Isolate VaultKeeper private-key material under `ATTEST_IT_HOME`.
+
+Previously, `ATTEST_IT_HOME` (and the programmatic home override / `--home-dir` flag) isolated only attest-it's own `config.yaml` and public keys. The encrypted private-key `.enc` blob was still written to the real, non-sandboxed `~/.config/vaultkeeper/file/` on every `identity create`, `identity migrate`, and any seal/sign operation — breaking the "isolated state for testing / CI-safe / embeddable" contract and accumulating orphaned key files outside the configured home.
+
+- **Home override now propagates into VaultKeeper's config-dir resolution.** A new public `getVaultKeeperConfigDir()` resolves a sandbox-relative `<home>/vaultkeeper` directory whenever a home override is in effect (and `undefined` otherwise, preserving VaultKeeper's own default for real installs). This directory is threaded through every `BackendRegistry.create('file', …)` call — store, delete, and the retrieve/sign provider path — so key material lands under the configured home consistently.
+- **Saved public-key `.pem` files now carry real PEM markers.** `savePublicKey`/`savePublicKeySync` write a standards-compliant SPKI `-----BEGIN PUBLIC KEY-----` document instead of bare base64.
+- **The 1Password/Keychain provider-prompt banner is suppressed under `--storage file`,** which touches no external security tool.

--- a/packages/cli/src/commands/identity/create.ts
+++ b/packages/cli/src/commands/identity/create.ts
@@ -221,11 +221,17 @@ async function runCreate(options: CreateOptions): Promise<void> {
           : ''
 
     // Check provider availability
-    // Note: Checking 1Password/YubiKey may trigger authentication prompts
-    info('Checking available key storage providers...')
-    info(
-      'You may see authentication prompts from 1Password, macOS Keychain, or other security tools.',
-    )
+    // Note: Checking 1Password/YubiKey may trigger authentication prompts.
+    // The file backend touches no external security tool, so suppress the
+    // provider-prompt banner when `--storage file` is explicitly requested --
+    // it would otherwise falsely warn about 1Password/Keychain prompts that
+    // this run will never surface.
+    if (options.storage !== 'file') {
+      info('Checking available key storage providers...')
+      info(
+        'You may see authentication prompts from 1Password, macOS Keychain, or other security tools.',
+      )
+    }
 
     const opAvailable = await isOnePasswordInstalled()
     verbose(`  1Password CLI (op): ${opAvailable ? 'found' : 'not found'}`)

--- a/packages/cli/test/integration/home-isolation.integration.test.ts
+++ b/packages/cli/test/integration/home-isolation.integration.test.ts
@@ -1,0 +1,196 @@
+/**
+ * UAT / end-to-end regression coverage for issue #129: `ATTEST_IT_HOME` must
+ * isolate *all* attest-it state -- including the VaultKeeper-backed encrypted
+ * private key -- under the configured sandbox home.
+ *
+ * Before the fix, `ATTEST_IT_HOME` isolated only attest-it's own `config.yaml`
+ * and public key; the encrypted `.enc` private-key blob still leaked to the
+ * real, non-sandboxed `~/.config/vaultkeeper/file/` on every run. This test
+ * drives the *real built CLI* as a subprocess (stdin closed, `< /dev/null`)
+ * with only `ATTEST_IT_HOME` set -- deliberately NOT `VAULTKEEPER_CONFIG_DIR`,
+ * so it proves the ATTEST_IT_HOME propagation alone isolates key material.
+ *
+ * It asserts, exactly as the issue's repro demands:
+ *   - the encrypted `.enc` key lands UNDER the sandbox home, and
+ *   - the real `~/.config/vaultkeeper/` gains NO new file (before/after diff).
+ *
+ * Against pre-fix code this fails: the `.enc` is absent from the sandbox and a
+ * new file appears under the real VaultKeeper directory.
+ *
+ * @see https://github.com/mike-north/attest-it/issues/129
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import { parse as parseYaml } from 'yaml'
+import {
+  collectFilesRecursive,
+  resolveRealVaultKeeperConfigDir,
+} from '../setup/vaultkeeper-isolation-guard.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+const CLI_CALL_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Spawn the built CLI with a fully controlled environment. Unlike the shared
+ * helpers in other integration files, this deliberately strips any inherited
+ * `VAULTKEEPER_CONFIG_DIR` from the child env so the test exercises isolation
+ * driven by `ATTEST_IT_HOME` alone (the whole point of issue #129).
+ */
+function runCli(args: string[], cwd: string, extraEnv: Record<string, string>): Promise<RunResult> {
+  const env: NodeJS.ProcessEnv = { ...process.env, NO_COLOR: '1', ...extraEnv }
+  delete env.VAULTKEEPER_CONFIG_DIR
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      cwd,
+      env,
+      // stdin closed == `< /dev/null`: a fall-through to an interactive prompt
+      // would hang until the timeout kills it, failing loudly.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()))
+    child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()))
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI did not exit within ${String(CLI_CALL_TIMEOUT_MS)}ms (hung on a prompt?): ` +
+            `attest-it ${args.join(' ')}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      )
+    }, CLI_CALL_TIMEOUT_MS)
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+/** Read the VaultKeeper `privateKey.id` attest-it recorded for `slug`. */
+function readPrivateKeyId(homeDir: string, slug: string): string {
+  const parsed: unknown = parseYaml(fs.readFileSync(path.join(homeDir, 'config.yaml'), 'utf8'))
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('identities' in parsed) ||
+    typeof (parsed as { identities: unknown }).identities !== 'object'
+  ) {
+    throw new Error('Expected local config to contain an identities map')
+  }
+  const identities = (parsed as { identities: Record<string, unknown> }).identities
+  const identity = identities[slug]
+  if (
+    typeof identity !== 'object' ||
+    identity === null ||
+    !('privateKey' in identity) ||
+    typeof (identity as { privateKey: unknown }).privateKey !== 'object'
+  ) {
+    throw new Error(`Expected identity "${slug}" to have a privateKey object`)
+  }
+  const privateKey = (identity as { privateKey: Record<string, unknown> }).privateKey
+  if (typeof privateKey.id !== 'string') {
+    throw new Error(`Expected identity "${slug}" to have a string privateKey.id`)
+  }
+  return privateKey.id
+}
+
+/**
+ * VaultKeeper `file`-backend secret path: `<configDir>/file/<hex(id)>.enc`
+ * (mirrors `getEntryPath` in vaultkeeper's file backend).
+ */
+function encPathFor(vaultKeeperConfigDir: string, secretId: string): string {
+  return path.join(
+    vaultKeeperConfigDir,
+    'file',
+    `${Buffer.from(secretId, 'utf8').toString('hex')}.enc`,
+  )
+}
+
+describe('ATTEST_IT_HOME isolates VaultKeeper key material (issue #129)', () => {
+  let homeDir: string
+  let projectDir: string
+
+  beforeEach(async () => {
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-129-home-'))
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-129-proj-'))
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+  })
+
+  it('writes the encrypted .enc key under the sandbox home and leaks nothing to the real ~/.config/vaultkeeper', async () => {
+    const realVkDir = resolveRealVaultKeeperConfigDir()
+    const before = collectFilesRecursive(realVkDir)
+
+    const result = await runCli(
+      ['identity', 'create', '--name', 'Isolation Test', '--slug', 'iso', '--storage', 'file'],
+      projectDir,
+      { ATTEST_IT_HOME: homeDir },
+    )
+
+    expect(result.exitCode, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0)
+
+    // 1. The encrypted key lands UNDER the sandbox home (in the namespaced
+    //    vaultkeeper subdir), not the real VaultKeeper directory.
+    const secretId = readPrivateKeyId(homeDir, 'iso')
+    const sandboxEnc = encPathFor(path.join(homeDir, 'vaultkeeper'), secretId)
+    expect(fs.existsSync(sandboxEnc), `expected encrypted key at ${sandboxEnc}`).toBe(true)
+
+    // 2. The real ~/.config/vaultkeeper gained NO new file.
+    const after = collectFilesRecursive(realVkDir)
+    const beforeSet = new Set(before)
+    const leaked = after.filter((f) => !beforeSet.has(f))
+    expect(leaked, `leaked key/config files to real VaultKeeper dir: ${leaked.join(', ')}`).toEqual(
+      [],
+    )
+
+    // 3. Belt-and-suspenders: nothing at all under the sandbox home escapes it.
+    expect(sandboxEnc.startsWith(homeDir)).toBe(true)
+  })
+
+  it('writes a real PEM public key (with BEGIN/END markers) under the sandbox home', async () => {
+    const result = await runCli(
+      ['identity', 'create', '--name', 'Pem Test', '--slug', 'pem', '--storage', 'file'],
+      projectDir,
+      { ATTEST_IT_HOME: homeDir },
+    )
+    expect(result.exitCode, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0)
+
+    const pemPath = path.join(homeDir, 'public-keys', 'pem.pem')
+    expect(fs.existsSync(pemPath)).toBe(true)
+    const pem = fs.readFileSync(pemPath, 'utf8')
+    expect(pem).toContain('-----BEGIN PUBLIC KEY-----')
+    expect(pem).toContain('-----END PUBLIC KEY-----')
+  })
+
+  it('does not print the 1Password/Keychain provider-prompt banner under --storage file', async () => {
+    const result = await runCli(
+      ['identity', 'create', '--name', 'Banner Test', '--slug', 'banner', '--storage', 'file'],
+      projectDir,
+      { ATTEST_IT_HOME: homeDir },
+    )
+    expect(result.exitCode, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0)
+
+    const combined = result.stdout + result.stderr
+    expect(combined).not.toContain('authentication prompts from 1Password')
+    expect(combined).not.toContain('Checking available key storage providers')
+  })
+})

--- a/packages/cli/test/setup/vaultkeeper-isolation-guard.test.ts
+++ b/packages/cli/test/setup/vaultkeeper-isolation-guard.test.ts
@@ -108,6 +108,33 @@ describe('assertNoNewEntries', () => {
     }).toThrow(/VAULTKEEPER_CONFIG_DIR/)
   })
 
+  // Issue #129: the guard must catch leaked *key* material, not just config.
+  // An encrypted private-key `.enc` blob under `file/` (what `identity create
+  // --storage file` writes) leaking to the real dir must fail the guard, and
+  // the remediation must point at the ATTEST_IT_HOME propagation mechanism.
+  it('throws on a leaked encrypted private-key (.enc) blob and names ATTEST_IT_HOME remediation', () => {
+    const before = [`${os.homedir()}/.config/vaultkeeper/config.json`]
+    const after = [
+      `${os.homedir()}/.config/vaultkeeper/config.json`,
+      `${os.homedir()}/.config/vaultkeeper/file/6174746573742d69742d6b65792e656e63.enc`,
+    ]
+    expect(() => {
+      assertNoNewEntries(`${os.homedir()}/.config/vaultkeeper`, before, after)
+    }).toThrow(/\.enc/)
+    expect(() => {
+      assertNoNewEntries(`${os.homedir()}/.config/vaultkeeper`, before, after)
+    }).toThrow(/ATTEST_IT_HOME/)
+  })
+
+  // Signing keys live under `signing-keys/`; a leak there must also be caught.
+  it('throws on a leaked signing key under signing-keys/', () => {
+    const before: string[] = []
+    const after = ['/tmp/vk/file/signing-keys/my-key']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/signing-keys/)
+  })
+
   it('names every new file when a leak writes more than one', () => {
     const before: string[] = []
     const after = ['/tmp/vk/file/one.enc', '/tmp/vk/file/two.enc']

--- a/packages/cli/test/setup/vaultkeeper-isolation-guard.ts
+++ b/packages/cli/test/setup/vaultkeeper-isolation-guard.ts
@@ -11,11 +11,15 @@
  * This module contains the guard's pure, unit-testable logic: resolving
  * the real (non-test-overridden) VaultKeeper config directory the same way
  * VaultKeeper itself does, recursively snapshotting its contents, and
- * asserting that no new files appeared between two snapshots. The vitest
- * wiring (`beforeAll`/`afterEach`) that actually runs this against the real
- * directory during a test run lives in `vaultkeeper-isolation-guard.setup.ts`,
- * which is registered as a global `setupFiles` entry so it applies to every
- * test in this package without each test file needing to opt in.
+ * asserting that no new files appeared between two snapshots. The recursive
+ * snapshot covers the whole tree -- config files at the root AND the
+ * encrypted private-key `.enc` blobs under `file/` and signing keys under
+ * `signing-keys/` -- so a test that leaks *key* material (issue #129), not
+ * just config, fails the guard. The vitest wiring (`beforeAll`/`afterEach`)
+ * that actually runs this against the real directory during a test run lives
+ * in `vaultkeeper-isolation-guard.setup.ts`, which is registered as a global
+ * `setupFiles` entry so it applies to every test in this package without each
+ * test file needing to opt in.
  *
  * @see vaultkeeper-isolation-guard.setup.ts
  * @see vaultkeeper-isolation-guard.test.ts
@@ -87,11 +91,15 @@ export function assertNoNewEntries(
   const newEntries = after.filter((entry) => !beforeSet.has(entry))
   if (newEntries.length > 0) {
     throw new Error(
-      `VaultKeeper test-isolation guard (issue #114): a test wrote to the REAL ` +
+      `VaultKeeper test-isolation guard (issues #114/#129): a test wrote to the REAL ` +
         `VaultKeeper config directory (${dir}) instead of an isolated temp directory. ` +
-        `New file(s): ${newEntries.join(', ')}. Set process.env.VAULTKEEPER_CONFIG_DIR ` +
-        `(and pass it through to any spawned CLI subprocess's env) to a per-test temp ` +
-        `directory before invoking anything that stores or deletes keys via the ` +
+        `This includes encrypted private-key '.enc' blobs under file/ and signing-keys/, ` +
+        `not just config. New file(s): ${newEntries.join(', ')}. Isolate the test by ` +
+        `setting ATTEST_IT_HOME (or the programmatic home override / --home-dir flag) to a ` +
+        `per-test temp directory -- attest-it now propagates that into VaultKeeper's ` +
+        `config-dir resolution -- or, for tests that drive VaultKeeper directly, set ` +
+        `process.env.VAULTKEEPER_CONFIG_DIR (and pass it through to any spawned CLI ` +
+        `subprocess's env) before invoking anything that stores or deletes keys via the ` +
         `VaultKeeper file backend.`,
     )
   }

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -318,6 +318,9 @@ export function getPreferencesPath(): string;
 export function getPublicKeyFromPrivate(privateKeyPem: string): string;
 
 // @public
+export function getVaultKeeperConfigDir(homeDir?: string): string | undefined;
+
+// @public
 export interface Identity {
     email?: string;
     github?: string;

--- a/packages/core/src/identity/config.ts
+++ b/packages/core/src/identity/config.ts
@@ -3,6 +3,7 @@
  * @packageDocumentation
  */
 
+import * as crypto from 'node:crypto'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { mkdir as mkdirAsync, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
@@ -119,6 +120,71 @@ export function getIdentityConfigDir(homeDir?: string): string {
     return override
   }
   return join(homedir(), '.config', 'attest-it')
+}
+
+/**
+ * Subdirectory (under the attest-it home) that holds VaultKeeper's config
+ * directory when the home is redirected. Mirrors the real-world layout where
+ * `~/.config/vaultkeeper` sits beside `~/.config/attest-it`: under a sandboxed
+ * home, VaultKeeper gets its own namespaced subdirectory rather than
+ * intermixing its `file/`, `.key`, and `signing-keys/` entries with attest-it's
+ * `config.yaml` and `public-keys/`.
+ */
+const VAULTKEEPER_SUBDIR = 'vaultkeeper'
+
+/**
+ * Resolve the VaultKeeper config directory that private-key material should be
+ * stored under, honoring attest-it's home override.
+ *
+ * @remarks
+ * VaultKeeper's file backend stores encrypted `.enc` key blobs (and its wrap
+ * key + signing keys) under `<configDir>/file`, where `configDir` is the value
+ * passed to the backend factory or, absent one, VaultKeeper's own default
+ * (`~/.config/vaultkeeper`, itself overridable via `VAULTKEEPER_CONFIG_DIR`).
+ *
+ * attest-it's `ATTEST_IT_HOME` (and the `--home-dir` flag / programmatic
+ * override, which feed the same resolution) used to isolate only attest-it's
+ * own `config.yaml` and public keys -- the encrypted private key still leaked
+ * to the real, non-sandboxed `~/.config/vaultkeeper/file/`. Returning a
+ * sandbox-relative directory here, and threading it through every
+ * `BackendRegistry.create('file', ...)` call (see `key-provider/store.ts` and
+ * `key-provider/registry.ts`), propagates the home override into VaultKeeper so
+ * key material is actually isolated under the configured home.
+ *
+ * An explicitly set `VAULTKEEPER_CONFIG_DIR` is VaultKeeper's own override and
+ * takes precedence: this returns `undefined` in that case so callers defer to
+ * VaultKeeper's env-based resolution (store and retrieve then resolve
+ * identically). Deliberate VaultKeeper redirection is respected, and it is
+ * still isolated -- the user chose that directory. Only when
+ * `VAULTKEEPER_CONFIG_DIR` is unset does the attest-it home override derive a
+ * sandbox-relative directory.
+ *
+ * @param homeDir - Optional explicit home directory override. When provided,
+ *   returns `{homeDir}/vaultkeeper` unconditionally (most explicit wins).
+ *   Otherwise honors `VAULTKEEPER_CONFIG_DIR`, then `ATTEST_IT_HOME` /
+ *   programmatic override.
+ * @returns The VaultKeeper config directory under the attest-it home, or
+ *   `undefined` when no home override is in effect (or `VAULTKEEPER_CONFIG_DIR`
+ *   is explicitly set) -- in which case callers must let VaultKeeper resolve
+ *   its own directory (never force one, which would change behavior for real
+ *   installs).
+ * @public
+ */
+export function getVaultKeeperConfigDir(homeDir?: string): string | undefined {
+  if (homeDir) {
+    return join(homeDir, VAULTKEEPER_SUBDIR)
+  }
+  // A user-set VAULTKEEPER_CONFIG_DIR is VaultKeeper's own explicit override --
+  // defer to it (return undefined) so deliberate redirection is honored and
+  // both store and retrieve paths resolve the same directory.
+  if (process.env.VAULTKEEPER_CONFIG_DIR) {
+    return undefined
+  }
+  const override = getAttestItHomeDir()
+  if (override) {
+    return join(override, VAULTKEEPER_SUBDIR)
+  }
+  return undefined
 }
 
 /**
@@ -431,13 +497,60 @@ export interface SavePublicKeyResult {
 }
 
 /**
+ * DER prefix of an Ed25519 SubjectPublicKeyInfo (SPKI) structure, preceding the
+ * 32-byte raw public key. `attest-it` stores the compact raw key (base64 of
+ * these 32 bytes) in `config.yaml`; prepending this prefix reconstructs the
+ * full 44-byte SPKI DER that a PEM `PUBLIC KEY` document wraps.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8410 (Ed25519 in SPKI)
+ * @see https://www.rfc-editor.org/rfc/rfc7468 (PEM textual encoding)
+ */
+const ED25519_SPKI_DER_PREFIX = Buffer.from('302a300506032b6570032100', 'hex')
+/** Byte length of a raw Ed25519 public key. */
+const ED25519_RAW_PUBLIC_KEY_LENGTH = 32
+
+/**
+ * Convert the compact base64 raw Ed25519 public key stored in `config.yaml`
+ * into a standards-compliant SPKI PEM document with real
+ * `-----BEGIN PUBLIC KEY-----` / `-----END PUBLIC KEY-----` markers.
+ *
+ * @remarks
+ * The saved `.pem` file used to contain only the bare base64 body with no PEM
+ * markers, so it was not a loadable PEM document. If `publicKey` already looks
+ * like a PEM document (defensive: some callers may pass one), it is returned
+ * unchanged.
+ *
+ * @param publicKey - Base64-encoded raw (32-byte) Ed25519 public key
+ * @returns A PEM `PUBLIC KEY` document
+ * @throws Error if `publicKey` does not decode to a 32-byte Ed25519 key
+ */
+function toPublicKeyPem(publicKey: string): string {
+  if (publicKey.includes('-----BEGIN')) {
+    return publicKey.endsWith('\n') ? publicKey : `${publicKey}\n`
+  }
+  const raw = Buffer.from(publicKey, 'base64')
+  if (raw.length !== ED25519_RAW_PUBLIC_KEY_LENGTH) {
+    throw new Error(
+      `Expected a base64-encoded ${String(ED25519_RAW_PUBLIC_KEY_LENGTH)}-byte Ed25519 public key, ` +
+        `got ${String(raw.length)} byte(s) after base64-decoding`,
+    )
+  }
+  const spkiDer = Buffer.concat([ED25519_SPKI_DER_PREFIX, raw])
+  const keyObject = crypto.createPublicKey({ key: spkiDer, format: 'der', type: 'spki' })
+  const pem = keyObject.export({ type: 'spki', format: 'pem' })
+  return typeof pem === 'string' ? pem : pem.toString('utf8')
+}
+
+/**
  * Save a public key to the user's home directory.
  *
- * This saves the public key as a base64-encoded string (matching the format in config.yaml)
- * to ~/.attest-it/public-keys/<slug>.pem for backup purposes.
+ * The key is written as a standards-compliant SPKI PEM document (with real
+ * `-----BEGIN PUBLIC KEY-----` markers) to ~/.attest-it/public-keys/<slug>.pem
+ * for backup purposes. The compact base64 form remains the source of truth in
+ * config.yaml.
  *
  * @param slug - The identity slug (used for the filename)
- * @param publicKey - The base64-encoded public key
+ * @param publicKey - The base64-encoded raw Ed25519 public key
  * @returns Path where the key was saved
  * @public
  */
@@ -446,18 +559,20 @@ export async function savePublicKey(slug: string, publicKey: string): Promise<Sa
   const homeDir = getHomePublicKeysDir()
   await mkdirAsync(homeDir, { recursive: true })
   const homePath = join(homeDir, `${slug}.pem`)
-  await writeFile(homePath, publicKey, 'utf8')
+  await writeFile(homePath, toPublicKeyPem(publicKey), 'utf8')
   return { homePath }
 }
 
 /**
  * Save a public key to the user's home directory (sync).
  *
- * This saves the public key as a base64-encoded string (matching the format in config.yaml)
- * to ~/.attest-it/public-keys/<slug>.pem for backup purposes.
+ * The key is written as a standards-compliant SPKI PEM document (with real
+ * `-----BEGIN PUBLIC KEY-----` markers) to ~/.attest-it/public-keys/<slug>.pem
+ * for backup purposes. The compact base64 form remains the source of truth in
+ * config.yaml.
  *
  * @param slug - The identity slug (used for the filename)
- * @param publicKey - The base64-encoded public key
+ * @param publicKey - The base64-encoded raw Ed25519 public key
  * @returns Path where the key was saved
  * @public
  */
@@ -466,6 +581,6 @@ export function savePublicKeySync(slug: string, publicKey: string): SavePublicKe
   const homeDir = getHomePublicKeysDir()
   mkdirSync(homeDir, { recursive: true })
   const homePath = join(homeDir, `${slug}.pem`)
-  writeFileSync(homePath, publicKey, 'utf8')
+  writeFileSync(homePath, toPublicKeyPem(publicKey), 'utf8')
   return { homePath }
 }

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -12,6 +12,7 @@ export {
   ATTEST_IT_HOME_ENV,
   getLocalConfigPath,
   getIdentityConfigDir,
+  getVaultKeeperConfigDir,
   setAttestItHomeDir,
   getAttestItHomeDir,
   loadLocalConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,6 +168,7 @@ export {
   ATTEST_IT_HOME_ENV,
   getLocalConfigPath,
   getIdentityConfigDir,
+  getVaultKeeperConfigDir,
   setAttestItHomeDir,
   getAttestItHomeDir,
   loadLocalConfig,

--- a/packages/core/src/key-provider/registry.ts
+++ b/packages/core/src/key-provider/registry.ts
@@ -14,6 +14,7 @@ import type { KeyProvider, KeyProviderConfig } from './types.js'
 import { BackendRegistry } from 'vaultkeeper'
 import { VaultKeyProvider } from './vault-key-provider.js'
 import { LegacyFilesystemKeyProvider } from './legacy-filesystem-provider.js'
+import { getVaultKeeperConfigDir } from '../identity/config.js'
 
 /**
  * Type for a key provider factory function.
@@ -70,9 +71,14 @@ export class KeyProviderRegistry {
   }
 }
 
-// Register the filesystem provider backed by VaultKeeper's file backend
+// Register the filesystem provider backed by VaultKeeper's file backend.
+// The config dir is resolved at *retrieval* time (per factory invocation, not
+// at module load) so it honors whatever attest-it home override is in effect
+// when a key is read/signed -- and must match the directory `storePrivateKey`
+// wrote the key under. `undefined` when no override is set, letting VaultKeeper
+// resolve its own default.
 KeyProviderRegistry.register('filesystem', (_config) => {
-  const backend = BackendRegistry.create('file')
+  const backend = BackendRegistry.create('file', undefined, getVaultKeeperConfigDir())
   return new VaultKeyProvider({ backend, displayName: 'Filesystem' })
 })
 

--- a/packages/core/src/key-provider/store.ts
+++ b/packages/core/src/key-provider/store.ts
@@ -11,6 +11,7 @@
 
 import * as crypto from 'node:crypto'
 import { BackendRegistry, SecretNotFoundError } from 'vaultkeeper'
+import { getVaultKeeperConfigDir } from '../identity/config.js'
 
 /**
  * Result of storing a private key via a VaultKeeper backend.
@@ -49,7 +50,17 @@ export async function storePrivateKey(
 ): Promise<StorePrivateKeyResult> {
   const vaultKeeperBackendType = backendType === 'file' ? 'file' : backendType
 
-  const backend = BackendRegistry.create(vaultKeeperBackendType)
+  // Propagate attest-it's home override (ATTEST_IT_HOME / --home-dir /
+  // programmatic override) into VaultKeeper's config-dir resolution so the
+  // file backend writes the encrypted `.enc` key blob under the configured
+  // home instead of the real, non-sandboxed `~/.config/vaultkeeper/file/`.
+  // `undefined` when no override is in effect -- VaultKeeper then resolves its
+  // own default, preserving behavior for real installs.
+  const backend = BackendRegistry.create(
+    vaultKeeperBackendType,
+    undefined,
+    getVaultKeeperConfigDir(),
+  )
   const secretId = `attest-it-${identityName}-${crypto.randomUUID()}`
   await backend.store(secretId, privateKeyPem)
 
@@ -81,7 +92,13 @@ export async function deletePrivateKey(
 ): Promise<void> {
   const vaultKeeperBackendType = backendType === 'file' ? 'file' : backendType
 
-  const backend = BackendRegistry.create(vaultKeeperBackendType)
+  // Same home-override propagation as storePrivateKey, so deletes target the
+  // sandboxed key location rather than the real `~/.config/vaultkeeper/`.
+  const backend = BackendRegistry.create(
+    vaultKeeperBackendType,
+    undefined,
+    getVaultKeeperConfigDir(),
+  )
   try {
     await backend.delete(secretId)
   } catch (err) {

--- a/packages/core/test/identity/config.test.ts
+++ b/packages/core/test/identity/config.test.ts
@@ -2,6 +2,7 @@
  * Tests for identity configuration loading, validation, and v1→v2 migration.
  */
 
+import * as crypto from 'node:crypto'
 import * as fs from 'node:fs'
 import { homedir } from 'node:os'
 import * as path from 'node:path'
@@ -15,6 +16,7 @@ import {
   saveLocalConfig,
   saveLocalConfigSync,
   getHomePublicKeysDir,
+  getVaultKeeperConfigDir,
   savePublicKey,
   savePublicKeySync,
   setAttestItHomeDir,
@@ -23,6 +25,14 @@ import {
 } from '../../src/identity/index.js'
 
 const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'identity-configs')
+
+/**
+ * A real, fixed base64-encoded raw (32-byte) Ed25519 public key -- the compact
+ * form attest-it stores in config.yaml. Generated once (deterministic constant,
+ * never `generateKeyPairSync` at test time) so the saved-PEM assertions below
+ * can compare against the RFC 8410 SPKI PEM this key must serialize to.
+ */
+const ED25519_RAW_PUBLIC_KEY_B64 = '27qLSoRz1uu6+KMGX6TAVae4eLuFv25/bg88Cm2tycM='
 
 describe('identity/config', () => {
   describe('getLocalConfigPath', () => {
@@ -815,35 +825,116 @@ identities:
       })
     })
 
+    describe('getVaultKeeperConfigDir (issue #129)', () => {
+      // These assert precedence, so control VAULTKEEPER_CONFIG_DIR explicitly
+      // rather than inheriting whatever the ambient test env happens to have.
+      let originalVkConfigDir: string | undefined
+
+      beforeEach(() => {
+        originalVkConfigDir = process.env.VAULTKEEPER_CONFIG_DIR
+        delete process.env.VAULTKEEPER_CONFIG_DIR
+      })
+
+      afterEach(() => {
+        if (originalVkConfigDir === undefined) {
+          delete process.env.VAULTKEEPER_CONFIG_DIR
+        } else {
+          process.env.VAULTKEEPER_CONFIG_DIR = originalVkConfigDir
+        }
+      })
+
+      it('should return undefined when no home override is set (defer to VaultKeeper default)', () => {
+        setAttestItHomeDir(null)
+        expect(getVaultKeeperConfigDir()).toBeUndefined()
+      })
+
+      it('should return a sandbox-relative vaultkeeper dir when the home override is set', () => {
+        setAttestItHomeDir(tempDir)
+        expect(getVaultKeeperConfigDir()).toBe(path.join(tempDir, 'vaultkeeper'))
+      })
+
+      it('should defer to an explicitly set VAULTKEEPER_CONFIG_DIR even when a home override is set', () => {
+        setAttestItHomeDir(tempDir)
+        process.env.VAULTKEEPER_CONFIG_DIR = '/deliberate/vk/dir'
+        // The user pointed VaultKeeper somewhere explicitly -- respect it
+        // (return undefined so the caller lets VaultKeeper resolve the env dir).
+        expect(getVaultKeeperConfigDir()).toBeUndefined()
+      })
+
+      it('should honor an explicit homeDir argument over ambient state', () => {
+        setAttestItHomeDir(null)
+        process.env.VAULTKEEPER_CONFIG_DIR = '/deliberate/vk/dir'
+        // The most explicit input (the argument) wins over both env and null override.
+        expect(getVaultKeeperConfigDir('/explicit/home')).toBe(
+          path.join('/explicit/home', 'vaultkeeper'),
+        )
+      })
+    })
+
     describe('savePublicKey', () => {
-      it('should save public key to home directory', async () => {
+      it('should save public key as a real PEM document with BEGIN/END markers (issue #129)', async () => {
         setAttestItHomeDir(tempDir)
 
-        const result = await savePublicKey('test-identity', 'dGVzdC1wdWJsaWMta2V5')
+        const result = await savePublicKey('test-identity', ED25519_RAW_PUBLIC_KEY_B64)
 
         expect(result.homePath).toBe(path.join(tempDir, 'public-keys', 'test-identity.pem'))
         expect(fs.existsSync(result.homePath)).toBe(true)
-        expect(fs.readFileSync(result.homePath, 'utf8')).toBe('dGVzdC1wdWJsaWMta2V5')
+
+        const contents = fs.readFileSync(result.homePath, 'utf8')
+        // RFC 7468: the document must carry real encapsulation boundaries --
+        // the old behavior wrote bare base64 with no markers at all.
+        expect(contents).toContain('-----BEGIN PUBLIC KEY-----')
+        expect(contents).toContain('-----END PUBLIC KEY-----')
+        // ...and it must be a loadable SPKI PEM that round-trips back to the
+        // exact raw key we stored (spec-correct, not merely "has markers").
+        const loaded = crypto.createPublicKey(contents)
+        const der = loaded.export({ type: 'spki', format: 'der' })
+        if (!Buffer.isBuffer(der)) {
+          throw new Error('Expected SPKI DER export to be a Buffer')
+        }
+        // Ed25519 SPKI: 12-byte header + 32-byte raw key.
+        const raw = der.subarray(12)
+        expect(raw.toString('base64')).toBe(ED25519_RAW_PUBLIC_KEY_B64)
       })
 
       it('should create directories if they do not exist', async () => {
         setAttestItHomeDir(tempDir)
 
-        const result = await savePublicKey('new-identity', 'bmV3LWlkZW50aXR5')
+        const result = await savePublicKey('new-identity', ED25519_RAW_PUBLIC_KEY_B64)
 
         expect(fs.existsSync(path.dirname(result.homePath))).toBe(true)
+      })
+
+      it('should reject a value that is not a 32-byte Ed25519 public key', async () => {
+        setAttestItHomeDir(tempDir)
+
+        // 'dGVzdC1wdWJsaWMta2V5' decodes to 15 bytes -- not a valid key.
+        await expect(savePublicKey('bad-identity', 'dGVzdC1wdWJsaWMta2V5')).rejects.toThrow(
+          /Ed25519 public key/,
+        )
       })
     })
 
     describe('savePublicKeySync', () => {
-      it('should save public key to home directory synchronously', () => {
+      it('should save public key as a real PEM document synchronously (issue #129)', () => {
         setAttestItHomeDir(tempDir)
 
-        const result = savePublicKeySync('sync-identity', 'c3luYy1pZGVudGl0eQ==')
+        const result = savePublicKeySync('sync-identity', ED25519_RAW_PUBLIC_KEY_B64)
 
         expect(result.homePath).toBe(path.join(tempDir, 'public-keys', 'sync-identity.pem'))
         expect(fs.existsSync(result.homePath)).toBe(true)
-        expect(fs.readFileSync(result.homePath, 'utf8')).toBe('c3luYy1pZGVudGl0eQ==')
+
+        const contents = fs.readFileSync(result.homePath, 'utf8')
+        expect(contents).toContain('-----BEGIN PUBLIC KEY-----')
+        expect(contents).toContain('-----END PUBLIC KEY-----')
+        const loaded = crypto.createPublicKey(contents)
+        const der = loaded.export({ type: 'spki', format: 'der' })
+        if (!Buffer.isBuffer(der)) {
+          throw new Error('Expected SPKI DER export to be a Buffer')
+        }
+        // Ed25519 SPKI: 12-byte header + 32-byte raw key.
+        const raw = der.subarray(12)
+        expect(raw.toString('base64')).toBe(ED25519_RAW_PUBLIC_KEY_B64)
       })
     })
   })

--- a/packages/core/test/setup/vaultkeeper-isolation-guard.test.ts
+++ b/packages/core/test/setup/vaultkeeper-isolation-guard.test.ts
@@ -108,6 +108,33 @@ describe('assertNoNewEntries', () => {
     }).toThrow(/VAULTKEEPER_CONFIG_DIR/)
   })
 
+  // Issue #129: the guard must catch leaked *key* material, not just config.
+  // An encrypted private-key `.enc` blob under `file/` (what `identity create
+  // --storage file` writes) leaking to the real dir must fail the guard, and
+  // the remediation must point at the ATTEST_IT_HOME propagation mechanism.
+  it('throws on a leaked encrypted private-key (.enc) blob and names ATTEST_IT_HOME remediation', () => {
+    const before = [`${os.homedir()}/.config/vaultkeeper/config.json`]
+    const after = [
+      `${os.homedir()}/.config/vaultkeeper/config.json`,
+      `${os.homedir()}/.config/vaultkeeper/file/6174746573742d69742d6b65792e656e63.enc`,
+    ]
+    expect(() => {
+      assertNoNewEntries(`${os.homedir()}/.config/vaultkeeper`, before, after)
+    }).toThrow(/\.enc/)
+    expect(() => {
+      assertNoNewEntries(`${os.homedir()}/.config/vaultkeeper`, before, after)
+    }).toThrow(/ATTEST_IT_HOME/)
+  })
+
+  // Signing keys live under `signing-keys/`; a leak there must also be caught.
+  it('throws on a leaked signing key under signing-keys/', () => {
+    const before: string[] = []
+    const after = ['/tmp/vk/file/signing-keys/my-key']
+    expect(() => {
+      assertNoNewEntries('/tmp/vk', before, after)
+    }).toThrow(/signing-keys/)
+  })
+
   it('names every new file when a leak writes more than one', () => {
     const before: string[] = []
     const after = ['/tmp/vk/file/one.enc', '/tmp/vk/file/two.enc']

--- a/packages/core/test/setup/vaultkeeper-isolation-guard.ts
+++ b/packages/core/test/setup/vaultkeeper-isolation-guard.ts
@@ -11,11 +11,15 @@
  * This module contains the guard's pure, unit-testable logic: resolving
  * the real (non-test-overridden) VaultKeeper config directory the same way
  * VaultKeeper itself does, recursively snapshotting its contents, and
- * asserting that no new files appeared between two snapshots. The vitest
- * wiring (`beforeAll`/`afterEach`) that actually runs this against the real
- * directory during a test run lives in `vaultkeeper-isolation-guard.setup.ts`,
- * which is registered as a global `setupFiles` entry so it applies to every
- * test in this package without each test file needing to opt in.
+ * asserting that no new files appeared between two snapshots. The recursive
+ * snapshot covers the whole tree -- config files at the root AND the
+ * encrypted private-key `.enc` blobs under `file/` and signing keys under
+ * `signing-keys/` -- so a test that leaks *key* material (issue #129), not
+ * just config, fails the guard. The vitest wiring (`beforeAll`/`afterEach`)
+ * that actually runs this against the real directory during a test run lives
+ * in `vaultkeeper-isolation-guard.setup.ts`, which is registered as a global
+ * `setupFiles` entry so it applies to every test in this package without each
+ * test file needing to opt in.
  *
  * @see vaultkeeper-isolation-guard.setup.ts
  * @see vaultkeeper-isolation-guard.test.ts
@@ -87,11 +91,15 @@ export function assertNoNewEntries(
   const newEntries = after.filter((entry) => !beforeSet.has(entry))
   if (newEntries.length > 0) {
     throw new Error(
-      `VaultKeeper test-isolation guard (issue #114): a test wrote to the REAL ` +
+      `VaultKeeper test-isolation guard (issues #114/#129): a test wrote to the REAL ` +
         `VaultKeeper config directory (${dir}) instead of an isolated temp directory. ` +
-        `New file(s): ${newEntries.join(', ')}. Set process.env.VAULTKEEPER_CONFIG_DIR ` +
-        `(and pass it through to any spawned CLI subprocess's env) to a per-test temp ` +
-        `directory before invoking anything that stores or deletes keys via the ` +
+        `This includes encrypted private-key '.enc' blobs under file/ and signing-keys/, ` +
+        `not just config. New file(s): ${newEntries.join(', ')}. Isolate the test by ` +
+        `setting ATTEST_IT_HOME (or the programmatic home override / --home-dir flag) to a ` +
+        `per-test temp directory -- attest-it now propagates that into VaultKeeper's ` +
+        `config-dir resolution -- or, for tests that drive VaultKeeper directly, set ` +
+        `process.env.VAULTKEEPER_CONFIG_DIR (and pass it through to any spawned CLI ` +
+        `subprocess's env) before invoking anything that stores or deletes keys via the ` +
         `VaultKeeper file backend.`,
     )
   }

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -47863,6 +47863,30 @@ var LegacyFilesystemKeyProvider = class {
     return { type: this.type, options: {} };
   }
 };
+var ATTEST_IT_HOME_ENV = "ATTEST_IT_HOME";
+var homeDirOverride = null;
+function getAttestItHomeDir() {
+  const envOverride = process.env[ATTEST_IT_HOME_ENV];
+  if (envOverride) {
+    return envOverride;
+  }
+  return homeDirOverride;
+}
+var VAULTKEEPER_SUBDIR = "vaultkeeper";
+function getVaultKeeperConfigDir(homeDir) {
+  if (homeDir) {
+    return (0, import_path4.join)(homeDir, VAULTKEEPER_SUBDIR);
+  }
+  if (process.env.VAULTKEEPER_CONFIG_DIR) {
+    return void 0;
+  }
+  const override = getAttestItHomeDir();
+  if (override) {
+    return (0, import_path4.join)(override, VAULTKEEPER_SUBDIR);
+  }
+  return void 0;
+}
+var ED25519_SPKI_DER_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 var KeyProviderRegistry = class {
   static providers = /* @__PURE__ */ new Map();
   /**
@@ -47897,7 +47921,7 @@ var KeyProviderRegistry = class {
   }
 };
 KeyProviderRegistry.register("filesystem", (_config) => {
-  const backend = BackendRegistry.create("file");
+  const backend = BackendRegistry.create("file", void 0, getVaultKeeperConfigDir());
   return new VaultKeyProvider({ backend, displayName: "Filesystem" });
 });
 KeyProviderRegistry.register("1password", (_config) => {

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -47866,6 +47866,30 @@ var LegacyFilesystemKeyProvider = class {
     return { type: this.type, options: {} };
   }
 };
+var ATTEST_IT_HOME_ENV = "ATTEST_IT_HOME";
+var homeDirOverride = null;
+function getAttestItHomeDir() {
+  const envOverride = process.env[ATTEST_IT_HOME_ENV];
+  if (envOverride) {
+    return envOverride;
+  }
+  return homeDirOverride;
+}
+var VAULTKEEPER_SUBDIR = "vaultkeeper";
+function getVaultKeeperConfigDir(homeDir) {
+  if (homeDir) {
+    return join4(homeDir, VAULTKEEPER_SUBDIR);
+  }
+  if (process.env.VAULTKEEPER_CONFIG_DIR) {
+    return void 0;
+  }
+  const override = getAttestItHomeDir();
+  if (override) {
+    return join4(override, VAULTKEEPER_SUBDIR);
+  }
+  return void 0;
+}
+var ED25519_SPKI_DER_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 var KeyProviderRegistry = class {
   static providers = /* @__PURE__ */ new Map();
   /**
@@ -47900,7 +47924,7 @@ var KeyProviderRegistry = class {
   }
 };
 KeyProviderRegistry.register("filesystem", (_config) => {
-  const backend = BackendRegistry.create("file");
+  const backend = BackendRegistry.create("file", void 0, getVaultKeeperConfigDir());
   return new VaultKeyProvider({ backend, displayName: "Filesystem" });
 });
 KeyProviderRegistry.register("1password", (_config) => {


### PR DESCRIPTION
## Summary

`ATTEST_IT_HOME` isolated only attest-it's own `config.yaml` and public key; the encrypted private-key `.enc` blob was still written to the real, non-sandboxed `~/.config/vaultkeeper/file/` on **every** `identity create --storage file` (and every migrate/seal/sign), regardless of the home override. This broke the "isolated state for testing / CI-safe / embeddable" contract and accumulated orphaned key files outside the configured home (the root cause behind the orphaned-key and test-isolation findings).

This PR propagates the attest-it home override into VaultKeeper's config-dir resolution so private-key material is actually isolated under the sandbox, and folds in the adjacent key-output fixes assigned to this issue.

## How the home override propagates to VaultKeeper

VaultKeeper's `file` backend stores its encrypted `.enc` blobs (plus wrap key and signing keys) under `<configDir>/file`, where `configDir` is the value passed to `BackendRegistry.create(type, config?, configDir?)` or, absent one, VaultKeeper's own default. Previously attest-it never passed one, so keys landed in VaultKeeper's default `~/.config/vaultkeeper`.

- New public `getVaultKeeperConfigDir()` (in `packages/core/src/identity/config.ts`) resolves a **sandbox-relative `<home>/vaultkeeper`** directory whenever an attest-it home override is in effect. It returns `undefined` — deferring to VaultKeeper's own resolution — when (a) no home override is set (real installs are unaffected) **or** (b) `VAULTKEEPER_CONFIG_DIR` is explicitly set (deliberate VaultKeeper redirection wins and stays isolated).
- This is threaded through **every** file-backend construction so store and retrieve resolve the same directory: `storePrivateKey` and `deletePrivateKey` (`key-provider/store.ts`) and the `filesystem` key-provider factory used for retrieve/sign (`key-provider/registry.ts`). The `--home-dir` flag and programmatic override feed the same `getAttestItHomeDir()` primitive, so they get identical isolation.

I chose the explicit-`configDir` path (over exporting `VAULTKEEPER_CONFIG_DIR` as a global env var) as the issue prefers, and namespaced it under a `vaultkeeper/` subdir so VaultKeeper's state does not intermix with attest-it's `config.yaml`/`public-keys/` — mirroring the real-world sibling layout under `~/.config`.

> Note: the user-facing `ATTEST_IT_HOME` documentation is intentionally **not** touched here — it is owned by the docs sweep in a separate issue. This PR only notes the propagation mechanism.

## Also folded in (same identity-create / key-output area)

- **Real PEM markers.** `savePublicKey`/`savePublicKeySync` now write a standards-compliant SPKI PEM document (`-----BEGIN PUBLIC KEY----- … -----END PUBLIC KEY-----`, RFC 7468 / RFC 8410) instead of bare base64. The compact base64 remains the source of truth in `config.yaml`.
- **Banner gating.** The "Checking available key storage providers… / You may see authentication prompts from 1Password, macOS Keychain…" banner no longer prints under `--storage file`, which touches no external security tool.
- **Extended #114 guard.** The test-isolation guard's recursive snapshot already covers the whole VaultKeeper tree; its docs and remediation message now explicitly call out leaked encrypted `.enc` key material (not just config) and point at the `ATTEST_IT_HOME` propagation mechanism, with added regression cases for a leaked `.enc` blob and a leaked `signing-keys/` entry.

## Acceptance criteria → tests

- **No file created outside the configured home by `identity create --storage file`; key material lands under the attest-it home** → `packages/cli/test/integration/home-isolation.integration.test.ts` — "writes the encrypted .enc key under the sandbox home and leaks nothing to the real ~/.config/vaultkeeper". Drives the **real built CLI** as a subprocess with stdin closed and **only** `ATTEST_IT_HOME` set (deliberately strips `VAULTKEEPER_CONFIG_DIR`), asserts the `.enc` lands under `<sandbox>/vaultkeeper/file/` and the real `~/.config/vaultkeeper` gains zero new files (before/after diff). Verified to fail against pre-fix code.
- **`--home-dir` flag gets the same isolation** → covered by the shared `getAttestItHomeDir()` primitive; unit-tested in `getVaultKeeperConfigDir (issue #129)` (`packages/core/test/identity/config.test.ts`), including the explicit-arg and `VAULTKEEPER_CONFIG_DIR`-precedence cases.
- **Regression guard also catches key files** → `packages/{core,cli}/test/setup/vaultkeeper-isolation-guard.test.ts` — new cases "throws on a leaked encrypted private-key (.enc) blob …" and "throws on a leaked signing key under signing-keys/".
- **PEM markers** → `savePublicKey`/`savePublicKeySync` PEM tests in `config.test.ts` (structural round-trip against the SPKI the key must serialize to) + a real-CLI PEM-on-disk assertion in the UAT. Fails pre-fix.
- **Banner suppressed under `--storage file`** → UAT "does not print the 1Password/Keychain provider-prompt banner under --storage file". Fails pre-fix.

## Verification

- `pnpm build` (required target) green; `nx check` (api-report + eslint + types) green for `@attest-it/core`, `@attest-it/cli`, `attest-it`.
- Full `@attest-it/core` (630) and `@attest-it/cli` (813) suites green; `@attest-it/github-action` green (its bundled `dist` was regenerated to carry the fix).
- Each of the three behavior changes was confirmed to **fail against pre-fix code** and pass after.

Changeset: `@attest-it/core`, `@attest-it/cli`, `attest-it` **minor** (new public `getVaultKeeperConfigDir`).

Refs #129
