### PR TITLE
docs: reconcile seals.json/seals path, dead packaged links, ATTEST_IT_HOME, and Quick Start drift

### DIFF
--- a/AI_ASSISTANT_GUIDE.md
+++ b/AI_ASSISTANT_GUIDE.md
@@ -18,7 +18,10 @@ This document is designed for AI assistants (including those using RAG systems) 
 
 ### 1. Local Identity (`~/.config/attest-it/config.yaml`)
 
-Your Ed25519 keypair and identity information:
+Your Ed25519 keypair and identity information. Override the directory with the `ATTEST_IT_HOME`
+environment variable -- for the `file` key-storage backend this also redirects where VaultKeeper
+stores the actual private key material, but **not** for `keychain`/`1password`/`yubikey` (see
+[`ATTEST_IT_HOME`](docs/configuration.md#attest_it_home)):
 
 ```yaml
 version: 2
@@ -27,7 +30,7 @@ identities:
   work:
     name: Alice Smith
     email: alice@example.com
-    publicKey: MCowBQYDK2VwAyEA...
+    publicKey: tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc=
     privateKey:
       type: keychain # or 'file' or '1password'
       id: attest-it-work-1a2b3c4d-5678-90ab-cdef-1234567890ab
@@ -46,7 +49,7 @@ Trust-critical data (team, gates) lives in `.attest-it/policy.yaml`, loaded from
 version: 1
 team:
   alice:
-    publicKey: MCowBQYDK2VwAyEA...
+    publicKey: tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc=
 gates:
   desktop-tests:
     authorizedSigners: [alice]
@@ -62,24 +65,24 @@ suites:
     gate: desktop-tests
 ```
 
-### 3. Seals File (`.attest-it/seals.json`)
+### 3. Seals (`.attest-it/seals/`)
 
-Contains cryptographically signed records:
+Each seal is a cryptographically signed record stored as its own YAML file, one per
+(gate, signer), under `.attest-it/seals/<gate-slug>/<signer-slug>.seal`:
 
-```json
-{
-  "version": 1,
-  "seals": {
-    "desktop-tests": {
-      "gateId": "desktop-tests",
-      "fingerprint": "a3b8c9...",
-      "timestamp": "2026-01-14T12:34:56.789Z",
-      "sealedBy": "alice",
-      "signature": "base64-ed25519-signature..."
-    }
-  }
-}
+```yaml
+# .attest-it/seals/desktop-tests-<hash>/alice-<hash>.seal
+gateId: desktop-tests
+fingerprint: sha256:a3b8c9...
+timestamp: 2026-01-14T12:34:56.789Z
+sealedBy: alice
+signature: base64-ed25519-signature...
 ```
+
+`readSeals`/`writeSeals` (from `@attest-it/core`) present this file-per-seal layout as a single
+in-memory aggregate, so most code never deals with individual `.seal` files directly. See
+[Configuration Reference: Seal storage layout](docs/configuration.md#seal-storage-layout-file-per-seal)
+for the full path scheme.
 
 ## Common Errors and Solutions
 
@@ -185,7 +188,6 @@ Note: STALE is a warning, not a failure. Verification still passes.
 
 - `Key provider 'keychain' is not available`
 - `Failed to retrieve private key`
-- `1Password CLI not found`
 
 **What this means:**
 The configured key storage backend isn't available.
@@ -193,7 +195,8 @@ The configured key storage backend isn't available.
 **Solutions by provider:**
 
 - **keychain**: Only available on macOS
-- **1password**: Install 1Password CLI (`op`)
+- **1password**: Requires a 1Password service account token (`OP_SERVICE_ACCOUNT_TOKEN`); the
+  1Password SDK ships with attest-it, so the legacy `op` CLI is not required
 - **file**: Check file path and permissions
 
 User can rotate keys to a new provider: `npx attest-it identity create` (create new identity with different provider)
@@ -265,7 +268,7 @@ This `CONFIG_ERROR` fail-closed behavior is the only thing `status`'s exit code 
 **DO NOT:**
 
 - Generate or guess Ed25519 keys
-- Modify `.attest-it/seals.json` directly
+- Modify files under `.attest-it/seals/` directly
 - Bypass signature verification
 - Edit identity configuration files directly
 - Suggest workarounds that bypass security
@@ -321,12 +324,12 @@ npx attest-it status
 
 ## Key Files Reference
 
-| File               | Location                          | Purpose                      |
-| ------------------ | --------------------------------- | ---------------------------- |
-| Local identity     | `~/.config/attest-it/config.yaml` | User's keypairs and settings |
-| Policy config      | `.attest-it/policy.yaml`          | Team, gates (trust-critical) |
-| Operational config | `.attest-it/config.yaml`          | Suites (reference gates)     |
-| Seals              | `.attest-it/seals.json`           | Cryptographic seals          |
+| File               | Location                                                           | Purpose                                       |
+| ------------------ | ------------------------------------------------------------------ | --------------------------------------------- |
+| Local identity     | `~/.config/attest-it/config.yaml` (override with `ATTEST_IT_HOME`) | User's keypairs and settings                  |
+| Policy config      | `.attest-it/policy.yaml`                                           | Team, gates (trust-critical)                  |
+| Operational config | `.attest-it/config.yaml`                                           | Suites (reference gates)                      |
+| Seals              | `.attest-it/seals/`                                                | Cryptographic seals, one file per gate/signer |
 
 ## Verification States
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Some tests require a human: desktop apps, OAuth flows, AI assistants, visual ver
 ## Quick Start
 
 ```bash
+# If this is a fresh project, ignore node_modules before doing anything else --
+# `attest-it run` refuses to seal against an uncommitted/dirty working tree.
+echo "node_modules/" >> .gitignore
+
 npm install attest-it
 
 # One-time setup: create your signing identity
@@ -16,6 +20,20 @@ npx attest-it identity create
 
 # Initialize project config
 npx attest-it init
+
+# Define a gate (what needs attestation, who can sign -- list your own identity
+# slug in authorizedSigners) in .attest-it/policy.yaml, and a suite (a runnable
+# command bound to that gate) in .attest-it/config.yaml -- see Configuration
+# below for the minimal shape, or copy the commented example already in each
+# scaffolded file.
+
+# Add yourself to the project team and authorize the gate you just defined
+npx attest-it team join --gates my-gate
+
+# Commit before the next step -- `run` refuses to seal a dirty tree. This
+# includes package.json/your lockfile (touched by `npm install` and `init`)
+# in addition to .attest-it/.
+git add -A && git commit -m "Configure attest-it"
 
 # Run tests and seal the gate
 npx attest-it run --suite my-suite
@@ -36,6 +54,9 @@ npx attest-it verify
 >   rejected as `UNKNOWN_SIGNER`).
 >
 > See the [threat model](docs/threat-model.md) for the full trust boundary.
+
+See [Getting Started](docs/getting-started.md) for the fully worked walkthrough,
+including the exact gate/suite YAML.
 
 ### Non-interactive (CI, embedders, agents)
 
@@ -122,7 +143,7 @@ rootGate:
 team:
   alice:
     name: Alice Smith
-    publicKey: MCowBQYDK2VwAyEA... # Ed25519 public key (base64)
+    publicKey: tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc= # Ed25519 public key (raw, base64)
 
 # Gates define what code requires human attestation
 gates:
@@ -298,11 +319,20 @@ Seals become invalid when:
 
 ## Key Storage Options
 
-When you run `attest-it identity create`, you can choose where to store your private key:
+When you run `attest-it identity create`, you can choose where to store your private key. All
+backends store the key through VaultKeeper, a dependency that manages the underlying secret
+storage; identity **metadata** (slug, name, public key, and a pointer to the private key) lives
+separately in `~/.config/attest-it/config.yaml` (or a directory of your choosing, via the
+[`ATTEST_IT_HOME`](docs/configuration.md#attest_it_home) environment variable -- for the `file`
+backend below, this also redirects VaultKeeper's own key storage; the `keychain`/`1password`/
+`yubikey` backends are not redirected by it. See the linked section for details).
 
 ### File System (Default)
 
-Keys are stored as PEM files in `~/.attest-it/keys/`. Simple but requires you to protect the file.
+The private key is stored via VaultKeeper's file backend, encrypted at rest. Under `ATTEST_IT_HOME`
+it's isolated alongside the rest of the sandboxed identity state (`<ATTEST_IT_HOME>/vaultkeeper/`);
+otherwise it uses VaultKeeper's real default location. Simple but requires you to protect that
+storage.
 
 ### macOS Keychain
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,8 @@ attest-it uses three types of configuration, split by trust level:
 
 1. **Policy configuration** (`.attest-it/policy.yaml`) - Trust-critical: team members and gates. Loaded from your repository's **default branch**, so pull requests cannot tamper with trust data.
 2. **Operational configuration** (`.attest-it/config.yaml`) - Non-security-critical: suites (test commands) and groups. Every suite must reference a gate defined in `policy.yaml`. Safe to load from PR branches.
-3. **Local identity configuration** (`~/.config/attest-it/config.yaml`) - Your personal signing identity.
+3. **Local identity configuration** (`~/.config/attest-it/config.yaml`, overridable via
+   [`ATTEST_IT_HOME`](#attest_it_home)) - Your personal signing identity.
 
 Run `attest-it init` to scaffold both `policy.yaml` and `config.yaml`. If you have an existing legacy unified `config.yaml` (a single file that held `team`, `gates`, and `suites` together), run `attest-it init --migrate` to split it into the pair automatically.
 
@@ -24,7 +25,7 @@ settings:
 team:
   alice:
     name: Alice Smith
-    publicKey: MCowBQYDK2VwAyEA...
+    publicKey: tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc=
 
 gates:
   desktop-tests:
@@ -281,11 +282,11 @@ team:
     name: Alice Smith
     email: alice@example.com
     github: alicedev
-    publicKey: MCowBQYDK2VwAyEAabc123...
+    publicKey: tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc=
 
   bob:
     name: Bob Jones
-    publicKey: MCowBQYDK2VwAyEAxyz789...
+    publicKey: ThmrTeY+vN6mT9ll6vtQoCnFXvP9iAH2js/VJywXGUQ=
 ```
 
 ### Team Member Fields
@@ -510,7 +511,7 @@ identities:
     name: Alice Smith
     email: alice@example.com
     github: alicedev
-    publicKey: MCowBQYDK2VwAyEAabc123...
+    publicKey: 3qdpoUtbULEkav5QsYUQ3yf1Wx5yJVtXFxHtsWJtRbw=
     privateKey:
       type: 1password
       id: attest-it-work-1a2b3c4d-5678-90ab-cdef-1234567890ab
@@ -519,7 +520,7 @@ identities:
   personal:
     name: Alice Smith
     email: alice@personal.com
-    publicKey: MCowBQYDK2VwAyEAdef456...
+    publicKey: OorDf+aGu8Hwnf5+kD44TfqnXi5qv7gvqIDH8ZOazKs=
     privateKey:
       type: keychain
       id: attest-it-personal-2b3c4d5e-6789-01bc-def2-234567890abc
@@ -635,6 +636,37 @@ Migrated keys therefore do not yet get delegated signing's no-disk-write benefit
 them once VaultKeeper offers a public-key-preserving external-key import is tracked in
 [#122](https://github.com/mike-north/attest-it/issues/122).
 
+### `ATTEST_IT_HOME`
+
+By default, local identity configuration lives at `~/.config/attest-it/config.yaml` (see
+[Local Identity Configuration](#local-identity-configuration) above). Set the `ATTEST_IT_HOME`
+environment variable to redirect that entire directory somewhere else -- useful for running
+multiple isolated identity sets on one machine, or for tests/CI that must not touch a real
+user's config.
+
+```bash
+export ATTEST_IT_HOME=/tmp/isolated-attest-it
+attest-it identity create --name "CI Bot" --storage file --slug ci-bot < /dev/null
+# writes to /tmp/isolated-attest-it/config.yaml instead of ~/.config/attest-it/config.yaml
+```
+
+**Precedence** (highest to lowest):
+
+1. `ATTEST_IT_HOME` environment variable
+2. A programmatic override via `@attest-it/core`'s `setAttestItHomeDir()` (embedders only)
+3. Default: `~/.config/attest-it`
+
+**Caveat -- only the `file` backend's VaultKeeper storage is covered.** Beyond redirecting
+`config.yaml` (the identity **metadata**: slug, name, public key, and a pointer to where the
+private key lives), `ATTEST_IT_HOME` also propagates into VaultKeeper's own config-dir
+resolution for the **`file`** key storage backend: the encrypted `.enc` private-key blob lands
+under `<ATTEST_IT_HOME>/vaultkeeper/`, not the real `~/.config/vaultkeeper/` (fixed in #129/#142
+-- previously it leaked to the real, non-sandboxed location even with `ATTEST_IT_HOME` set). The
+`keychain`, `1password`, and `yubikey` backends are **not** covered by this propagation -- the
+macOS Keychain item, 1Password vault entry, or YubiKey-encrypted file are still located exactly
+where they'd be without `ATTEST_IT_HOME` set, regardless of its value. A fully isolated test/CI
+environment today is only practical with the `file` backend.
+
 ---
 
 ## Verification States
@@ -654,6 +686,42 @@ including `MISSING`, `FINGERPRINT_MISMATCH`, `INVALID_SIGNATURE`, and `UNKNOWN_S
 | `FINGERPRINT_MISMATCH` | 1             | Code changed since seal was created     |
 | `INVALID_SIGNATURE`    | 1             | Signature verification failed           |
 | `UNKNOWN_SIGNER`       | 1             | Signer not in team configuration        |
+
+### `status --json` Output Schema
+
+`attest-it status --json` prints an array with one object per gate (or `[]` when the
+configuration defines zero gates, which still exits `NO_WORK`):
+
+```json
+[
+  {
+    "gateId": "desktop-tests",
+    "state": "VALID",
+    "currentFingerprint": "sha256:e05bdb2e8f005bac24d6266f5fe867c08d8440f1e80d65064c2b4c171327ee19",
+    "sealedFingerprint": "sha256:e05bdb2e8f005bac24d6266f5fe867c08d8440f1e80d65064c2b4c171327ee19",
+    "sealedBy": "alice",
+    "sealedAt": "2026-01-14T12:34:56.789Z",
+    "age": 0
+  }
+]
+```
+
+| Field                | Type                | Always present | Description                                                                            |
+| -------------------- | ------------------- | -------------- | -------------------------------------------------------------------------------------- |
+| `gateId`             | string              | Yes            | The gate's identifier (its key under `gates:` in `policy.yaml`)                        |
+| `state`              | `VerificationState` | Yes            | One of the states in the table above                                                   |
+| `currentFingerprint` | string              | Yes            | The fingerprint computed from the gate's current fingerprint paths, `sha256:`-prefixed |
+| `sealedFingerprint`  | string              | Only if sealed | The fingerprint recorded in the seal, if a seal exists for this gate                   |
+| `sealedBy`           | string              | Only if sealed | The signer's identity slug, if a seal exists                                           |
+| `sealedAt`           | string (ISO 8601)   | Only if sealed | The seal's timestamp, if a seal exists                                                 |
+| `age`                | number (days)       | Only if sealed | Days elapsed since `sealedAt`, floored                                                 |
+| `message`            | string \| undefined | No             | An optional human-readable explanation (e.g. why a state is not `VALID`)               |
+
+`attest-it verify --json` uses a **different** shape (`SealVerificationResult[]`): each entry is
+`{ gateId, state, seal?, message? }`, where `seal` -- when present -- nests
+`{ gateId, fingerprint, timestamp, sealedBy, signature }` rather than the flattened
+`sealedFingerprint`/`sealedBy`/`sealedAt`/`age` fields `status --json` uses. Neither shape is yet
+stabilized as a public API contract the way the [embeddable API](embedding.md) is.
 
 ### Exit Codes
 
@@ -780,12 +848,12 @@ team:
     name: Alice Smith
     email: alice@example.com
     github: alicedev
-    publicKey: MCowBQYDK2VwAyEAabc123...
+    publicKey: tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc=
 
   bob:
     name: Bob Jones
     email: bob@example.com
-    publicKey: MCowBQYDK2VwAyEAxyz789...
+    publicKey: ThmrTeY+vN6mT9ll6vtQoCnFXvP9iAH2js/VJywXGUQ=
 
 gates:
   desktop-vscode:

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -112,6 +112,29 @@ attestation states — a key backend failing or being cancelled, or a filesystem
 I/O error — are **thrown**, not returned as taxonomy failures; an embedder
 treats those as an inability to decide and fails closed.
 
+## Identity resolution and `ATTEST_IT_HOME`
+
+`seal(path, { identity }, options?)` resolves `identity` (a local identity slug) against the
+caller's **local identity configuration** -- the same `~/.config/attest-it/config.yaml` the CLI
+reads (see [Local Identity Configuration](configuration.md#local-identity-configuration)). An
+embedder running in an isolated process (tests, CI, a sandboxed worker) that must not read or
+write a real user's identity config should set the `ATTEST_IT_HOME` environment variable, or call
+`setAttestItHomeDir()` exported from `@attest-it/core`, before invoking `seal(...)`:
+
+```ts
+import { setAttestItHomeDir, seal } from '@attest-it/core'
+
+setAttestItHomeDir('/tmp/isolated-attest-it-home')
+await seal('src/tool.ts', { identity: 'ci-bot' }, { baseDir: '/path/to/repo' })
+```
+
+The environment variable takes precedence over the programmatic override -- see
+[`ATTEST_IT_HOME`](configuration.md#attest_it_home) for full precedence rules. As with the CLI,
+this also redirects where VaultKeeper stores the private key material for the **`file`**
+key-storage backend, but not for `keychain`/`1password`/`yubikey` -- so a fully isolated
+embedding test/CI environment today is only practical with the `file` backend. See the caveat in
+[`ATTEST_IT_HOME`](configuration.md#attest_it_home) for the current state.
+
 ## Schema versioning and breaking changes
 
 `API_SCHEMA_VERSION` (currently `1`) is stamped onto every result. **Changing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,8 @@ This guide walks you through setting up attest-it for your project.
 
 **Optional** (for secure key storage):
 
-- 1Password CLI (`op`) for 1Password storage
+- A 1Password service account token (`OP_SERVICE_ACCOUNT_TOKEN`) for 1Password storage -- the
+  1Password SDK ships with attest-it, so the legacy `op` CLI is not required
 - macOS for Keychain storage
 
 ## Installation
@@ -23,6 +24,16 @@ npm install attest-it
 pnpm add attest-it
 # or
 yarn add attest-it
+```
+
+If this is a fresh project (no `.gitignore` yet), add one before running any
+attest-it commands so `node_modules/` doesn't end up tracked or counted as an
+uncommitted change (`attest-it run` refuses to seal against a dirty working
+tree -- see [Working Tree Has Uncommitted
+Changes](configuration.md#working-tree-has-uncommitted-changes)):
+
+```bash
+echo "node_modules/" >> .gitignore
 ```
 
 ## Step 1: Create Your Identity
@@ -57,7 +68,7 @@ Generating Ed25519 keypair...
 ✓ Identity 'work' created successfully!
 
 Public key (share with team):
-  MCowBQYDK2VwAyEAabc123...
+  tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty3...
 
 Private key stored in: macOS Keychain (attest-it/work)
 
@@ -66,7 +77,11 @@ Next steps:
   2. Run: npx attest-it init (in your project)
 ```
 
-Your identity is stored locally at `~/.config/attest-it/config.yaml`.
+Your identity is stored locally at `~/.config/attest-it/config.yaml`. Set the
+`ATTEST_IT_HOME` environment variable to point this at a different directory
+(useful for testing or running multiple isolated setups on one machine) --
+see [`ATTEST_IT_HOME`](configuration.md#attest_it_home) for precedence and an
+important caveat about key storage.
 
 ### Non-interactive identity creation
 
@@ -140,9 +155,19 @@ Next steps:
   2. Run: attest-it identity create  (if you haven't already)
   3. Run: attest-it team join
   4. Edit .attest-it/policy.yaml to define your gates, and .attest-it/config.yaml to define suites
+  5. Bootstrap the trust anchor: attest-it init --root-signer <your-identity-slug>
+     (safe to run at any time — it merges in the root gate and leaves your
+     existing gates, suites, and seals untouched)
 
 Would you like to enable shell completions for zsh? (Y/n)
 ```
+
+Step 5 (bootstrapping the trust anchor) establishes `policy.yaml` itself as a
+sealed artifact so a pull request can't tamper with `team`/`gates`; it's
+optional but recommended, and -- as the output notes -- safe to run later once
+you already have gates/suites defined. See [Root Gate](configuration.md#root-gate-rootgate)
+for what it does and why. This walkthrough continues without it below for
+brevity.
 
 That last prompt is a one-time, optional offer to install shell completions
 for your detected shell (`bash`, `zsh`, or `fish`) -- unrelated to
@@ -166,7 +191,7 @@ resolves. For example:
 version: 1
 
 settings:
-  sealsPath: .attest-it/seals.json
+  maxAgeDays: 30
 
 team: {}
 
@@ -222,7 +247,7 @@ team:
   alice:
     name: Alice Smith
     email: alice@example.com
-    publicKey: MCowBQYDK2VwAyEAabc123... # From identity export
+    publicKey: tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc= # From identity export
 ```
 
 To get your public key for manual addition:
@@ -249,17 +274,18 @@ npx attest-it team join --gates desktop-tests < /dev/null
 
 ```bash
 npx attest-it team add --slug bob --name "Bob Jones" \
-  --public-key "MCowBQYDK2VwAyEA..." --gates desktop-tests < /dev/null
+  --public-key "ThmrTeY+vN6mT9ll6vtQoCnFXvP9iAH2js/VJywXGUQ=" --gates desktop-tests < /dev/null
 ```
 
 ## Step 3b: Commit Your Configuration
 
 Before running tests, commit everything you've changed so far -- the `package.json` update
-from `init`, and the `.attest-it/policy.yaml` / `.attest-it/config.yaml` edits from Steps 2b
-and 3:
+from `init`, a freshly created lockfile if `npm install`/`pnpm add`/`yarn add` in
+[Installation](#installation) hadn't already been committed, and the
+`.attest-it/policy.yaml` / `.attest-it/config.yaml` edits from Steps 2b and 3:
 
 ```bash
-git add package.json .attest-it/
+git add -A
 git commit -m "Configure attest-it: gate, suite, and team"
 ```
 
@@ -288,7 +314,7 @@ The workflow:
 2. **Execute**: Runs the test command
 3. **Confirm**: Asks if tests passed and you want to seal
 4. **Sign**: Creates Ed25519 signature with your private key
-5. **Save**: Updates `.attest-it/seals.json`
+5. **Save**: Writes a seal file under `.attest-it/seals/`
 
 Example output:
 
@@ -305,12 +331,14 @@ Test Files  1 passed (1)
 ✓ Tests passed!
 ? Create seal for gate 'desktop-tests'? Yes
 
-✓ Seal created for desktop-tests
-  Fingerprint: a3b8c9d2...
-  Sealed by: alice
-  Sealed at: 2026-01-14T12:34:56.789Z
+Suite 'desktop-tests' is linked to gate 'desktop-tests'
+✓ Seal created for gate 'desktop-tests'
+  Sealed by: alice (Alice Smith)
+  Timestamp: 2026-01-14T12:34:56.789Z
 
-Commit: git add .attest-it/seals.json && git commit -m "Seal desktop-tests"
+✓ Suite completed!
+
+To commit: git add .attest-it/seals/ && git commit -m "Update seals"
 ```
 
 ### Non-interactive sealing
@@ -339,7 +367,7 @@ npx attest-it seal desktop-tests
 produced is the seal itself. Add it to version control:
 
 ```bash
-git add .attest-it/seals.json
+git add .attest-it/seals/
 git commit -m "Add seal for desktop-tests"
 git push
 ```
@@ -348,9 +376,11 @@ The `.attest-it/` directory structure:
 
 ```
 .attest-it/
-├── policy.yaml  # Trust-critical config: team, gates (commit; merge to default branch)
-├── config.yaml  # Operational config: suites (commit)
-└── seals.json   # Seals (commit after creating)
+├── policy.yaml            # Trust-critical config: team, gates (commit; merge to default branch)
+├── config.yaml            # Operational config: suites (commit)
+└── seals/                 # Seals, one file per (gate, signer) (commit after creating)
+    └── desktop-tests-.../
+        └── alice-....seal
 ```
 
 ## Step 6: Set Up CI Verification
@@ -419,18 +449,21 @@ npx attest-it status
 Example output:
 
 ```
-Gate Status
-===========
+Suite         │ Status │ Fingerprint         │ Age
+──────────────┼────────┼─────────────────────┼───────
+desktop-tests │ VALID  │ sha256:e05bdb2e8... │ 0 days
 
-Gate: desktop-tests
-Status: ✓ VALID
-Fingerprint: a3b8c9d2...
-Sealed by: alice
-Sealed at: 2026-01-14T12:34:56.789Z
-Age: 2 days
+Seal metadata:
+  desktop-tests:
+    Sealed by: alice
+    Sealed at: 1/14/2026, 12:34:56 PM
 
-Overall: All gates valid
+✓ All gate seals valid
 ```
+
+(The table's leftmost column is labeled "Suite" even though its values are
+gate IDs; that mislabel is tracked separately at
+[#130](https://github.com/mike-north/attest-it/issues/130).)
 
 **`status` is informational and exits `0` when it successfully reports gate results** --
 even when a gate is `MISSING`, `FINGERPRINT_MISMATCH`, or otherwise invalid, it reports what
@@ -478,7 +511,7 @@ team:
   bob:
     name: Bob Jones
     email: bob@example.com
-    publicKey: MCowBQYDK2VwAyEAxyz789...
+    publicKey: ThmrTeY+vN6mT9ll6vtQoCnFXvP9iAH2js/VJywXGUQ=
 ```
 
 4. Add to gate's `authorizedSigners`:

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -364,7 +364,7 @@ If seals are missing, provide clear instructions:
     echo "To fix:"
     echo "  1. Run: npx attest-it status"
     echo "  2. Run: npx attest-it seal <gate-name>"
-    echo "  3. Commit: git add .attest-it/seals.json"
+    echo "  3. Commit: git add .attest-it/seals/"
     exit 1
 ```
 
@@ -426,7 +426,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .attest-it/seals.json
+          git add .attest-it/seals/
           git diff --staged --quiet || git commit -m "chore: prune stale seals"
           git push
 ```
@@ -505,7 +505,7 @@ Require reviews for seal changes:
 
 ```yaml
 # .github/CODEOWNERS
-.attest-it/seals.json @your-team/security-reviewers
+.attest-it/seals/ @your-team/security-reviewers
 ```
 
 ### Branch Protection
@@ -537,7 +537,7 @@ After rebasing, re-seal if files in fingerprint paths changed:
 git rebase main
 npx attest-it status  # Check what changed
 npx attest-it seal <gate-name>
-git add .attest-it/seals.json
+git add .attest-it/seals/
 git rebase --continue
 ```
 

--- a/docs/manual-testing-guide.md
+++ b/docs/manual-testing-guide.md
@@ -92,8 +92,9 @@ pnpm exec attest-it run --suite 1password-integration
 pnpm exec attest-it seal 1password-integration
 ```
 
-The seal is a cryptographic signature proving you ran the test. It's stored in `.attest-it/seals.json`
-(configurable via the policy's `settings.sealsPath`).
+The seal is a cryptographic signature proving you ran the test. It's stored under
+`.attest-it/seals/` (one file per gate/signer; the directory is configurable via the policy's
+`settings.sealsPath`).
 
 ## When to Re-attest
 
@@ -291,7 +292,7 @@ pnpm --filter @attest-it/cli test:manual:my-integration
 pnpm exec attest-it seal my-integration
 ```
 
-Commit the seals file (`.attest-it/seals.json`) along with your changes.
+Commit the new seal file(s) under `.attest-it/seals/` along with your changes.
 
 ### Example: Full Flow
 

--- a/packages/attest-it/README.md
+++ b/packages/attest-it/README.md
@@ -26,14 +26,25 @@ yarn add attest-it
 ## Quick Start
 
 ```bash
+# Fresh project? Ignore node_modules first -- `attest-it run` refuses to seal
+# against an uncommitted/dirty working tree.
+echo "node_modules/" >> .gitignore
+
 # Create your signing identity
 npx attest-it identity create
 
 # Initialize project configuration
 npx attest-it init
 
-# Add yourself to the project team
-npx attest-it team join
+# Define a gate and a suite that references it -- see Configuration below for
+# the minimal shape, or copy the commented example already in each scaffolded
+# file (.attest-it/policy.yaml and .attest-it/config.yaml).
+
+# Add yourself to the project team and authorize the gate you just defined
+npx attest-it team join --gates my-gate
+
+# Commit before sealing (config edits + any new lockfile from installing)
+git add -A && git commit -m "Configure attest-it"
 
 # Run tests and create seal
 npx attest-it run --suite my-suite
@@ -41,6 +52,9 @@ npx attest-it run --suite my-suite
 # Verify seals (in CI)
 npx attest-it verify
 ```
+
+See [Getting Started](https://github.com/mike-north/attest-it/blob/main/docs/getting-started.md)
+for the fully worked walkthrough.
 
 ## Package Contents
 
@@ -59,7 +73,28 @@ This umbrella package includes:
 | `verify` | Verify seals (for CI)     |
 | `prune`  | Remove stale seals        |
 
-For identity and team management commands, see the [main README](../../README.md#cli-commands).
+**Identity management:**
+
+| Command                  | Description                           |
+| ------------------------ | ------------------------------------- |
+| `identity create`        | Create a new identity with keypair    |
+| `identity list`          | List all local identities             |
+| `identity use <slug>`    | Switch active identity                |
+| `identity show [slug]`   | Show identity details                 |
+| `identity export [slug]` | Export public key for team onboarding |
+| `identity remove <slug>` | Delete identity and associated key    |
+| `whoami`                 | Show current active identity          |
+
+**Team management:**
+
+| Command              | Description                                           |
+| -------------------- | ----------------------------------------------------- |
+| `team list`          | List team members and gates                           |
+| `team add`           | Add a team member                                     |
+| `team join`          | Add yourself to the project team with active identity |
+| `team remove <slug>` | Remove team member                                    |
+
+Run `npx attest-it <command> --help` for detailed usage.
 
 ### Programmatic API
 
@@ -99,8 +134,7 @@ version: 1
 
 settings:
   maxAgeDays: 30
-  publicKeyPath: .attest-it/pubkey.pem
-  sealsPath: .attest-it/seals.json
+  sealsPath: .attest-it/seals/
 
 gates:
   desktop-tests:
@@ -124,12 +158,20 @@ suites:
     command: pnpm vitest --project desktop
 ```
 
+Local identity configuration (your personal signing identity, distinct from the project's
+`.attest-it/`) lives at `~/.config/attest-it/config.yaml` by default. Set `ATTEST_IT_HOME` to
+redirect that directory (e.g. for isolated test runs); for the `file` key-storage backend this
+also redirects where VaultKeeper stores the private key material, but **not** for `keychain`,
+`1password`, or `yubikey` -- see
+[`ATTEST_IT_HOME`](https://github.com/mike-north/attest-it/blob/main/docs/configuration.md#attest_it_home)
+for details.
+
 ## Documentation
 
-- [Getting Started](../../docs/getting-started.md) - Complete setup guide
-- [Configuration](../../docs/configuration.md) - All configuration options
-- [GitHub Integration](../../docs/github-integration.md) - CI setup
-- [API Documentation](../../docs/api/attest-it.md) - Full API reference
+- [Getting Started](https://github.com/mike-north/attest-it/blob/main/docs/getting-started.md) - Complete setup guide
+- [Configuration](https://github.com/mike-north/attest-it/blob/main/docs/configuration.md) - All configuration options
+- [GitHub Integration](https://github.com/mike-north/attest-it/blob/main/docs/github-integration.md) - CI setup
+- [Embedding attest-it](https://github.com/mike-north/attest-it/blob/main/docs/embedding.md) - The stable, versioned embeddable API
 
 ## Related Packages
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -82,6 +82,12 @@ All commands support these global options:
 | `--help`              | Show help           |
 | `--version`           | Show version        |
 
+### Environment Variables
+
+| Variable         | Description                                                                                                                                                                                                                                                                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ATTEST_IT_HOME` | Override the local identity config directory (default `~/.config/attest-it`). Also redirects VaultKeeper's own private-key storage for the `file` backend, but not `keychain`/`1password`/`yubikey`. See [Configuration](https://github.com/mike-north/attest-it/blob/main/docs/configuration.md#attest_it_home). |
+
 ## Exit Codes
 
 | Code | Constant     | Meaning                             |
@@ -105,9 +111,9 @@ program.parse(['node', 'attest-it', 'status', '--json'])
 
 ## Documentation
 
-- [Getting Started](../../docs/getting-started.md)
-- [Configuration](../../docs/configuration.md)
-- [GitHub Integration](../../docs/github-integration.md)
+- [Getting Started](https://github.com/mike-north/attest-it/blob/main/docs/getting-started.md)
+- [Configuration](https://github.com/mike-north/attest-it/blob/main/docs/configuration.md)
+- [GitHub Integration](https://github.com/mike-north/attest-it/blob/main/docs/github-integration.md)
 
 ## Requirements
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,18 @@ program
 // Handle --version manually to avoid loading package.json on every invocation
 program.option('-V, --version', 'output the version number')
 
+program.addHelpText(
+  'after',
+  `
+Environment Variables:
+  ATTEST_IT_HOME  Override the local identity config directory (default:
+                  ~/.config/attest-it). Takes precedence over any
+                  programmatic override. Also redirects VaultKeeper's private
+                  key storage for the "file" backend, but not for
+                  macOS Keychain, 1Password, or YubiKey -- see
+                  docs/configuration.md for details.`,
+)
+
 // Register commands
 program.addCommand(initCommand)
 program.addCommand(statusCommand)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -118,7 +118,9 @@ backward compatibility with older, non-Ed25519 signing flows.
 
 ## API Documentation
 
-See the [API documentation](../../docs/api/core.md) for complete type definitions and function signatures.
+Full type definitions ship with the package (`dist/index.d.ts`) -- browse them via your editor's
+type hints, or see the [Embedding attest-it](https://github.com/mike-north/attest-it/blob/main/docs/embedding.md)
+guide for the stable, versioned embeddable API surface.
 
 ## Requirements
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -14,13 +14,13 @@ Schemas are versioned in subdirectories (e.g., `v1/`) to ensure backward compati
 
 ### v1 (Current)
 
-| Schema                          | Purpose                        | Used By                           |
-| ------------------------------- | ------------------------------ | --------------------------------- |
-| `v1/project-config.schema.json` | Complete project configuration | `.attest-it/config.yaml`          |
-| `v1/identity.schema.json`       | Local identity management      | `~/.config/attest-it/config.yaml` |
-| `v1/policy.schema.json`         | Security policy (team, gates)  | Split config deployments          |
-| `v1/config.schema.json`         | Operational config (suites)    | Split config deployments          |
-| `v1/seals.schema.json`          | Seals file format              | `.attest-it/seals.json`           |
+| Schema                          | Purpose                                                           | Used By                                                                                                                         |
+| ------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `v1/project-config.schema.json` | Complete project configuration                                    | `.attest-it/config.yaml`                                                                                                        |
+| `v1/identity.schema.json`       | Local identity management                                         | `~/.config/attest-it/config.yaml`                                                                                               |
+| `v1/policy.schema.json`         | Security policy (team, gates)                                     | Split config deployments                                                                                                        |
+| `v1/config.schema.json`         | Operational config (suites)                                       | Split config deployments                                                                                                        |
+| `v1/seals.schema.json`          | Legacy monolithic seals file format (pre-file-per-seal migration) | Migration/backward-compat only -- current seals live under `.attest-it/seals/<gate-slug>/<signer-slug>.seal`, one seal per file |
 
 ## Editor Setup
 


### PR DESCRIPTION
## Summary

Pure-doc reconciliation sweep for the DX-wave-1 cluster of documentation drift in #132. No
behavioral/code changes except one non-functional `--help` text addition in
`packages/cli/src/index.ts` (documents the existing `ATTEST_IT_HOME` env var; no logic changed).

**Rebased onto `main` (tip `157585c`) after #138/#140/#141/#142/#143/#144 merged.** One real
conflict, in `README.md`'s Quick Start section: #140 inserted an `[!IMPORTANT]` callout about
`verify` not being the CI trust boundary right where this PR added a "See Getting Started" pointer
line. Resolved by keeping #140's callout in full and appending this PR's pointer line after it —
no wording from either side was dropped. Two more regions this PR touched (`docs/getting-started.md`
Step 6, `docs/github-integration.md`) auto-merged cleanly since #140's edits and this PR's
`seals.json`→`seals/` edits landed in disjoint hunks. Beyond the mechanical conflict, two doc
sections needed *content* updates because the code they describe changed after this PR was
originally written — see criteria 3 and 5 below for what changed and how it was re-verified.

## Criterion → verification mapping

1. **`seals.json` → `seals/` everywhere.** Replaced every `.attest-it/seals.json` reference
   (including `git add .attest-it/seals.json`, which fails with `fatal: pathspec ... did not
   match any files` — reproduced live) across `README.md`, `docs/getting-started.md`,
   `docs/github-integration.md`, `docs/manual-testing-guide.md`, `AI_ASSISTANT_GUIDE.md`,
   `packages/attest-it/README.md`, and `schemas/README.md`. Fixed the `sealsPath` default shown
   in doc policy examples to `.attest-it/seals/`. Verified: `grep -rn "seals\.json" --include="*.md" .`
   now only matches intentional legacy-migration explanations in `docs/configuration.md` and the
   unreleased `.changeset/file-per-seal-storage.md` (both describing the migrated-away format on
   purpose).
2. **Dead packaged-README links.** `packages/attest-it/README.md`, `packages/cli/README.md`, and
   `packages/core/README.md` all had `../../README.md#cli-commands` / `../../docs/*.md` links that
   resolve to nothing once installed from `node_modules`. Inlined the identity/team command
   reference tables in `packages/attest-it/README.md` (matching the pattern already used for
   init/status/run/verify), and converted the remaining doc links to absolute
   `github.com/mike-north/attest-it/blob/main/...` URLs. `docs/api/*.md` doesn't exist in the repo
   at all (never generated/committed on `main`), so those two links were replaced rather than
   pointed at a 404 — `packages/core/README.md` now points at the shipped `.d.ts` + the embedding
   guide instead.
3. **`ATTEST_IT_HOME` documented.** Added a `### ATTEST_IT_HOME` section to
   `docs/configuration.md` (precedence: env var → `setAttestItHomeDir()` → default) and shorter
   pointers from `README.md`, `docs/getting-started.md`, `docs/embedding.md`,
   `AI_ASSISTANT_GUIDE.md`, `packages/attest-it/README.md`, and `packages/cli/README.md`. Added a
   `--help` mention in `packages/cli/src/index.ts`. **Updated post-rebase**: #129/#142 landed while
   this PR was open and fixed `ATTEST_IT_HOME` propagation into VaultKeeper's own config-dir
   resolution for the **`file`** key-storage backend specifically (verified live pre-fix-wording:
   an isolated `ATTEST_IT_HOME` with `--storage file` now writes the encrypted key under
   `<ATTEST_IT_HOME>/vaultkeeper/` and the real `~/.config/vaultkeeper/` gains no new file). Traced
   the actual code (`packages/core/src/key-provider/registry.ts`) to confirm this propagation is
   `file`-only: the `1password`, `macos-keychain`, and `yubikey` factories still call
   `BackendRegistry.create(...)` with no `configDir` argument, so those three backends remain
   unaffected by `ATTEST_IT_HOME`. Every mention across the docs now states this precisely
   (covered: `file`; not covered: `keychain`/`1password`/`yubikey`) rather than the blanket
   "not covered for any backend" wording this PR originally shipped with pre-rebase.
4. **Quick Start copy-paste runnable.** Reordered `README.md`'s Quick Start to
   `init` → define gate/suite (pointer to Configuration, per the issue's allowed alternative) →
   `team join --gates <gate>` → commit → `run --suite`, matching the ordering
   `docs/getting-started.md` already uses. Discovered and worked around a related footgun while
   verifying live: `team join --gates X` run *before* any gate exists silently authorizes nothing
   (no error, because `resolveGateAuthorization` short-circuits on an empty `gates` map) — this is
   exactly why gate/suite must come before `team join`. Added the `.gitignore` mention for
   `node_modules` before the first command. Also fixed a related copy-paste trap discovered while
   verifying: a fresh `npm install` leaves an untracked lockfile that the prior
   `git add .attest-it/`-only commit instruction missed, causing `run` to fail on "dirty working
   tree" — broadened both `README.md`'s and `docs/getting-started.md`'s commit instructions to
   `git add -A`.
5. **init "Next steps" 4→5 steps.** Updated `docs/getting-started.md`'s example to the real
   5-step output (adds "Bootstrap the trust anchor: attest-it init --root-signer ..."). **Updated
   post-rebase**: #138 landed while this PR was open and reordered/reworded the real output (the
   bootstrap step moved from position 4 to position 5, after the gate/suite-editing step, and
   gained a trailing "(safe to run at any time...)" note) — re-verified live against the rebased
   binary and updated the doc example + explanatory sentence to match exactly.
6. **`status` doc example + `--json` schema.** Synced `docs/getting-started.md`'s `status` example
   to the real table-based output (including the "Suite" column mislabel, left untouched and
   cross-referenced to #130 rather than "fixed" here). Added a `### status --json Output Schema`
   section to `docs/configuration.md` with a field table, and a short note on how `verify --json`'s
   shape differs (`SealVerificationResult[]`, nested `seal` object) — discovered while verifying,
   this wasn't previously documented anywhere.
7. **Public-key doc examples.** Replaced every `MCowBQYDK2VwAyEA...`-style SPKI-wrapped example
   with real raw-base64 Ed25519 public keys captured from a live `identity create`/`identity
   export` run (`tatJ4K7XDrycr83Tp7XZg2JLKbZb8Ty322jCijuA+Rc=` for alice,
   `ThmrTeY+vN6mT9ll6vtQoCnFXvP9iAH2js/VJywXGUQ=` for bob, plus two more for the
   work/personal local-identity example) across `README.md`, `docs/configuration.md`,
   `docs/getting-started.md`, and `AI_ASSISTANT_GUIDE.md`. No key-output code touched (per #129's
   scope).

## Non-goals honored

- Did not touch `init.ts`'s scaffold `sealsPath` default (#127), the renderer's "Suite"→"Gate"
  relabel (#130), or `.pem`/provider-banner key-output code (#129) — code in those files is
  untouched; only doc examples describing their *current* (pre-fix) output were synced.
- Did not touch verify/CI trust-boundary wording, or `docs/github-integration.md`'s CI workflow
  snippets beyond the `seals.json`→`seals/` path swaps, or `threat-model.md` — reserved for #140.
- Left `packages/cli/test/manual/scripts/README.md`'s `seals.json` mention alone: it documents a
  manual test script (`keychain-integration.ts`) that still writes to the legacy path directly in
  code, so "fixing" the doc without touching that test-script code would make the doc wrong
  instead of right. Flagging as a separate follow-up rather than fixing here (test-script code
  change, out of pure-doc scope).

## Quick Start verification (real surface)

Built the CLI (`pnpm nx run-many -t build`) and ran the *exact* rewritten `README.md` Quick Start
end to end against the built `attest-it` binary, in a fresh temp git repo with an isolated
`ATTEST_IT_HOME` and a `--storage file` identity (no mocks):

```
echo "node_modules/" >> .gitignore && git commit
npm install <locally-built attest-it package>
attest-it identity create --name "Alice Smith" --storage file --slug alice
attest-it init
# hand-edited .attest-it/policy.yaml / config.yaml to add a "my-gate"/"my-suite" pair,
# per the Quick Start's pointer to the Configuration section
attest-it team join --gates my-gate     # -> "Authorized for gates: my-gate"
git add -A && git commit -m "Configure attest-it"
attest-it run --suite my-suite --yes    # -> seal created, "git add .attest-it/seals/ && ..."
git add .attest-it/seals/ && git commit
attest-it verify                        # -> exit 0, "All gate seals valid"
```

All steps succeeded copy-paste-clean, re-verified end-to-end against the rebased+rebuilt binary
after resolving conflicts with #138/#140/#141/#142/#143/#144. Test identities/keys created during
verification were removed afterward (`identity remove`); nothing leaked to the real
`~/.config/vaultkeeper/` this run (confirming the `ATTEST_IT_HOME`/`file`-backend fix from #142).

## Build/lint/test status (post-rebase, tip `15d9c10`)

- `pnpm run build` — green (the one pre-existing `@attest-it/github-action:build` Nx flaky-task
  warning is a known flake unrelated to this change; passes on immediate retry).
- `pnpm run check` (lint + types + api-report across all packages) — green, 0 errors (only
  pre-existing `security/detect-object-injection` warnings, none in files this PR touches).
- `pnpm run test` — green, all test suites pass, 1,522/1,522 individual tests pass
  (62 github-action + 632 core + 828 cli), 0 failures.
- `pnpm exec prettier --check .` — green.
- `pnpm exec knip` — clean, no new unused exports.

## Changeset

None added — this is a docs-only change (plus one non-functional CLI `--help` text addition) with
no published-package behavior or public-type change, and no CI job in this repo requires a
changeset outside the release workflow.

Refs #132
