### PR TITLE
fix: block-style team: writes and --gates validation on team join

### DIFF
--- a/.changeset/team-join-block-style-and-gate-validation.md
+++ b/.changeset/team-join-block-style-and-gate-validation.md
@@ -1,0 +1,10 @@
+---
+'@attest-it/core': minor
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Fix two `team join` write-path bugs in the trust-critical `.attest-it/policy.yaml`:
+
+- `team join`/`team add` now emit block-style YAML for the `team:` section (matching the scaffold and every doc example) instead of rewriting it into flow-style, JSON-like YAML (`team: {alice: {...}}`) the moment a member is added to the scaffolded, empty `team: {}`. Untouched sections stay byte-for-byte unchanged.
+- `team join --gates <name>` / `team add --gates <name>` now validate each named gate against the gates defined in `policy.yaml` and hard-fail naming the missing gate when it isn't defined, instead of silently succeeding with the authorization as a no-op.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -235,7 +235,9 @@ npx attest-it identity export
 
 Pass `--gates` (comma-separated gate IDs) to authorize gates without the
 checkbox prompt; omitting it authorizes no gates rather than prompting or
-failing. `team join` also accepts `--slug` for the rare case where your
+failing. Each named gate must already be defined in `policy.yaml` -- naming
+a gate that doesn't exist fails fast rather than silently authorizing
+nothing. `team join` also accepts `--slug` for the rare case where your
 identity slug is already taken by another member:
 
 ```bash

--- a/packages/cli/src/commands/team/utils.ts
+++ b/packages/cli/src/commands/team/utils.ts
@@ -91,6 +91,14 @@ export async function promptForGateAuthorization(
  * authorized), so a missing `--gates` flag in a non-interactive context is
  * not an error -- it resolves to an empty array rather than failing fast.
  *
+ * A supplied `--gates` flag is always validated against the gates defined in
+ * `policy.yaml`, even when no gates (or an empty `gates: {}`) are defined --
+ * previously that case short-circuited to an empty array *before* the flag
+ * was ever inspected, so `--gates <typo>` silently authorized nothing with no
+ * indication the named gate doesn't exist. This is a trust-critical
+ * authorization command, so an undefined gate hard-fails naming it rather
+ * than warning. See issue #135.
+ *
  * @param gates - The gates configuration from the policy file
  * @param gatesFlag - Comma-separated gate IDs from a `--gates` flag, if supplied
  * @returns Array of gate IDs to authorize
@@ -101,22 +109,23 @@ export async function resolveGateAuthorization(
   gates: PolicyConfig['gates'] | undefined,
   gatesFlag?: string,
 ): Promise<string[]> {
-  if (!gates || Object.keys(gates).length === 0) {
-    return []
-  }
-
   if (gatesFlag !== undefined) {
+    const knownGates = gates ?? {}
     const requested = gatesFlag
       .split(',')
       .map((id) => id.trim())
       .filter((id) => id.length > 0)
-    const unknown = requested.filter((id) => !Object.hasOwn(gates, id))
+    const unknown = requested.filter((id) => !Object.hasOwn(knownGates, id))
     if (unknown.length > 0) {
       throw new Error(
-        `--gates references unknown gate(s): ${unknown.join(', ')}. Known gates: ${Object.keys(gates).join(', ')}`,
+        `--gates references unknown gate(s): ${unknown.join(', ')}. Known gates: ${Object.keys(knownGates).join(', ') || '(none defined)'}`,
       )
     }
     return requested
+  }
+
+  if (!gates || Object.keys(gates).length === 0) {
+    return []
   }
 
   if (!isInteractiveTTY()) {

--- a/packages/cli/test/integration/team-join-write-path.integration.test.ts
+++ b/packages/cli/test/integration/team-join-write-path.integration.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression tests for issues #134 and #135, both on the `team join` write
+ * path against a real, built CLI subprocess -- not a hand-built
+ * approximation of policy.yaml or the command's option parsing.
+ *
+ * #134: `team join` rewrote the `team:` section of the trust-critical,
+ * review-gated `policy.yaml` into flow-style, JSON-like YAML
+ * (`team: {alice: {...}}`) the moment a member was added to the scaffolded,
+ * empty `team: {}`, while the untouched `gates:` section (and every doc
+ * example) stayed block-style. This made security review diffs noisy.
+ *
+ * #135: `team join --gates <name>` naming a gate that isn't defined in
+ * policy.yaml silently succeeded (exit 0), giving no signal that the named
+ * authorization was a no-op.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+
+const CLI_CALL_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run the built CLI as a real subprocess with stdin closed (equivalent to
+ * `< /dev/null`) and a hard timeout, so a regression that reintroduces an
+ * interactive prompt fails loudly instead of hanging the suite.
+ */
+function runCliNonInteractive(
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = {},
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(
+        new Error(
+          `CLI call did not exit within ${String(CLI_CALL_TIMEOUT_MS)}ms: node attest-it ${args.join(' ')}\n` +
+            `stdout so far:\n${stdout}\nstderr so far:\n${stderr}`,
+        ),
+      )
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+describe('team join write path (issues #134, #135)', () => {
+  let projectDir: string
+  let homeDir: string
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-team-join-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-team-join-home-'))
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  it(
+    'writes the `team:` section in block style (not flow-style JSON-like YAML), leaving the untouched `gates:` section byte-unchanged (issue #134)',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
+      const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+
+      // 1. init: scaffolds policy.yaml with block-style `team: {}` / `gates: {}`.
+      const initResult = await runCliNonInteractive(['init'], projectDir, env)
+      expect(initResult.exitCode).toBe(0)
+
+      const scaffolded = await fs.promises.readFile(policyPath, 'utf8')
+      expect(scaffolded).toContain('team: {}')
+
+      // Sanity: the untouched `gates:` section snapshot we'll assert is
+      // byte-for-byte identical after `team join` writes.
+      const gatesSectionBefore = scaffolded.slice(scaffolded.indexOf('# Gates define'))
+
+      // 2. identity create: the identity `team join` will add.
+      const createResult = await runCliNonInteractive(
+        ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+        projectDir,
+        env,
+      )
+      expect(createResult.exitCode).toBe(0)
+
+      // 3. team join: previously rewrote `team:` into flow-style YAML the
+      // instant a member was added to the scaffolded, empty `team: {}`.
+      const joinResult = await runCliNonInteractive(['team', 'join'], projectDir, env)
+      expect(joinResult.exitCode).toBe(0)
+      expect(joinResult.stdout).toContain('added successfully')
+
+      const afterJoin = await fs.promises.readFile(policyPath, 'utf8')
+
+      // The written `team:` section must not contain a flow-style JSON-like
+      // mapping anywhere (this is the exact regression from issue #134).
+      expect(afterJoin).not.toMatch(/team:\s*\{/)
+      expect(afterJoin).toMatch(/team:\n {2}test-user:\n {4}name: Test User/)
+
+      // The untouched `gates:` section (including its commented example and
+      // the empty `gates: {}` scaffold) must be byte-for-byte unchanged.
+      const gatesSectionAfter = afterJoin.slice(afterJoin.indexOf('# Gates define'))
+      expect(gatesSectionAfter).toBe(gatesSectionBefore)
+    },
+    CLI_CALL_TIMEOUT_MS * 3,
+  )
+
+  it(
+    'hard-fails naming the missing gate when --gates references a gate not defined in policy.yaml, and still succeeds for a gate that does exist (issue #135)',
+    async () => {
+      const env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
+      const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+
+      const initResult = await runCliNonInteractive(['init'], projectDir, env)
+      expect(initResult.exitCode).toBe(0)
+
+      // policy.yaml scaffolds `gates: {}` -- no gates are defined at all,
+      // matching the exact repro in issue #135.
+      const scaffolded = await fs.promises.readFile(policyPath, 'utf8')
+      expect(scaffolded).toContain('gates: {}')
+
+      const createResult = await runCliNonInteractive(
+        ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+        projectDir,
+        env,
+      )
+      expect(createResult.exitCode).toBe(0)
+
+      // --gates my-gate, where "my-gate" is not defined anywhere in
+      // policy.yaml -- must hard-fail (nonzero exit) naming "my-gate", not
+      // silently succeed.
+      const joinWithUnknownGate = await runCliNonInteractive(
+        ['team', 'join', '--gates', 'my-gate'],
+        projectDir,
+        env,
+      )
+      expect(joinWithUnknownGate.exitCode).not.toBe(0)
+      expect(joinWithUnknownGate.stdout + joinWithUnknownGate.stderr).toContain('my-gate')
+
+      // The failed attempt must not have written the team member to disk.
+      const afterFailedJoin = await fs.promises.readFile(policyPath, 'utf8')
+      expect(afterFailedJoin).not.toContain('test-user:')
+
+      // Now hand-author a real gate into policy.yaml (no CLI command creates
+      // gates yet) and confirm referencing an *existing* gate by name still
+      // works unchanged.
+      const withGate = afterFailedJoin.replace(
+        'gates: {}',
+        'gates:\n  release:\n    name: Release Gate\n    description: Release approval\n    authorizedSigners:\n      - placeholder\n    fingerprint:\n      paths:\n        - src\n',
+      )
+      await fs.promises.writeFile(policyPath, withGate, 'utf8')
+
+      const joinWithKnownGate = await runCliNonInteractive(
+        ['team', 'join', '--gates', 'release'],
+        projectDir,
+        env,
+      )
+      expect(joinWithKnownGate.exitCode).toBe(0)
+      expect(joinWithKnownGate.stdout).toContain('added successfully')
+
+      const afterSuccessfulJoin = await fs.promises.readFile(policyPath, 'utf8')
+      expect(afterSuccessfulJoin).toContain('test-user:')
+      expect(afterSuccessfulJoin).toMatch(
+        /authorizedSigners:\s*\n\s*-\s*placeholder\s*\n\s*-\s*test-user/,
+      )
+    },
+    CLI_CALL_TIMEOUT_MS * 3,
+  )
+})

--- a/packages/cli/test/team-utils.test.ts
+++ b/packages/cli/test/team-utils.test.ts
@@ -44,9 +44,26 @@ describe('resolveGateAuthorization', () => {
     )
   })
 
-  it('should return an empty array when no gates are configured', async () => {
-    const result = await resolveGateAuthorization(undefined, 'release')
+  it('should return an empty array when --gates is omitted and no gates are configured', async () => {
+    const result = await resolveGateAuthorization(undefined, undefined)
 
     expect(result).toEqual([])
+  })
+
+  // Regression test for issue #135: `--gates <name>` naming a gate that
+  // doesn't exist silently succeeded (returned `[]`) whenever `gates` was
+  // undefined or `{}`, because that case short-circuited *before* the flag
+  // was ever validated. A trust-critical authorization command must hard-fail
+  // naming the missing gate instead of silently doing nothing.
+  it('should throw naming the missing gate when --gates is supplied but no gates are configured at all', async () => {
+    await expect(resolveGateAuthorization(undefined, 'release')).rejects.toThrow(
+      '--gates references unknown gate(s): release',
+    )
+  })
+
+  it('should throw naming the missing gate when --gates is supplied but gates is an empty object', async () => {
+    await expect(resolveGateAuthorization({}, 'my-gate')).rejects.toThrow(
+      '--gates references unknown gate(s): my-gate',
+    )
   })
 })

--- a/packages/core/src/config/policy-writer.ts
+++ b/packages/core/src/config/policy-writer.ts
@@ -123,7 +123,29 @@ function applyPolicyDiff(
   }
 
   if (isPlainRecord(before) && isPlainRecord(after)) {
-    const keys = new Set([...Object.keys(before), ...Object.keys(after)])
+    const beforeKeys = Object.keys(before)
+    const afterKeys = Object.keys(after)
+
+    // A record transitioning from empty to populated (e.g. the scaffolded
+    // `team: {}` gaining its first member) must not be edited key-by-key.
+    // `document.setIn` on a *nested* path reuses the existing node in place
+    // (YAMLMap#set), which keeps whatever collection style that node already
+    // had -- and an empty mapping like `{}` is parsed as flow style. The
+    // result was a trust-critical file where `team:` silently became
+    // flow-style JSON-like YAML (`team: {alice: {...}}`) the moment someone
+    // ran `team join`, while every other block-style section (including the
+    // untouched `gates:`) stayed block-style. See issue #134.
+    //
+    // Replacing the node wholesale instead (the same path used for scalar/
+    // array changes below) makes `yaml` synthesize a brand-new node for
+    // `after`, which defaults to block style -- matching the scaffold and
+    // every doc example.
+    if (beforeKeys.length === 0 && afterKeys.length > 0) {
+      document.setIn(path, after)
+      return
+    }
+
+    const keys = new Set([...beforeKeys, ...afterKeys])
     for (const key of keys) {
       applyPolicyDiff(document, [...path, key], before[key], after[key])
     }

--- a/packages/core/test/config/policy-writer.test.ts
+++ b/packages/core/test/config/policy-writer.test.ts
@@ -126,6 +126,35 @@ describe('serializeEditablePolicy (YAML)', () => {
     expect(output).toContain('alice:')
   })
 
+  // Regression test for issue #134: `team join` rewrote the `team:` section
+  // of the trust-critical, review-gated policy.yaml into flow-style,
+  // JSON-like YAML (`team: {alice: {...}}`) the moment a member was added to
+  // the scaffolded, empty `team: {}`, while every other section (including
+  // the untouched `gates:`) stayed block-style like the scaffold and every
+  // doc example. This fails pre-fix because `document.setIn` on a nested
+  // path reuses the existing (flow-style, since empty) `team` node in place.
+  it('emits block-style YAML for `team:` when a member is added to the scaffolded empty team, leaving `gates:` byte-unchanged (issue #134)', () => {
+    const editable = loadAnnotatedPolicy()
+    const updated: PolicyConfig = {
+      ...editable.policy,
+      team: {
+        alice: { name: 'Alice', publicKey: 'pk-alice', publicKeyAlgorithm: 'ed25519' },
+      },
+    }
+
+    const output = serializeEditablePolicy(editable, updated)
+
+    // No flow-style JSON-like mapping anywhere in the written `team:` section.
+    expect(output).not.toMatch(/team:\s*\{/)
+    expect(output).toMatch(/team:\n {2}alice:\n {4}name: Alice/)
+
+    // The untouched `gates:` section must be byte-for-byte identical to the
+    // source annotated policy.
+    const gatesSectionBefore = ANNOTATED_POLICY_YAML.slice(ANNOTATED_POLICY_YAML.indexOf('gates:'))
+    const gatesSectionAfter = output.slice(output.indexOf('gates:'))
+    expect(gatesSectionAfter).toBe(gatesSectionBefore)
+  })
+
   it('preserves comments nested inside an unrelated, unchanged section', () => {
     const editable = loadAnnotatedPolicy()
     const updated: PolicyConfig = {


### PR DESCRIPTION
## Summary

Fixes two bugs on the `team join`/`team add` write path over the trust-critical, review-gated `.attest-it/policy.yaml`. Both are shipped together since they touch the same write path.

**#134 — flow-style `team:` writes.** `team join`/`team add` rewrote the `team:` section into flow-style, JSON-like YAML (`team: {alice: {...}}`) the moment a member was added to the scaffolded, empty `team: {}`, while the untouched `gates:` section stayed block-style like the scaffold and every doc example. This made security review diffs noisy.

Root cause: `policy-writer.ts`'s comment-preserving diff (`applyPolicyDiff`) edited a record key-by-key even when the record transitioned from empty to populated. Adding a new key via `document.setIn(['team', 'alice'], ...)` reuses the existing `team` node in place (`YAMLMap#set`), which keeps whatever collection style that node already had — and an empty mapping (`{}`) parses as flow style. Fix: when a record goes from empty to populated, replace it wholesale (`document.setIn(['team'], after)`), which makes `yaml` synthesize a brand-new node that defaults to block style.

