### PR TITLE
fix(core): make suites optional for gate-only and read-only flows

### DIFF
--- a/.changeset/suites-optional-gate-only.md
+++ b/.changeset/suites-optional-gate-only.md
@@ -1,0 +1,25 @@
+---
+'@attest-it/core': minor
+'attest-it': minor
+---
+
+Make suites optional for gate-only / read-only flows.
+
+The operational config (`.attest-it/config.yaml`) previously required at least
+one suite — a global precondition enforced at parse time. That rejected an empty
+`suites: {}`, which is exactly what `attest-it init` scaffolds, so gate-only
+"Direct Sealing" and read-only operations failed on a freshly-initialized repo:
+`listGates`, `fingerprint`, `verifyOne`, `verifyAll`, `seal`, `status`, and
+`verify` all returned a `malformed` failure ("At least one suite must be
+defined") even though they need only policy/gate data, never a suite.
+
+Suites are operational data, not a global precondition. An empty (or omitted)
+`suites` map is now a valid operational config, so those flows load cleanly
+against `suites: {}`. Suite-**dependent** operations are unchanged: `run --suite
+<name>` still validates that the named suite exists and fails cleanly when it
+does not — this relaxes the global precondition, not per-operation suite
+resolution.
+
+The relaxation is purely additive: every previously-valid config remains valid,
+and root-gate trust anchoring is unaffected (a gate-only config can still be
+root-anchored and still enforces the root gate on verify).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,13 +120,13 @@ recommended repository posture.
 
 ### Root Fields
 
-| Field        | Type   | Required | Default | Description                                       |
-| ------------ | ------ | -------- | ------- | ------------------------------------------------- |
-| `version`    | `1`    | Yes      | -       | Schema version (must be `1`)                      |
-| `minVersion` | string | No       | -       | Minimum attest-it version required (e.g. "0.9.0") |
-| `settings`   | object | No       | `{}`    | Operational settings                              |
-| `suites`     | object | Yes      | -       | Suite definitions (min 1 suite)                   |
-| `groups`     | object | No       | -       | Named groups of suites                            |
+| Field        | Type   | Required | Default | Description                                                      |
+| ------------ | ------ | -------- | ------- | ---------------------------------------------------------------- |
+| `version`    | `1`    | Yes      | -       | Schema version (must be `1`)                                     |
+| `minVersion` | string | No       | -       | Minimum attest-it version required (e.g. "0.9.0")                |
+| `settings`   | object | No       | `{}`    | Operational settings                                             |
+| `suites`     | object | No       | `{}`    | Suite definitions (may be empty for gate-only / read-only flows) |
+| `groups`     | object | No       | -       | Named groups of suites                                           |
 
 ---
 

--- a/packages/cli/test/integration/cli.integration.test.ts
+++ b/packages/cli/test/integration/cli.integration.test.ts
@@ -68,12 +68,13 @@ async function runCli(
   args: string[],
   cwd: string = FIXTURE_PATH,
   stdin?: string,
+  env?: Record<string, string>,
 ): Promise<RunResult> {
   return new Promise((resolve) => {
     // Run the built CLI
     const child = spawn('node', [CLI_PATH, ...args], {
       cwd,
-      env: { ...process.env, NO_COLOR: '1' }, // Disable colors for testing
+      env: { ...process.env, NO_COLOR: '1', ...env }, // Disable colors for testing
     })
 
     let stdout = ''
@@ -551,14 +552,13 @@ describe('CLI Integration Tests', () => {
      * "verified nothing"). See `verify.test.ts`/`status.test.ts` for the direct
      * unit-level exercise of that branch.
      *
-     * This scenario cannot be produced end-to-end through real config files: the
-     * operational schema requires at least one suite (`operational-graph.ts`), and
-     * every suite must reference an existing gate (cross-config validation), so a
-     * schema-valid config with suites always has at least one gate too. Emptying
-     * `suites` to force `gates: {}` instead hits that schema error first — which
-     * this test documents as the actual, correct behavior for that input.
+     * Since #137 made suites genuinely optional (an empty `suites: {}` is a valid
+     * operational config), this scenario IS now producible end-to-end: a config
+     * with `suites: {}` and `gates: {}` loads cleanly and reaches the zero-gates
+     * branch, exiting NO_WORK (2) — not CONFIG_ERROR — which is the correct
+     * verdict for a valid-but-empty configuration.
      */
-    it('an operational config with zero suites is rejected before the zero-gates check is reached', async () => {
+    it('a config with zero suites and zero gates reaches the zero-gates NO_WORK verdict', async () => {
       const policyPath = path.join(tempDir, '.attest-it', 'policy.yaml')
       const policyContent = await fs.promises.readFile(policyPath, 'utf8')
       const policy = yaml.parse(policyContent) as Record<string, unknown>
@@ -574,8 +574,87 @@ describe('CLI Integration Tests', () => {
       await runCommand('git add . && git commit -m "clear gates and suites"', tempDir)
 
       const result = await runCli(['verify'], tempDir)
-      expect(result.exitCode).toBe(3) // CONFIG_ERROR: operational schema rejects zero suites
-      expect(result.stderr).toContain('At least one suite must be defined')
+      expect(result.exitCode).toBe(2) // NO_WORK: valid config, but zero gates to verify
+      expect(result.stderr).toContain('No gates defined in configuration')
+    })
+  })
+
+  /**
+   * Issue #137: gate-only / read-only commands must succeed against an
+   * operational config with `suites: {}` — exactly what `init` scaffolds. The
+   * repo has a valid gate (`example-gate`) but no suites; pre-fix, loading such a
+   * config threw "At least one suite must be defined" and every command exited 3
+   * (CONFIG_ERROR). These tests drive the REAL built CLI binary and assert exit 0.
+   */
+  describe('suites optional for gate-only / read-only CLI flows (#137)', () => {
+    /** Rewrite the operational config to the empty-suites shape `init` scaffolds. */
+    async function writeEmptySuitesConfig(): Promise<void> {
+      const configPath = path.join(tempDir, '.attest-it', 'config.yaml')
+      const configContent = await fs.promises.readFile(configPath, 'utf8')
+      const config = yaml.parse(configContent) as Record<string, unknown>
+      config.suites = {}
+      await fs.promises.writeFile(configPath, yaml.stringify(config), 'utf8')
+      await runCommand('git add . && git commit -m "empty suites"', tempDir)
+    }
+
+    /**
+     * Point the CLI subprocess at a temp attest-it home holding a local identity
+     * (`test-user`) whose keypair matches the gate's authorized signer, so the
+     * real `seal` command can sign end-to-end.
+     */
+    async function setupLocalIdentity(): Promise<string> {
+      const home = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-home-'))
+      const keyPath = path.join(home, 'test-user.pem')
+      await fs.promises.writeFile(keyPath, privateKeyPem, 'utf8')
+      const localConfig = {
+        version: 2,
+        activeIdentity: 'test-user',
+        identities: {
+          'test-user': {
+            name: 'Test User',
+            publicKey: publicKeyBase64,
+            privateKey: { type: 'filesystem', path: keyPath },
+          },
+        },
+      }
+      await fs.promises.writeFile(
+        path.join(home, 'config.yaml'),
+        yaml.stringify(localConfig),
+        'utf8',
+      )
+      return home
+    }
+
+    it('status exits 0 on a config with an empty suites map', async () => {
+      await writeEmptySuitesConfig()
+      const result = await runCli(['status'], tempDir)
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr).not.toContain('At least one suite')
+    })
+
+    it('seal <gate> exits 0 on a config with an empty suites map', async () => {
+      await writeEmptySuitesConfig()
+      const home = await setupLocalIdentity()
+      try {
+        const result = await runCli(['seal', 'example-gate'], tempDir, undefined, {
+          ATTEST_IT_HOME: home,
+        })
+        expect(result.exitCode).toBe(0)
+        expect(result.stderr).not.toContain('At least one suite')
+      } finally {
+        await fs.promises.rm(home, { recursive: true, force: true })
+      }
+    })
+
+    it('run --suite <name> still fails cleanly for an undefined suite (per-operation resolution intact)', async () => {
+      // Relaxing the GLOBAL suite precondition must NOT relax per-operation suite
+      // resolution: a suite-dependent command still validates the named suite
+      // exists. With `suites: {}`, `run --suite example` must fail — cleanly, with
+      // a "not found" message — not silently succeed.
+      await writeEmptySuitesConfig()
+      const result = await runCli(['run', '--suite', 'example'], tempDir)
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('not found in config')
     })
   })
 

--- a/packages/core/api-report/core.api.md
+++ b/packages/core/api-report/core.api.md
@@ -617,7 +617,7 @@ export const operationalSchema: z.ZodObject<{
             type: string;
         } | undefined;
     }>>;
-    suites: z.ZodEffects<z.ZodRecord<z.ZodString, z.ZodObject<{
+    suites: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodObject<{
         command: z.ZodOptional<z.ZodString>;
         depends_on: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
         description: z.ZodOptional<z.ZodString>;
@@ -641,23 +641,7 @@ export const operationalSchema: z.ZodObject<{
         interactive?: boolean | undefined;
         invalidates?: string[] | undefined;
         timeout?: string | undefined;
-    }>>, Record<string, {
-        command?: string | undefined;
-        depends_on?: string[] | undefined;
-        description?: string | undefined;
-        gate: string;
-        interactive?: boolean | undefined;
-        invalidates?: string[] | undefined;
-        timeout?: string | undefined;
-    }>, Record<string, {
-        command?: string | undefined;
-        depends_on?: string[] | undefined;
-        description?: string | undefined;
-        gate: string;
-        interactive?: boolean | undefined;
-        invalidates?: string[] | undefined;
-        timeout?: string | undefined;
-    }>>;
+    }>>>;
     version: z.ZodEffects<z.ZodUnion<[z.ZodLiteral<1>, z.ZodLiteral<string>]>, 1, 1 | string>;
 }, "strict", z.ZodTypeAny, {
     groups?: Record<string, string[]> | undefined;
@@ -699,7 +683,7 @@ export const operationalSchema: z.ZodObject<{
             type: string;
         } | undefined;
     } | undefined;
-    suites: Record<string, {
+    suites?: Record<string, {
         command?: string | undefined;
         depends_on?: string[] | undefined;
         description?: string | undefined;
@@ -707,7 +691,7 @@ export const operationalSchema: z.ZodObject<{
         interactive?: boolean | undefined;
         invalidates?: string[] | undefined;
         timeout?: string | undefined;
-    }>;
+    }> | undefined;
     version: 1 | string;
 }>;
 

--- a/packages/core/src/config/migrations/operational-graph.ts
+++ b/packages/core/src/config/migrations/operational-graph.ts
@@ -70,11 +70,15 @@ const operationalSchemaV1 = z
     version: versionSchema(1),
     minVersion: semverSchema.optional(),
     settings: operationalSettingsSchemaV1.default({}),
-    suites: z
-      .record(z.string(), suiteSchemaV1)
-      .refine((suites) => Object.keys(suites).length >= 1, {
-        message: 'At least one suite must be defined',
-      }),
+    // Suites are OPERATIONAL data, not a global precondition. An empty (or
+    // omitted) `suites` map is a valid operational config: gate-only "Direct
+    // Sealing" and read-only flows (listGates/fingerprint/verifyOne/verifyAll/
+    // seal/status/verify) need only policy/gate data and must load cleanly
+    // against `suites: {}` — exactly what `init` scaffolds. Suite-DEPENDENT
+    // operations (`run --suite <name>`) still validate that the named suite
+    // exists at resolution time, so the global ">=1 suite" precondition that
+    // used to be enforced here was the wrong layer (issue #137).
+    suites: z.record(z.string(), suiteSchemaV1).default({}),
     groups: z
       .record(z.string(), z.array(z.string().min(1, 'Suite name in group cannot be empty')))
       .optional(),

--- a/packages/core/src/config/migrations/unified-to-split.ts
+++ b/packages/core/src/config/migrations/unified-to-split.ts
@@ -73,11 +73,10 @@ const unifiedConfigSchema = z
     settings: unifiedSettingsSchema.default({}),
     team: z.record(z.string(), teamMemberSchema).optional(),
     gates: z.record(z.string(), gateSchema).optional(),
-    suites: z
-      .record(z.string(), unifiedSuiteSchema)
-      .refine((suites) => Object.keys(suites).length >= 1, {
-        message: 'At least one suite must be defined',
-      }),
+    // An empty (or omitted) `suites` map is valid: suites are operational data,
+    // not a global precondition (issue #137). A unified config that defines only
+    // gates migrates cleanly to a split pair with no suites.
+    suites: z.record(z.string(), unifiedSuiteSchema).default({}),
     groups: z.record(z.string(), z.array(z.string().min(1))).optional(),
   })
   .strict()

--- a/packages/core/test/api/helpers.ts
+++ b/packages/core/test/api/helpers.ts
@@ -63,6 +63,13 @@ export interface CreateTestProjectOptions {
    * of repo-relative path → content. Used to populate a pattern gate's matches.
    */
   files?: Record<string, string>
+  /**
+   * Scaffold the operational config with an empty `suites: {}` map (the shape
+   * `init` writes). Exercises the gate-only / read-only flows that must load
+   * cleanly without any suite defined (issue #137). Defaults to `false` (a
+   * single `build` suite referencing the gate).
+   */
+  emptySuites?: boolean
 }
 
 /**
@@ -117,7 +124,7 @@ export function createTestProject(options: CreateTestProjectOptions = {}): TestP
   }
   const operational = {
     version: 1,
-    suites: { build: { gate: gateId } },
+    suites: options.emptySuites ? {} : { build: { gate: gateId } },
   }
   mkdirSync(join(baseDir, '.attest-it'), { recursive: true })
   writeFileSync(join(baseDir, '.attest-it', 'policy.yaml'), stringifyYaml(policy), 'utf8')

--- a/packages/core/test/api/operations.test.ts
+++ b/packages/core/test/api/operations.test.ts
@@ -324,3 +324,64 @@ describe('failure taxonomy', () => {
     expect(one.schemaVersion).toBe(API_SCHEMA_VERSION)
   })
 })
+
+/**
+ * Issue #137: suites are OPTIONAL for gate-only / read-only flows.
+ *
+ * A config with `suites: {}` (exactly what `init` scaffolds) supplies all the
+ * policy/gate data these operations need. Pre-fix, loading such a config failed
+ * with `malformed` + "At least one suite must be defined", so every one of these
+ * calls returned that failure instead of operating on the perfectly-valid gate.
+ * Each assertion below FAILS against pre-fix code.
+ */
+describe('suites optional for gate-only / read-only flows (#137)', () => {
+  it('listGates succeeds against a config with an empty suites map', async () => {
+    project = createTestProject({ emptySuites: true })
+    const result = await listGates({ baseDir: project.baseDir })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // The gate is enumerated purely from policy data — no suite required.
+    expect(result.gates.map((g) => g.gateId)).toEqual(['tools'])
+  })
+
+  it('seal succeeds against a config with an empty suites map', async () => {
+    project = createTestProject({ emptySuites: true })
+    const result = await seal(
+      project.gatedFile,
+      { identity: 'alice' },
+      { baseDir: project.baseDir },
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.gateId).toBe('tools')
+    expect(result.sealedBy).toBe('alice')
+  })
+
+  it('verifyOne succeeds against a config with an empty suites map after sealing', async () => {
+    project = createTestProject({ emptySuites: true })
+    const sealed = await seal(
+      project.gatedFile,
+      { identity: 'alice' },
+      { baseDir: project.baseDir },
+    )
+    expect(sealed.ok).toBe(true)
+    const result = await verifyOne(project.gatedFile, { baseDir: project.baseDir })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.gateId).toBe('tools')
+    expect(result.path).toBe(project.gatedFile)
+  })
+
+  it('status and verifyAll succeed against a config with an empty suites map', async () => {
+    project = createTestProject({ emptySuites: true })
+    await seal(project.gatedFile, { identity: 'alice' }, { baseDir: project.baseDir })
+
+    const statusResult = await status(undefined, { baseDir: project.baseDir })
+    expect(statusResult.ok).toBe(true)
+
+    const allResult = await verifyAll({}, { baseDir: project.baseDir })
+    expect(allResult.ok).toBe(true)
+    if (!allResult.ok) return
+    expect(allResult.results[0]?.ok).toBe(true)
+  })
+})

--- a/packages/core/test/config/operational-schema.test.ts
+++ b/packages/core/test/config/operational-schema.test.ts
@@ -357,21 +357,26 @@ suites:
         expect(() => parseOperationalContent(yaml, 'yaml')).toThrow('version')
       })
 
