### PR TITLE
fix(cli): make identity remove of the last identity atomic

### DIFF
--- a/.changeset/fix-identity-remove-last-atomic.md
+++ b/.changeset/fix-identity-remove-last-atomic.md
@@ -1,0 +1,16 @@
+---
+'@attest-it/cli': minor
+---
+
+**Fixed `identity remove` of the last identity leaving an orphaned config reference after deleting its private key (issue #133).**
+
+Removing the last identity in a repo is refused (`✗ Cannot remove last identity`, exit code 3) --
+but the command previously deleted the private key from storage _before_ checking whether the
+removal would be refused. A refused `identity remove <slug> -y` on the last identity left `whoami`
+reporting the identity as healthy while the underlying private key was already gone, so any
+operation needing it (e.g. `init --root-signer <slug>`) later failed with "Secret not found in
+file store".
+
+The last-identity guard (and other preconditions) now run before any destructive key deletion, so
+a refused removal never half-applies: the private key remains in place and fully usable. The
+last-identity policy itself is unchanged -- a repo must always retain at least one identity.

--- a/packages/cli/src/commands/identity/remove.ts
+++ b/packages/cli/src/commands/identity/remove.ts
@@ -93,18 +93,15 @@ export async function runRemove(slug: string, options: RemoveOptions = {}): Prom
     log(`  Private key: ${keyLocation}`)
     log('')
 
-    const keepKey = options.keepKey ?? false
-
-    if (keepKey) {
-      log(`  Keeping private key (--keep-key): ${keyLocation}`)
-    } else {
-      await deleteKeyMaterial(identity.privateKey)
-    }
-
-    // Remove from config
+    // Remove from config -- but do NOT persist or delete anything yet. All
+    // guards must pass first so a refused removal never leaves the private
+    // key deleted while the config still references it. See issue #133.
     const { [slug]: _removed, ...remainingIdentities } = config.identities
 
-    // Check if this was the last identity
+    // Check if this was the last identity. This guard (and any future
+    // precondition) must run before the destructive `deleteKeyMaterial`
+    // call below -- otherwise a refused removal leaves an orphaned config
+    // entry pointing at key material that no longer exists. See issue #133.
     if (Object.keys(remainingIdentities).length === 0) {
       error('Cannot remove last identity')
       log('')
@@ -129,6 +126,14 @@ export async function runRemove(slug: string, options: RemoveOptions = {}): Prom
       version: 2 as const,
       activeIdentity: newActiveIdentity,
       identities: remainingIdentities,
+    }
+
+    const keepKey = options.keepKey ?? false
+
+    if (keepKey) {
+      log(`  Keeping private key (--keep-key): ${keyLocation}`)
+    } else {
+      await deleteKeyMaterial(identity.privateKey)
     }
 
     await saveLocalConfig(newConfig)

--- a/packages/cli/test/identity-remove.test.ts
+++ b/packages/cli/test/identity-remove.test.ts
@@ -192,6 +192,47 @@ describe('identity remove — non-interactive (--yes) (issue #94)', () => {
   )
 })
 
+// Regression coverage for issue #133: removing the *last* identity deleted
+// the private key from storage first, then failed the "cannot remove last
+// identity" guard -- leaving an orphaned config entry pointing at key
+// material that no longer existed. The guard must run, and refuse, before
+// any destructive delete. Against the pre-fix implementation this test
+// fails: `unlink` (the legacy-filesystem deletion path) is called even
+// though the removal is ultimately refused.
+describe('identity remove — refuses the last identity before deleting its key (issue #133)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not delete the private key when the removal is refused as the last identity', async () => {
+    vi.mocked(loadLocalConfig).mockResolvedValue(
+      mockLocalConfig({
+        activeIdentity: 'alice',
+        identities: {
+          alice: {
+            name: 'Alice',
+            publicKey: 'pk-alice',
+            privateKey: { type: 'filesystem', path: '/tmp/alice.pem' },
+          },
+        },
+      }),
+    )
+
+    await runRemove('alice', { yes: true })
+
+    expect(unlink).not.toHaveBeenCalled()
+    expect(saveLocalConfig).not.toHaveBeenCalled()
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot remove last identity'),
+    )
+    expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.CONFIG_ERROR)
+  })
+})
+
 // Regression coverage for issue #95: exit code 3 (CONFIG_ERROR) was
 // overloaded to also cover a force-closed/interrupted prompt, surfacing
 // @inquirer/core's raw "User force closed the prompt with 0 null" message.