**#135 — silent no-op on an unknown `--gates` name.** `team join --gates <name>` (and `team add --gates`, which shares the same helper) naming a gate not defined in `policy.yaml` silently succeeded (exit 0) whenever no gates were configured at all, or `gates: {}`. This is because `resolveGateAuthorization` short-circuited to `[]` *before* ever inspecting the `--gates` flag in that case — validation only ran when at least one gate already existed. Fix: validate the flag first, against whatever gates are configured (including none), and hard-fail naming the missing gate. Referencing a gate that does exist continues to work unchanged.

## Acceptance criteria coverage

**#134**
- "Commands that write `policy.yaml` emit block-style YAML for the `team:` section... matching the scaffold" — covered by `packages/core/test/config/policy-writer.test.ts` (`emits block-style YAML for team: when a member is added to the scaffolded empty team...`) and the subprocess UAT `packages/cli/test/integration/team-join-write-path.integration.test.ts` (`writes the team: section in block style...`).
- "Comment/schema-directive preservation from #102 is retained" — covered by the existing `policy-writer.test.ts` suite (all 10 pre-existing tests still pass unmodified) plus `policy-comment-preservation.integration.test.ts`, both green.
- "Regression test: scaffold policy.yaml (block-style), run `team join`, assert the written `team:` section is block-style... and the `gates:` section is byte-unchanged" — covered by both the unit test above (byte-identical `gates:` slice comparison) and the subprocess UAT.