-      it('should reject config with no suites', () => {
+      // Issue #137: suites are OPTIONAL operational data, not a global
+      // precondition. An empty `suites: {}` — exactly what `init` scaffolds — is
+      // a valid operational config so gate-only / read-only flows load cleanly.
+      it('should accept config with an empty suites map', () => {
         const yaml = `
 version: 1
 suites: {}
 `
-        expect(() => parseOperationalContent(yaml, 'yaml')).toThrow(OperationalValidationError)
-        expect(() => parseOperationalContent(yaml, 'yaml')).toThrow('At least one suite')
+        const result = parseOperationalContent(yaml, 'yaml')
+        expect(result.suites).toEqual({})
       })
 
-      it('should reject config with missing suites', () => {
+      // Issue #137: an omitted `suites` key is equivalent to an empty map and
+      // must also be accepted (defaults to {}).
+      it('should accept config with missing suites (defaults to empty)', () => {
         const yaml = `
 version: 1
 `
-        expect(() => parseOperationalContent(yaml, 'yaml')).toThrow(OperationalValidationError)
-        expect(() => parseOperationalContent(yaml, 'yaml')).toThrow('suites')
+        const result = parseOperationalContent(yaml, 'yaml')
+        expect(result.suites).toEqual({})
       })
 
       it('should reject suite without gate', () => {
@@ -699,9 +704,13 @@ suites:
 
   describe('OperationalValidationError', () => {
     it('should include Zod issues in the error', () => {
+      // A suite missing its required `gate` is an invalid operational config
+      // (empty `suites: {}` is now valid — issue #137).
       const yaml = `
 version: 1
-suites: {}
+suites:
+  unit:
+    command: pnpm test
 `
       try {
         parseOperationalContent(yaml, 'yaml')

--- a/packages/core/test/integration/embedder-root-gate.test.ts
+++ b/packages/core/test/integration/embedder-root-gate.test.ts
@@ -77,15 +77,26 @@ afterEach(() => {
 /**
  * Scaffold a project on disk with the given policy, operational config, and
  * seals, and return the base directory the embeddable API is pointed at.
+ *
+ * `emptySuites` writes `suites: {}` (the gate-only shape `init` scaffolds) to
+ * prove that relaxing the suite precondition (issue #137) does not bypass
+ * root-gate enforcement for gate-only configs.
  */
-function scaffold(policy: Record<string, unknown>, seals: SealsFile): Fixture {
+function scaffold(
+  policy: Record<string, unknown>,
+  seals: SealsFile,
+  options: { emptySuites?: boolean } = {},
+): Fixture {
   const baseDir = mkdtempSync(join(tmpdir(), 'attest-embedder-rootgate-'))
   dirsToClean.push(baseDir)
   mkdirSync(join(baseDir, '.attest-it'), { recursive: true })
   mkdirSync(join(baseDir, 'src', 'lib'), { recursive: true })
   writeFileSync(join(baseDir, 'src', 'lib', 'tool.ts'), 'export const tool = () => 42\n', 'utf8')
 
-  const operational = { version: 1, suites: { build: { gate: GATE_ID } } }
+  const operational = {
+    version: 1,
+    suites: options.emptySuites ? {} : { build: { gate: GATE_ID } },
+  }
   writeFileSync(join(baseDir, POLICY_REL), stringifyYaml(policy), 'utf8')
   writeFileSync(join(baseDir, '.attest-it', 'config.yaml'), stringifyYaml(operational), 'utf8')
   writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
@@ -365,6 +376,72 @@ describe('embeddable API root-gate enforcement (#131)', () => {
     // No rootGate → no trust anchor to check → verifies unchanged, and never
     // reports untrusted-config.
     const result = await verifyAll({}, { baseDir })
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.results[0]?.ok).toBe(true)
+  })
+
+  /**
+   * Interaction guard between #137 (suites optional) and #131/#139 (root-gate
+   * enforcement): a gate-only config (`suites: {}`) can still be root-anchored,
+   * and relaxing the suite precondition must NOT let such a config skip the
+   * root-gate pre-step. A tampered, self-sealed gate-only policy must still be
+   * REJECTED, and a legitimately-anchored gate-only policy must still verify.
+   */
+  it('(#137) still ENFORCES the root gate for a gate-only (empty-suites) config: tampered anchor is rejected', async () => {
+    const alice = generateEd25519KeyPair()
+    const mallory = generateEd25519KeyPair()
+
+    // Working tree: mallory self-added to team + root signers, self-sealed —
+    // exactly the (a) attack, but on a config with NO suites at all.
+    const policy = anchoredPolicy(
+      {
+        alice: { name: 'Alice Developer', publicKey: alice.publicKey },
+        mallory: { name: 'Mallory', publicKey: mallory.publicKey },
+      },
+      ['alice', 'mallory'],
+    )
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} }, { emptySuites: true })
+    const seals: SealsFile = {
+      version: 1,
+      seals: {
+        [ROOT_GATE_ID]: rootSealOver(baseDir, 'mallory', mallory),
+        [GATE_ID]: gateSealOver(baseDir, 'alice', alice),
+      },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    const trustedConfig = trustedBaseConfig(alice)
+
+    const all = await verifyAll({}, { baseDir, trustedConfig })
+    expect(all.ok).toBe(false)
+    if (all.ok) return
+    expect(all.failureClass).toBe('untrusted-config')
+
+    const one = await verifyOne('src/lib/tool.ts', { baseDir, trustedConfig })
+    expect(one.ok).toBe(false)
+    if (one.ok) return
+    expect(one.failureClass).toBe('untrusted-config')
+  })
+
+  it('(#137) VERIFIES a legitimately-anchored gate-only (empty-suites) config against the trusted root', async () => {
+    const alice = generateEd25519KeyPair()
+    const policy = anchoredPolicy(
+      { alice: { name: 'Alice Developer', publicKey: alice.publicKey } },
+      ['alice'],
+    )
+    const { baseDir } = scaffold(policy, { version: 1, seals: {} }, { emptySuites: true })
+    const seals: SealsFile = {
+      version: 1,
+      seals: {
+        [ROOT_GATE_ID]: rootSealOver(baseDir, 'alice', alice),
+        [GATE_ID]: gateSealOver(baseDir, 'alice', alice),
+      },
+    }
+    writeFileSync(join(baseDir, SEALS_REL), JSON.stringify(seals, null, 2), 'utf8')
+
+    const trustedConfig = trustedBaseConfig(alice)
+    const result = await verifyAll({}, { baseDir, trustedConfig })
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.results[0]?.ok).toBe(true)

--- a/packages/github-action/dist/index.cjs
+++ b/packages/github-action/dist/index.cjs
@@ -46460,9 +46460,15 @@ var operationalSchemaV1 = external_exports.object({
   version: versionSchema3(1),
   minVersion: semverSchema.optional(),
   settings: operationalSettingsSchemaV1.default({}),
-  suites: external_exports.record(external_exports.string(), suiteSchemaV1).refine((suites) => Object.keys(suites).length >= 1, {
-    message: "At least one suite must be defined"
-  }),
+  // Suites are OPERATIONAL data, not a global precondition. An empty (or
+  // omitted) `suites` map is a valid operational config: gate-only "Direct
+  // Sealing" and read-only flows (listGates/fingerprint/verifyOne/verifyAll/
+  // seal/status/verify) need only policy/gate data and must load cleanly
+  // against `suites: {}` — exactly what `init` scaffolds. Suite-DEPENDENT
+  // operations (`run --suite <name>`) still validate that the named suite
+  // exists at resolution time, so the global ">=1 suite" precondition that
+  // used to be enforced here was the wrong layer (issue #137).
+  suites: external_exports.record(external_exports.string(), suiteSchemaV1).default({}),
   groups: external_exports.record(external_exports.string(), external_exports.array(external_exports.string().min(1, "Suite name in group cannot be empty"))).optional()
 }).strict();
 var schemaV14 = fromZod("1", operationalSchemaV1);
@@ -46495,9 +46501,10 @@ var unifiedConfigSchema = external_exports.object({
   settings: unifiedSettingsSchema.default({}),
   team: external_exports.record(external_exports.string(), teamMemberSchema).optional(),
   gates: external_exports.record(external_exports.string(), gateSchema).optional(),
-  suites: external_exports.record(external_exports.string(), unifiedSuiteSchema).refine((suites) => Object.keys(suites).length >= 1, {
-    message: "At least one suite must be defined"
-  }),
+  // An empty (or omitted) `suites` map is valid: suites are operational data,
+  // not a global precondition (issue #137). A unified config that defines only
+  // gates migrates cleanly to a split pair with no suites.
+  suites: external_exports.record(external_exports.string(), unifiedSuiteSchema).default({}),
   groups: external_exports.record(external_exports.string(), external_exports.array(external_exports.string().min(1))).optional()
 }).strict();
 var policySchema = policySchemaV1;

--- a/packages/github-action/dist/index.js
+++ b/packages/github-action/dist/index.js
@@ -46463,9 +46463,15 @@ var operationalSchemaV1 = external_exports.object({
   version: versionSchema3(1),
   minVersion: semverSchema.optional(),
   settings: operationalSettingsSchemaV1.default({}),
-  suites: external_exports.record(external_exports.string(), suiteSchemaV1).refine((suites) => Object.keys(suites).length >= 1, {
-    message: "At least one suite must be defined"
-  }),
+  // Suites are OPERATIONAL data, not a global precondition. An empty (or
+  // omitted) `suites` map is a valid operational config: gate-only "Direct
+  // Sealing" and read-only flows (listGates/fingerprint/verifyOne/verifyAll/
+  // seal/status/verify) need only policy/gate data and must load cleanly
+  // against `suites: {}` — exactly what `init` scaffolds. Suite-DEPENDENT
+  // operations (`run --suite <name>`) still validate that the named suite
+  // exists at resolution time, so the global ">=1 suite" precondition that
+  // used to be enforced here was the wrong layer (issue #137).
+  suites: external_exports.record(external_exports.string(), suiteSchemaV1).default({}),
   groups: external_exports.record(external_exports.string(), external_exports.array(external_exports.string().min(1, "Suite name in group cannot be empty"))).optional()
 }).strict();
 var schemaV14 = fromZod("1", operationalSchemaV1);
@@ -46498,9 +46504,10 @@ var unifiedConfigSchema = external_exports.object({
   settings: unifiedSettingsSchema.default({}),
   team: external_exports.record(external_exports.string(), teamMemberSchema).optional(),
   gates: external_exports.record(external_exports.string(), gateSchema).optional(),
-  suites: external_exports.record(external_exports.string(), unifiedSuiteSchema).refine((suites) => Object.keys(suites).length >= 1, {
-    message: "At least one suite must be defined"
-  }),
+  // An empty (or omitted) `suites` map is valid: suites are operational data,
+  // not a global precondition (issue #137). A unified config that defines only
+  // gates migrates cleanly to a split pair with no suites.
+  suites: external_exports.record(external_exports.string(), unifiedSuiteSchema).default({}),
   groups: external_exports.record(external_exports.string(), external_exports.array(external_exports.string().min(1))).optional()
 }).strict();
 var policySchema = policySchemaV1;

--- a/schemas/v1/config.schema.json
+++ b/schemas/v1/config.schema.json
@@ -74,27 +74,6 @@
               "description": {
                 "type": "string"
               },
-              "packages": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              },
-              "files": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              },
-              "ignore": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              },
               "command": {
                 "type": "string"
               },
@@ -119,8 +98,10 @@
                 }
               }
             },
+            "required": ["gate"],
             "additionalProperties": false
-          }
+          },
+          "default": {}
         },
         "groups": {
           "type": "object",
@@ -133,7 +114,7 @@
           }
         }
       },
-      "required": ["version", "suites"],
+      "required": ["version"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Summary

`config.yaml` required **≥1 suite** even for gate-only "Direct Sealing" and read-only embedding operations. A global precondition (`suites.length >= 1`, refined in the operational Zod schema) ran at parse time, so loading a config with `suites: {}` — exactly what `attest-it init` scaffolds — threw `malformed` "At least one suite must be defined". Every operation that only needs policy/gate data failed on a freshly-initialized repo: `listGates`, `fingerprint`, `verifyOne`, `verifyAll`, `seal`, `status`, and `verify`.

This splits **policy validity** from **operational (suite) validity**: an empty (or omitted) `suites` map is now a valid operational config, so gate-only / read-only flows load cleanly. Suite-**dependent** operations are unchanged.

## How policy vs operational validity was split

- The `>=1 suite` rule was a **global precondition** enforced in the operational schema Zod refinement (`packages/core/src/config/migrations/operational-graph.ts`, plus the retired-unified migration schema in `unified-to-split.ts`). That is the wrong layer — it gates *all* config loading, including policy-only reads.
- Removed that refinement and made `suites` genuinely optional: `z.record(...).default({})`. Empty or absent → `{}`. Every previously-valid config remains valid (purely additive relaxation).
- **Per-operation suite resolution is untouched.** `run --suite <name>` still validates the named suite exists at resolution time (`packages/cli/src/commands/run.ts` — "Suite … not found in config") and fails cleanly. This change relaxes the *global* precondition only.

## Coordination with #139 (root-gate enforcement)

#139's `enforceRootGate` pre-step in `api/operations.ts` is **intact and unmodified**. The relaxation is confined to config-schema parsing; it does not touch the verify pre-step. A gate-only config (`suites: {}`) can still be root-anchored, and `verifyOne`/`verifyAll` still run the mandatory root-gate pre-step against the trusted anchor before evaluating any gate. New tests below prove a tampered, self-sealed **gate-only** policy is still rejected `untrusted-config`, and a legitimately-anchored gate-only policy still verifies.

## Acceptance criteria → tests

- **Criterion 1** (suites optional for gate-only/read-only flows) — covered by `suites optional for gate-only / read-only flows (#137)` in `packages/core/test/api/operations.test.ts`: `listGates` / `seal` / `verifyOne` / `status` / `verifyAll` against `{ baseDir }` with `suites: {}` all return `ok: true`.
- **Criterion 2** (suite-dependent resolution intact) — covered by `run --suite <name> still fails cleanly for an undefined suite` in `packages/cli/test/integration/cli.integration.test.ts`.
- **Criterion 3a** (embeddable API regression) — the operations.test.ts block above; fails against pre-fix code.
- **Criterion 3b** (CLI/UAT regression) — `status exits 0` and `seal <gate> exits 0` (real built-binary subprocess against init's `suites: {}` scaffold) in `cli.integration.test.ts`; fail against pre-fix code.
- **#139 interaction guard** — `(#137) still ENFORCES the root gate for a gate-only (empty-suites) config` and `(#137) VERIFIES a legitimately-anchored gate-only config` in `packages/core/test/integration/embedder-root-gate.test.ts`.
- **Schema-level** — `should accept config with an empty suites map` / `… missing suites (defaults to empty)` in `packages/core/test/config/operational-schema.test.ts`.

All new regression tests were confirmed to **fail against pre-fix code** (schema, embeddable API, and root-gate interaction layers) and pass with the fix.

## Behavior change

The prior #81 regression test (which documented `suites:{}`+`gates:{}` as rejected at parse time) is updated: that scenario now loads cleanly and reaches the zero-gates branch, exiting `NO_WORK` (2) — the correct verdict for a valid-but-empty config — instead of `CONFIG_ERROR` (3).

## Docs / generated artifacts

- `docs/configuration.md`: `suites` row updated from Required/"min 1 suite" to Optional (default `{}`).
- `schemas/v1/config.schema.json` regenerated: `suites` dropped from `required`, `default: {}` added. Regeneration also corrected pre-existing staleness (removed the retired `packages`/`files`/`ignore` suite fields and added `required: ["gate"]` on suites) so the generated schema matches its Zod source.
- `packages/core/api-report/core.api.md` regenerated: `operationalSchema.suites` shifts `ZodEffects` → `ZodDefault` (input type now optional; the inferred `OperationalConfig` output type is unchanged — `suites` stays a non-optional record).
- `packages/github-action/dist/*` rebuilt (the action bundles core; kept in sync as prior core PRs do).

## Changeset

`@attest-it/core` + `attest-it` (umbrella) **minor**.

Refs #137