--- a/packages/cli/test/integration/identity-remove-last-atomic.integration.test.ts
+++ b/packages/cli/test/integration/identity-remove-last-atomic.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * UAT for `identity remove` refusing to remove the last identity (issue #133).
+ *
+ * Pre-fix, `identity remove <slug> -y` on a repo's *last* identity deleted
+ * the private key from VaultKeeper storage first, then failed the "cannot
+ * remove last identity" guard -- leaving an orphaned config entry that still
+ * pointed at now-missing key material. `whoami` kept reporting the identity
+ * healthy, but any operation needing the private key (e.g. bootstrapping the
+ * root gate) failed with "Secret not found in file store".
+ *
+ * This test drives the real, built CLI as subprocesses (mirroring the exact
+ * repro from the issue): create a single `file`-backed identity, attempt to
+ * remove it, and assert both that the removal is refused (exit 3) *and* that
+ * the private key still resolves afterward via a real signing operation
+ * (`init --root-signer <slug>`, which loads the identity's private key and
+ * uses it to create the root gate's anchoring seal). Against the pre-fix
+ * implementation, the refused removal still deletes the key, so the
+ * subsequent `init --root-signer` call fails -- this test fails there and
+ * passes once the guard runs before the destructive delete.
+ *
+ * @see https://github.com/mike-north/attest-it/issues/133
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import { parse as parseYaml } from 'yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+
+const CLI_CALL_TIMEOUT_MS = 15000
+const CONFIG_ERROR_EXIT_CODE = 3
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/** Run the built CLI as a real subprocess with stdin closed and a hard timeout. */
+function runCliNonInteractive(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(CLI_CALL_TIMEOUT_MS)}ms: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+describe('identity remove refuses to remove the last identity atomically (issue #133)', () => {
+  let projectDir: string
+  let homeDir: string
+  let env: NodeJS.ProcessEnv
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-remove-last-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-remove-last-home-'))
+    // Issue #114: redirect VaultKeeper's `file` backend to the same isolated
+    // temp home used for ATTEST_IT_HOME, so the real
+    // `~/.config/vaultkeeper/file/` store is never touched by this test.
+    env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  it(
+    'refuses removal of the last identity (exit 3) and leaves the private key ' +
+      'usable -- a subsequent `init --root-signer` still resolves and signs with it',
+    async () => {
+      const slug = 'only-one'
+
+      const createResult = await runCliNonInteractive(
+        ['identity', 'create', '--name', 'Only One', '--slug', slug, '--storage', 'file'],
+        projectDir,
+        env,
+      )
+      expect(createResult.exitCode).toBe(0)
+
+      // Sanity check: exactly one identity exists before the removal attempt.
+      const configBefore: unknown = parseYaml(
+        await fs.promises.readFile(path.join(homeDir, 'config.yaml'), 'utf8'),
+      )
+      if (!isRecordOfUnknown(configBefore) || !isRecordOfUnknown(configBefore.identities)) {
+        throw new Error('Expected local config to contain an identities map')
+      }
+      expect(Object.keys(configBefore.identities)).toEqual([slug])
+
+      // Attempt to remove the only identity -- must be refused.
+      const removeResult = await runCliNonInteractive(
+        ['identity', 'remove', slug, '-y'],
+        projectDir,
+        env,
+      )
+      expect(removeResult.exitCode).toBe(CONFIG_ERROR_EXIT_CODE)
+      expect(removeResult.stdout + removeResult.stderr).toContain('Cannot remove last identity')
+
+      // Config must still reference the identity -- the refused removal
+      // didn't half-apply.
+      const configAfter: unknown = parseYaml(
+        await fs.promises.readFile(path.join(homeDir, 'config.yaml'), 'utf8'),
+      )
+      if (!isRecordOfUnknown(configAfter) || !isRecordOfUnknown(configAfter.identities)) {
+        throw new Error('Expected local config to still contain an identities map')
+      }
+      expect(Object.keys(configAfter.identities)).toEqual([slug])
+
+      // The real regression check: the private key must still resolve and be
+      // usable for signing, not just referenced in config. `init
+      // --root-signer` loads the identity's private key from VaultKeeper and
+      // uses it to create the root gate's anchoring seal -- pre-fix, this
+      // failed with "Secret not found in file store" because the key had
+      // already been deleted before the last-identity guard ran.
+      const initResult = await runCliNonInteractive(
+        ['init', '--root-signer', slug, '--force'],
+        projectDir,
+        env,
+      )
+      expect(initResult.exitCode).toBe(0)
+      expect(initResult.stdout + initResult.stderr).not.toMatch(/Secret not found/)
+    },
+    CLI_CALL_TIMEOUT_MS * 2,
+  )
+})


### PR DESCRIPTION
## Summary

`identity remove` of the **last** identity was non-atomic: it deleted the private key from
storage first, then failed the "cannot remove last identity" guard -- leaving an orphaned config
entry that still pointed at now-missing key material. `whoami` kept reporting the identity
healthy, but any later operation needing the private key (e.g. `init --root-signer <slug>`) failed
with "Secret not found in file store".

This moves the last-identity guard (and the active-identity/config bookkeeping) ahead of the
destructive `deleteKeyMaterial` call, so a refused removal never half-applies -- the private key
is only deleted after every guard has passed. The last-identity **policy** itself is unchanged (a
repo must always retain >=1 identity); only the ordering/atomicity changed.

`packages/cli/src/commands/identity/remove.ts`:
```diff
-    const keyLocation = formatKeyLocation(identity.privateKey)
-    log(`  Private key: ${keyLocation}`)
-    log('')
-
-    const keepKey = options.keepKey ?? false
-
-    if (keepKey) {
-      log(`  Keeping private key (--keep-key): ${keyLocation}`)
-    } else {
-      await deleteKeyMaterial(identity.privateKey)
-    }
-
-    // Remove from config
+    const keyLocation = formatKeyLocation(identity.privateKey)
+    log(`  Private key: ${keyLocation}`)
+    log('')
+
+    // Remove from config -- but do NOT persist or delete anything yet.
     const { [slug]: _removed, ...remainingIdentities } = config.identities

-    // Check if this was the last identity
+    // Guard must run before the destructive delete below.
     if (Object.keys(remainingIdentities).length === 0) {
       error('Cannot remove last identity')
       ...
     }
     ...
+    const keepKey = options.keepKey ?? false
+    if (keepKey) {
+      log(`  Keeping private key (--keep-key): ${keyLocation}`)
+    } else {
+      await deleteKeyMaterial(identity.privateKey)
+    }
+
     await saveLocalConfig(newConfig)
```

## Acceptance criteria mapping (issue #133)

- **AC1** -- "The last-identity rule (and any other precondition) is validated before any
  destructive action" -- covered by the code change itself plus the unit test
  `identity remove — refuses the last identity before deleting its key (issue #133) > does not
  delete the private key when the removal is refused as the last identity` in
  `packages/cli/test/identity-remove.test.ts`, which asserts `unlink` is never called and
  `saveLocalConfig` is never called when the last identity's removal is refused.
- **AC2** -- "After a refused `identity remove only-one -y`, the private key still exists and the
  identity remains fully functional" -- covered by
  `packages/cli/test/integration/identity-remove-last-atomic.integration.test.ts`'s
  `refuses removal of the last identity (exit 3) and leaves the private key usable -- a subsequent
  \`init --root-signer\` still resolves and signs with it` test, which runs a real
  `init --root-signer <slug>` subprocess after the refused removal and asserts it exits 0 (loading
  and signing with the private key).
- **AC3** -- "Regression test at the CLI/UAT layer (real subprocess against a temp
  `ATTEST_IT_HOME`, isolated VaultKeeper dir per #114): create a single identity, attempt to
  remove it, assert exit 3 AND the key still resolves afterward" -- covered by the same
  `identity-remove-last-atomic.integration.test.ts` test: it spawns the real built CLI binary
  (`identity create --storage file` -> `identity remove -y` -> `init --root-signer`) with
  `ATTEST_IT_HOME` and `VAULTKEEPER_CONFIG_DIR` both redirected to an isolated temp directory.
  Confirmed this test **fails against pre-fix code** (reverted `remove.ts` locally, rebuilt, ran
  the test: it failed with `expected 3 to be +0` because `init --root-signer` failed after the key
  was deleted) and passes with the fix.

## Test plan

- [x] `packages/cli/test/integration/identity-remove-last-atomic.integration.test.ts` (new UAT,
      real subprocess CLI, temp `ATTEST_IT_HOME` + isolated `VAULTKEEPER_CONFIG_DIR` per #114) --
      verified it fails against the pre-fix `remove.ts` and passes with the fix.
- [x] `packages/cli/test/identity-remove.test.ts` -- new unit regression test plus all 10
      pre-existing tests in the file still pass.
- [x] `pnpm run build` -- green across all projects.
- [x] `pnpm run check` (lint + types + api-report) -- green, no new warnings/errors introduced by
      this change.
- [x] `pnpm run test` -- 810/810 tests passed across all projects.
- [x] Changeset added: `@attest-it/cli` minor (`.changeset/fix-identity-remove-last-atomic.md`).

Refs #133