**#135**
- "`team join --gates <name>` (and `team add --gates`, since it shares the same helper) validates each named gate... hard-fails with a nonzero exit and a message naming the missing gate" — covered by `packages/cli/test/team-utils.test.ts` (two new cases: no gates configured at all, and `gates: {}`) and the subprocess UAT (`hard-fails naming the missing gate...`).
- "Referencing a gate that DOES exist continues to work unchanged" — covered by the existing `team-utils.test.ts` case (`should resolve a --gates flag naming real gate IDs`) plus the second half of the subprocess UAT, which hand-authors a real gate and confirms `--gates release` still succeeds.
- "Regression test: `gates: {}` + `team join --gates my-gate` asserts the documented failure... naming `my-gate`; a valid gate name still succeeds" — covered end-to-end by the subprocess UAT above.

All four new/changed regression tests were verified to fail against the pre-fix code (confirmed locally by reverting each source fix and re-running) and pass with the fix applied.

## Other changes

- `docs/getting-started.md`: documents that `--gates` now validates each named gate against `policy.yaml`.
- Changeset (`@attest-it/core`, `@attest-it/cli`, `attest-it`; minor) describing both fixes.

## Test plan

- [x] `packages/core/test/config/policy-writer.test.ts` — 11 tests pass (10 pre-existing + 1 new for #134)
- [x] `packages/cli/test/team-utils.test.ts` — 6 tests pass (4 pre-existing, 1 updated, 2 new for #135)
- [x] `packages/cli/test/integration/team-join-write-path.integration.test.ts` — 2 new subprocess-CLI tests (one per issue), both fail pre-fix and pass post-fix
- [x] Full workspace `pnpm run build` — green
- [x] Full workspace `pnpm run check:packages` (eslint + tsc + api-extractor) — green, no new warnings (only pre-existing `security/detect-object-injection` warnings on unrelated/unchanged lines)
- [x] Full workspace `pnpm run check:formatting` — green
- [x] Full workspace `pnpm run test` — 47 CLI test files / 812 tests + 33 core test files / 625 tests, all green

Refs #134 #135
