### PR TITLE
feat(cli): wire kind:pattern gates through seal/verify/status/run

### DIFF
--- a/.changeset/cli-pattern-gate-wiring.md
+++ b/.changeset/cli-pattern-gate-wiring.md
@@ -1,0 +1,15 @@
+---
+'@attest-it/cli': minor
+'attest-it': minor
+---
+
+Wire `kind: pattern` gates through the full CLI surface (`seal`, `verify`, `status`, `run`).
+
+Per-file pattern gates already existed in `@attest-it/core` (per-file fingerprinting and per-file seal storage), but the CLI never called that path — a gate declared `kind: pattern` silently degraded to single-gate behavior (one combined fingerprint, one seal per gate, no per-file rows or per-file invalidation). The CLI now honors pattern gates end-to-end:
+
+- **`seal`** fingerprints and seals **each matched file independently**, writing one standalone seal per file at `.attest-it/seals/<gate>/<artifact>/<signer>.seal` through the low-level per-file writer (never the aggregate writer, which would prune the sibling per-file seals). A file that already has a valid per-file seal is skipped unless `--force`.
+- **`status`** and **`verify`** report **one row per matched file** (deterministically ordered by path) in both the table and `--json`. A newly-added matching file shows up as unsealed with no `policy.yaml` edit; changing one byte of a sealed file flips only that file to invalid while its siblings stay valid.
+- **`run --suite`** over a pattern gate seals each matched file independently, consistent with `seal`.
+- Single (non-pattern) gates are completely unaffected — the change is additive.
+
+The `status`/`verify` table's label column, which shows gate-level (or per-file) data, is relabeled from `Suite` to `Gate`.

--- a/packages/cli/src/commands/run-utils.ts
+++ b/packages/cli/src/commands/run-utils.ts
@@ -7,8 +7,15 @@
  * @packageDocumentation
  */
 
-import type { AttestItConfig, VerificationState, SealsFile } from '@attest-it/core'
+import type {
+  AttestItConfig,
+  VerificationState,
+  SealsFile,
+  SealVerificationResult,
+  GateConfig,
+} from '@attest-it/core'
 import { computeFingerprint, readSealsSync, verifyGateSeal } from '@attest-it/core'
+import { isPatternGate, verifyPatternGateSync } from '../utils/pattern-gate.js'
 
 /**
  * Information about a suite's current status.
@@ -71,6 +78,15 @@ export async function getAllSuiteStatuses(config: AttestItConfig): Promise<Suite
       continue
     }
 
+    // A pattern gate is evaluated per matched file; roll the per-file results up
+    // into a single suite status (VALID only when every matched file is valid) so
+    // `run --all`/interactive reflect real per-file state rather than the old
+    // single-combined-fingerprint verdict (issue #130).
+    if (isPatternGate(gateConfig)) {
+      results.push(rollUpPatternSuite(suiteName, config, suiteConfig.gate, gateConfig))
+      continue
+    }
+
     // Compute current fingerprint
     const fingerprintResult = await computeFingerprint({
       paths,
@@ -104,6 +120,52 @@ export async function getAllSuiteStatuses(config: AttestItConfig): Promise<Suite
   }
 
   return results
+}
+
+/**
+ * Roll a pattern gate's independent per-file verification results into one
+ * {@link SuiteStatus}. The suite is `VALID` only when it matched at least one
+ * file and every matched file verifies `VALID`; otherwise the first non-valid
+ * file drives the reported state/reason (e.g. a newly-added unsealed file
+ * surfaces as `MISSING`, a modified sealed file as `FINGERPRINT_MISMATCH`).
+ */
+function rollUpPatternSuite(
+  suiteName: string,
+  config: AttestItConfig,
+  gateId: string,
+  gateConfig: GateConfig,
+): SuiteStatus {
+  const perFile = verifyPatternGateSync(config, gateId, gateConfig, process.cwd())
+
+  const [first] = perFile
+  if (!first) {
+    return {
+      name: suiteName,
+      status: 'MISSING',
+      reason: 'Pattern gate matched no files',
+      currentFingerprint: '',
+    }
+  }
+
+  const firstInvalid = perFile.find((f) => f.result.state !== 'VALID')
+  const representative: SealVerificationResult = (firstInvalid ?? first).result
+  const fileCount = perFile.length
+
+  if (!firstInvalid) {
+    return {
+      name: suiteName,
+      status: 'VALID',
+      reason: `All ${String(fileCount)} matched file(s) sealed`,
+      currentFingerprint: first.fingerprint,
+    }
+  }
+
+  return {
+    name: suiteName,
+    status: representative.state,
+    reason: `${representative.artifactPath ?? ''}: ${representative.message ?? formatStatusReason(representative.state)}`,
+    currentFingerprint: first.fingerprint,
+  }
 }
 
 /**

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -16,9 +16,19 @@ import {
   createSealWithProvider,
   readSealsSync,
   writeSealsSync,
+  writeSealFileSync,
+  resolveSealsRoot,
+  verifyPatternArtifactSeal,
   type AttestItConfig,
+  type GateConfig,
   type Identity,
+  type Seal,
 } from '@attest-it/core'
+import {
+  isPatternGate,
+  computePatternFingerprintsSync,
+  readPatternSealsByArtifactSync,
+} from '../utils/pattern-gate.js'
 import { log, success, error, warn, verbose } from '../utils/output.js'
 import { confirmAction, isInteractiveTTY, handlePromptableError } from '../utils/prompts.js'
 import { resolveKeyPassphrase } from '../utils/passphrase.js'
@@ -534,6 +544,15 @@ async function promptForSeal(
 
     // eslint-disable-next-line security/detect-object-injection
     const gate = config.gates[gateId]
+    const identitySlug = localConfig.activeIdentity
+
+    // A pattern gate seals each matched file independently (one per-file seal
+    // via the low-level writer), consistent with `attest-it seal`. Without this
+    // branch a suite over a `kind: pattern` gate silently produced a single
+    // combined seal (issue #130).
+    if (isPatternGate(gate)) {
+      return await sealPatternGateForRun(gateId, gate, config, identity, identitySlug)
+    }
 
     // Compute fingerprint for the gate
     const gateFingerprint = computeFingerprintSync({
@@ -550,7 +569,6 @@ async function promptForSeal(
     // it is passphrase-encrypted (e.g. `identity create --passphrase-stdin`),
     // resolves the passphrase from the environment, a prompt, or fails fast
     // (see issue #80).
-    const identitySlug = localConfig.activeIdentity
     const seal = await createSealWithProvider({
       gateId,
       fingerprint: gateFingerprint.fingerprint,
@@ -583,6 +601,78 @@ async function promptForSeal(
     }
     return 'not-attempted'
   }
+}
+
+/**
+ * Seal every matched file of a **pattern gate** (`kind: pattern`) independently,
+ * mirroring `attest-it seal`'s per-file path: each file is fingerprinted on its
+ * own and written as a standalone `.seal` via the low-level
+ * {@link writeSealFileSync} (never the aggregate writer, which would prune the
+ * siblings). Files that already carry a valid per-file seal are left untouched.
+ *
+ * @returns `'sealed'` when at least one file was (re)sealed or all files were
+ *   already valid, `'not-attempted'` when the gate matched no files.
+ */
+async function sealPatternGateForRun(
+  gateId: string,
+  gate: GateConfig,
+  config: AttestItConfig,
+  identity: Identity,
+  identitySlug: string,
+): Promise<SealAttemptOutcome> {
+  const projectRoot = process.cwd()
+  const perFile = computePatternFingerprintsSync(gate, projectRoot)
+  if (perFile.length === 0) {
+    warn(`Pattern gate '${gateId}' matched no files - no seal created`)
+    return 'not-attempted'
+  }
+
+  const existingSeals = readPatternSealsByArtifactSync(
+    projectRoot,
+    config.settings.sealsPath,
+    gateId,
+  )
+  const sealsRoot = resolveSealsRoot(projectRoot, config.settings.sealsPath)
+
+  const keyProvider = createKeyProviderFromIdentity(identity)
+  const keyRef = getKeyRefFromIdentity(identity)
+
+  let sealedCount = 0
+  for (const { path: filePath, fingerprint } of perFile) {
+    const existing = existingSeals.get(filePath)
+    if (existing) {
+      const verification = verifyPatternArtifactSeal(
+        config,
+        gateId,
+        filePath,
+        existing,
+        fingerprint,
+        gate.maxAge,
+      )
+      if (verification.state === 'VALID') {
+        continue
+      }
+    }
+
+    const seal = await createSealWithProvider({
+      gateId,
+      fingerprint,
+      sealedBy: identitySlug,
+      keyProvider,
+      keyRef,
+      resolvePassphrase: resolveKeyPassphrase,
+    })
+    const perFileSeal: Seal = { ...seal, artifactPath: filePath }
+    writeSealFileSync(sealsRoot, perFileSeal)
+    sealedCount++
+    log(`  Sealed ${gateId} file: ${filePath}`)
+  }
+
+  success(
+    `Seal(s) created for pattern gate '${gateId}' (${String(sealedCount)} of ${String(perFile.length)} file(s) resealed)`,
+  )
+  log(`  Sealed by: ${identitySlug} (${identity.name})`)
+  return 'sealed'
 }
 
 /**

--- a/packages/cli/src/commands/seal.ts
+++ b/packages/cli/src/commands/seal.ts
@@ -16,16 +16,25 @@ import {
   createSealWithProvider,
   readSealsSync,
   writeSealsSync,
+  writeSealFileSync,
+  resolveSealsRoot,
   verifyGateSeal,
+  verifyPatternArtifactSeal,
   KeyProviderRegistry,
   ROOT_GATE_ID,
   API_SCHEMA_VERSION,
   type AttestItConfig,
   type FailureClass,
+  type GateConfig,
   type Identity,
   type Seal,
   type SealsFile,
 } from '@attest-it/core'
+import {
+  isPatternGate,
+  computePatternFingerprintsSync,
+  readPatternSealsByArtifactSync,
+} from '../utils/pattern-gate.js'
 import { log, success, error, warn, verbose, outputJson } from '../utils/output.js'
 import { ExitCode } from '../utils/exit-codes.js'
 import { resolveKeyPassphrase } from '../utils/passphrase.js'
@@ -54,14 +63,23 @@ interface SealOptions {
 }
 
 interface SealSummary {
-  sealed: { gate: string; fingerprint: string; sealedBy: string; sealedAt: string }[]
+  sealed: {
+    gate: string
+    /** Set for a pattern gate's per-file seal (the matched file it covers). */
+    artifactPath?: string
+    fingerprint: string
+    sealedBy: string
+    sealedAt: string
+  }[]
   skipped: {
     gate: string
+    artifactPath?: string
     reason: string
     failureClass?: FailureClass
   }[]
   failed: {
     gate: string
+    artifactPath?: string
     error: string
   }[]
 }
@@ -143,7 +161,33 @@ async function runSeal(gates: string[], options: SealOptions): Promise<void> {
     // Get the identity slug for sealedBy field
     const identitySlug = localConfig.activeIdentity
 
+    // Track whether any aggregate (single-gate) seal was added, so we only
+    // rewrite the aggregate seals when it actually changed. Pattern-gate per-file
+    // seals are written directly through the low-level writer and never enter the
+    // aggregate, so they must not force an aggregate rewrite.
+    let aggregateSealsAdded = false
+
     for (const gateId of gatesToSeal) {
+      // eslint-disable-next-line security/detect-object-injection -- gateId validated against config.gates above
+      const gateForKind = config.gates[gateId]
+      if (gateForKind && isPatternGate(gateForKind)) {
+        try {
+          await processPatternGate(
+            gateId,
+            gateForKind,
+            config,
+            identity,
+            identitySlug,
+            options,
+            summary,
+          )
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : 'Unknown error'
+          summary.failed.push({ gate: gateId, error: errorMsg })
+        }
+        continue
+      }
+
       try {
         const result = await processSingleGate(
           gateId,
@@ -155,6 +199,7 @@ async function runSeal(gates: string[], options: SealOptions): Promise<void> {
         )
 
         if (result.sealed && result.seal) {
+          aggregateSealsAdded = true
           summary.sealed.push({
             gate: gateId,
             fingerprint: result.seal.fingerprint,
@@ -182,8 +227,11 @@ async function runSeal(gates: string[], options: SealOptions): Promise<void> {
       }
     }
 
-    // Write seals file if not dry run and we sealed anything
-    if (!options.dryRun && summary.sealed.length > 0) {
+    // Persist the aggregate seals only when a single-gate seal actually changed
+    // it. Pattern-gate per-file seals were already written directly through the
+    // low-level per-file writer inside processPatternGate — routing them through
+    // the aggregate writeSeals would prune the sibling per-file seals.
+    if (!options.dryRun && aggregateSealsAdded) {
       writeSealsSync(projectRoot, sealsFile, config.settings.sealsPath)
     }
 
@@ -450,6 +498,140 @@ async function processSingleGate(
 }
 
 /**
+ * Seal a **pattern gate** (`kind: pattern`): fingerprint every matched file
+ * independently and produce **one seal per file**, each written as a standalone
+ * `.seal` at `<gate>/<artifact>/<signer>.seal` via the low-level
+ * {@link writeSealFileSync}. This is the per-file path the CLI previously never
+ * used — without it a `kind: pattern` gate silently degraded to single-gate
+ * behavior (issue #130).
+ *
+ * Per-file seals are written directly (never through the aggregate `writeSeals`,
+ * which is one-file-per-gate and would prune the siblings). A file that already
+ * has a valid per-file seal is skipped unless `--force`; a file whose seal is
+ * missing/invalid, or a brand-new matching file, is (re)sealed. Authorization is
+ * checked once for the gate (all its files share `authorizedSigners`).
+ *
+ * Results are recorded into the shared {@link SealSummary} keyed by gate +
+ * `artifactPath`.
+ */
+async function processPatternGate(
+  gateId: string,
+  gate: GateConfig,
+  config: AttestItConfig,
+  identity: Identity,
+  identitySlug: string,
+  options: SealOptions,
+  summary: SealSummary,
+): Promise<void> {
+  if (!options.json) {
+    verbose(`Processing pattern gate: ${gateId}`)
+  }
+
+  // Authorization is per gate: refuse the whole gate up front (nothing signed or
+  // written yet) exactly like the single-gate path. See #136.
+  if (!isAuthorizedSigner(config, gateId, identity.publicKey)) {
+    summary.skipped.push({
+      gate: gateId,
+      reason: `Not authorized to seal this gate (authorized signers: ${gate.authorizedSigners.join(', ')})`,
+      failureClass: 'unauthorized-signer',
+    })
+    return
+  }
+
+  const projectRoot = process.cwd()
+  const perFile = computePatternFingerprintsSync(gate, projectRoot)
+
+  if (perFile.length === 0) {
+    summary.skipped.push({
+      gate: gateId,
+      reason: 'Pattern gate matched no files',
+    })
+    return
+  }
+
+  const existingSeals = readPatternSealsByArtifactSync(
+    projectRoot,
+    config.settings.sealsPath,
+    gateId,
+  )
+  const sealsRoot = resolveSealsRoot(projectRoot, config.settings.sealsPath)
+
+  // Lazily create the signing provider only if at least one file needs sealing.
+  let keyProvider: ReturnType<typeof createKeyProviderFromIdentity> | undefined
+  let keyRef: string | undefined
+
+  for (const { path: filePath, fingerprint } of perFile) {
+    // Skip a file that already has a valid per-file seal, unless --force.
+    const existing = existingSeals.get(filePath)
+    if (existing && !options.force) {
+      const verification = verifyPatternArtifactSeal(
+        config,
+        gateId,
+        filePath,
+        existing,
+        fingerprint,
+        gate.maxAge,
+      )
+      if (verification.state === 'VALID') {
+        summary.skipped.push({
+          gate: gateId,
+          artifactPath: filePath,
+          reason: 'File already has a valid seal (use --force to override)',
+        })
+        continue
+      }
+    }
+
+    if (options.dryRun) {
+      if (!options.json) {
+        log(`  Would seal ${gateId} file: ${filePath}`)
+      }
+      summary.sealed.push({
+        gate: gateId,
+        artifactPath: filePath,
+        fingerprint: '',
+        sealedBy: identitySlug,
+        sealedAt: '',
+      })
+      continue
+    }
+
+    if (!keyProvider) {
+      keyProvider = createKeyProviderFromIdentity(identity)
+      keyRef = getKeyRefFromIdentity(identity)
+    }
+
+    const seal = await createSealWithProvider({
+      gateId,
+      fingerprint,
+      sealedBy: identitySlug,
+      keyProvider,
+      keyRef: keyRef ?? '',
+      resolvePassphrase: resolveKeyPassphrase,
+    })
+
+    // artifactPath is a storage/linkage field; the signed fingerprint already
+    // binds the file's path. Write it as a standalone per-file seal.
+    const perFileSeal: Seal = { ...seal, artifactPath: filePath }
+    writeSealFileSync(sealsRoot, perFileSeal)
+
+    if (!options.json) {
+      log(`  Sealed ${gateId} file: ${filePath}`)
+      verbose(`    Sealed by: ${identitySlug} (${identity.name})`)
+      verbose(`    Timestamp: ${seal.timestamp}`)
+    }
+
+    summary.sealed.push({
+      gate: gateId,
+      artifactPath: filePath,
+      fingerprint: perFileSeal.fingerprint,
+      sealedBy: perFileSeal.sealedBy,
+      sealedAt: perFileSeal.timestamp,
+    })
+  }
+}
+
+/**
  * Get all gate IDs from configuration.
  *
  * @param config - The attest-it configuration
@@ -471,8 +653,13 @@ function displaySummary(summary: SealSummary, dryRun?: boolean): void {
   const prefix = dryRun ? 'Would seal' : 'Sealed'
 
   if (summary.sealed.length > 0) {
-    const gateNames = summary.sealed.map((s) => s.gate).join(', ')
-    success(`${prefix} ${String(summary.sealed.length)} gate(s): ${gateNames}`)
+    // A pattern gate contributes one entry per matched file; label a per-file
+    // entry as `<gate> › <artifact>` and dedupe repeated gate ids so the banner
+    // reads cleanly whether the seals were single-gate or per-file.
+    const labels = summary.sealed.map((s) =>
+      s.artifactPath !== undefined ? `${s.gate} › ${s.artifactPath}` : s.gate,
+    )
+    success(`${prefix} ${String(summary.sealed.length)} seal(s): ${labels.join(', ')}`)
   }
 
   // An unauthorized-signer skip is a hard failure (nothing was sealed for
@@ -486,9 +673,9 @@ function displaySummary(summary: SealSummary, dryRun?: boolean): void {
 
   if (benignSkips.length > 0) {
     log('')
-    warn(`Skipped ${String(benignSkips.length)} gate(s):`)
+    warn(`Skipped ${String(benignSkips.length)}:`)
     for (const skip of benignSkips) {
-      log(`  ${skip.gate}: ${skip.reason}`)
+      log(`  ${summaryLabel(skip)}: ${skip.reason}`)
     }
   }
 
@@ -496,21 +683,26 @@ function displaySummary(summary: SealSummary, dryRun?: boolean): void {
     log('')
     error(`Refused to seal ${String(unauthorizedSkips.length)} gate(s) (unauthorized signer):`)
     for (const skip of unauthorizedSkips) {
-      log(`  ${skip.gate}: ${skip.reason}`)
+      log(`  ${summaryLabel(skip)}: ${skip.reason}`)
     }
   }
 
   if (summary.failed.length > 0) {
     log('')
-    error(`Failed to seal ${String(summary.failed.length)} gate(s):`)
+    error(`Failed to seal ${String(summary.failed.length)}:`)
     for (const fail of summary.failed) {
-      log(`  ${fail.gate}: ${fail.error}`)
+      log(`  ${summaryLabel(fail)}: ${fail.error}`)
     }
   }
 
   if (summary.sealed.length === 0 && summary.skipped.length === 0 && summary.failed.length === 0) {
     log('No gates to seal')
   }
+}
+
+/** Label a summary entry as the gate id, or `<gate> › <artifact>` for a per-file entry. */
+function summaryLabel(entry: { gate: string; artifactPath?: string }): string {
+  return entry.artifactPath !== undefined ? `${entry.gate} › ${entry.artifactPath}` : entry.gate
 }
 
 /**

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -4,11 +4,12 @@ import {
   computeFingerprintSync,
   readSealsSync,
   verifyGateSeal,
-  verifyAllSeals,
+  getGate,
   SplitConfigNotFoundError,
   type VerificationState,
   type SealVerificationResult,
 } from '@attest-it/core'
+import { isPatternGate, verifyPatternGateSync } from '../utils/pattern-gate.js'
 import {
   log,
   success,
@@ -36,6 +37,11 @@ interface StatusOptions {
 
 interface GateStatus {
   gateId: string
+  /**
+   * For a pattern gate's per-file row, the specific matched file this row
+   * covers (repo-relative, forward-slash). Absent for a single-gate row.
+   */
+  artifactPath?: string
   state: VerificationState
   currentFingerprint: string
   sealedFingerprint?: string
@@ -104,53 +110,33 @@ async function runStatus(
       }
     }
 
-    // Compute fingerprints for all gates
-    const fingerprints: Record<string, string> = {}
+    // Build status results. A pattern gate (`kind: pattern`) expands into one
+    // row per matched file (each fingerprinted and sealed independently); a
+    // single gate keeps its one combined-fingerprint row exactly as before.
+    const results: GateStatus[] = []
     for (const gateId of gatesToCheck) {
-      // eslint-disable-next-line security/detect-object-injection
-      const gate = config.gates[gateId]
-      if (!gate) continue
+      const gate = getGate(config, gateId)
+      if (gate && isPatternGate(gate)) {
+        for (const { path: filePath, fingerprint, result } of verifyPatternGateSync(
+          config,
+          gateId,
+          gate,
+          projectRoot,
+        )) {
+          results.push(toGateStatus(result, fingerprint, filePath))
+        }
+        continue
+      }
 
-      const result = computeFingerprintSync({
-        paths: gate.fingerprint.paths,
-        ...(gate.fingerprint.exclude && { exclude: gate.fingerprint.exclude }),
-      })
-      // eslint-disable-next-line security/detect-object-injection
-      fingerprints[gateId] = result.fingerprint
+      const fingerprint = gate
+        ? computeFingerprintSync({
+            paths: gate.fingerprint.paths,
+            ...(gate.fingerprint.exclude && { exclude: gate.fingerprint.exclude }),
+          }).fingerprint
+        : ''
+      const result = verifyGateSeal(config, gateId, sealsFile, fingerprint)
+      results.push(toGateStatus(result, fingerprint))
     }
-
-    // Verify seals
-    const verificationResults =
-      gates.length > 0
-        ? gatesToCheck.map((gateId) =>
-            // eslint-disable-next-line security/detect-object-injection
-            verifyGateSeal(config, gateId, sealsFile, fingerprints[gateId] ?? ''),
-          )
-        : verifyAllSeals(config, sealsFile, fingerprints)
-
-    // Build status results
-    const results: GateStatus[] = verificationResults.map((result: SealVerificationResult) => {
-      const status: GateStatus = {
-        gateId: result.gateId,
-        state: result.state,
-        currentFingerprint: fingerprints[result.gateId] ?? '',
-        message: result.message,
-      }
-
-      if (result.seal) {
-        status.sealedFingerprint = result.seal.fingerprint
-        status.sealedBy = result.seal.sealedBy
-        status.sealedAt = result.seal.timestamp
-
-        // Calculate age
-        const timestamp = new Date(result.seal.timestamp)
-        const now = Date.now()
-        const ageMs = now - timestamp.getTime()
-        status.age = Math.floor(ageMs / (1000 * 60 * 60 * 24))
-      }
-
-      return status
-    })
 
     // Output results
     if (options.json) {
@@ -180,13 +166,48 @@ async function runStatus(
 }
 
 /**
+ * Build a {@link GateStatus} row from a verification result and the current
+ * fingerprint, carrying `artifactPath` for a pattern gate's per-file row.
+ */
+function toGateStatus(
+  result: SealVerificationResult,
+  currentFingerprint: string,
+  artifactPath?: string,
+): GateStatus {
+  const status: GateStatus = {
+    gateId: result.gateId,
+    ...(artifactPath !== undefined && { artifactPath }),
+    state: result.state,
+    currentFingerprint,
+    message: result.message,
+  }
+
+  if (result.seal) {
+    status.sealedFingerprint = result.seal.fingerprint
+    status.sealedBy = result.seal.sealedBy
+    status.sealedAt = result.seal.timestamp
+
+    const timestamp = new Date(result.seal.timestamp)
+    const ageMs = Date.now() - timestamp.getTime()
+    status.age = Math.floor(ageMs / (1000 * 60 * 60 * 24))
+  }
+
+  return status
+}
+
+/** Human-readable label for a row: the gate id, or `<gateId> › <artifact>` per file. */
+function rowLabel(r: { gateId: string; artifactPath?: string }): string {
+  return r.artifactPath !== undefined ? `${r.gateId} › ${r.artifactPath}` : r.gateId
+}
+
+/**
  * Display status results in a formatted table.
  *
  * @param results - Status results for gates
  */
 function displayStatusTable(results: GateStatus[]): void {
   const tableRows: TableRow[] = results.map((r) => ({
-    suite: r.gateId,
+    gate: rowLabel(r),
     status: colorizeState(r.state),
     fingerprint: r.currentFingerprint.slice(0, 16) + '...',
     age: formatAge(r),
@@ -201,7 +222,7 @@ function displayStatusTable(results: GateStatus[]): void {
   if (sealed.length > 0) {
     log('Seal metadata:')
     for (const result of sealed) {
-      log(`  ${result.gateId}:`)
+      log(`  ${rowLabel(result)}:`)
       log(`    Sealed by: ${result.sealedBy ?? 'unknown'}`)
       if (result.sealedAt) {
         const date = new Date(result.sealedAt)
@@ -216,7 +237,7 @@ function displayStatusTable(results: GateStatus[]): void {
   if (withIssues.length > 0) {
     log('Issues:')
     for (const result of withIssues) {
-      log(`  ${result.gateId}: ${result.message ?? 'Unknown issue'}`)
+      log(`  ${rowLabel(result)}: ${result.message ?? 'Unknown issue'}`)
     }
     log('')
   }

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -5,9 +5,9 @@ import {
   computePolicyFingerprintSync,
   findPolicyPath,
   readSealsSync,
-  verifyAllSeals,
   verifyGateSeal,
   verifyRootGate,
+  getGate,
   isBlockingRootGateState,
   SplitConfigNotFoundError,
   type AttestItConfig,
@@ -15,6 +15,7 @@ import {
   type SealVerificationResult,
   type RootGateVerificationResult,
 } from '@attest-it/core'
+import { isPatternGate, verifyPatternGateSync } from '../utils/pattern-gate.js'
 import {
   log,
   success,
@@ -200,29 +201,27 @@ async function runVerify(
       }
     }
 
-    // Compute fingerprints for all gates
-    const fingerprints: Record<string, string> = {}
+    // Verify each gate. A pattern gate (`kind: pattern`) fans out into one
+    // independent per-file result (each matched file fingerprinted and sealed on
+    // its own); a single gate keeps its one combined-fingerprint result.
+    const results: SealVerificationResult[] = []
     for (const gateId of gatesToVerify) {
-      // eslint-disable-next-line security/detect-object-injection
-      const gate = config.gates[gateId]
-      if (!gate) continue
+      const gate = getGate(config, gateId)
+      if (gate && isPatternGate(gate)) {
+        for (const { result } of verifyPatternGateSync(config, gateId, gate, projectRoot)) {
+          results.push(result)
+        }
+        continue
+      }
 
-      const result = computeFingerprintSync({
-        paths: gate.fingerprint.paths,
-        ...(gate.fingerprint.exclude && { exclude: gate.fingerprint.exclude }),
-      })
-      // eslint-disable-next-line security/detect-object-injection
-      fingerprints[gateId] = result.fingerprint
+      const fingerprint = gate
+        ? computeFingerprintSync({
+            paths: gate.fingerprint.paths,
+            ...(gate.fingerprint.exclude && { exclude: gate.fingerprint.exclude }),
+          }).fingerprint
+        : ''
+      results.push(verifyGateSeal(config, gateId, sealsFile, fingerprint))
     }
-
-    // Verify seals
-    const results =
-      gates.length > 0
-        ? gatesToVerify.map((gateId) =>
-            // eslint-disable-next-line security/detect-object-injection
-            verifyGateSeal(config, gateId, sealsFile, fingerprints[gateId] ?? ''),
-          )
-        : verifyAllSeals(config, sealsFile, fingerprints)
 
     // Output results
     if (options.json) {
@@ -293,9 +292,10 @@ function rootGateResultToJson(result: RootGateVerificationResult): SealVerificat
 function displayResults(results: SealVerificationResult[]): void {
   log('')
 
-  // Build table rows
+  // Build table rows. A pattern gate's per-file result is labelled
+  // `<gateId> › <artifactPath>` so each matched file is individually identifiable.
   const tableRows: TableRow[] = results.map((r) => ({
-    suite: r.gateId,
+    gate: verificationRowLabel(r),
     status: colorizeState(r.state),
     fingerprint: formatFingerprint(r),
     age: formatAge(r),
@@ -315,7 +315,7 @@ function displayResults(results: SealVerificationResult[]): void {
   if (withIssues.length > 0) {
     for (const result of withIssues) {
       if (result.message) {
-        log(`${result.gateId}: ${result.message}`)
+        log(`${verificationRowLabel(result)}: ${result.message}`)
       }
     }
     log('')
@@ -338,6 +338,16 @@ function displayResults(results: SealVerificationResult[]): void {
       log('Run `attest-it seal --force <gate>` to update stale seals')
     }
   }
+}
+
+/**
+ * Human-readable label for a result row: the gate id, or `<gateId> › <artifact>`
+ * for a pattern gate's per-file result.
+ */
+function verificationRowLabel(result: SealVerificationResult): string {
+  return result.artifactPath !== undefined
+    ? `${result.gateId} › ${result.artifactPath}`
+    : result.gateId
 }
 
 /**

--- a/packages/cli/src/utils/git-policy.ts
+++ b/packages/cli/src/utils/git-policy.ts
@@ -22,7 +22,7 @@ import { relative } from 'node:path'
  * must fail **closed** on any such error (missing ref, missing file, no git),
  * never fall open to the untrusted working-tree policy — so callers treat this
  * as a configuration error with an actionable message.
- * @public
+ * @internal
  */
 export class GitRefPolicyError extends Error {
   constructor(message: string) {
@@ -34,7 +34,7 @@ export class GitRefPolicyError extends Error {
 /**
  * The policy content read from a git ref, plus the parse format inferred from
  * the policy file's extension.
- * @public
+ * @internal
  */
 export interface RefPolicy {
   /** Raw policy file content as committed at the ref. */
@@ -59,7 +59,7 @@ export interface RefPolicy {
  * @returns The policy content at the ref and its parse format.
  * @throws {@link GitRefPolicyError} If git is unavailable, the ref is missing, or
  *   the policy file does not exist at the ref.
- * @public
+ * @internal
  */
 export function readPolicyFromRef(
   ref: string,

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -85,9 +85,11 @@ export function info(message: string): void {
   log(getTheme().info('ℹ ' + message))
 }
 
-// Table formatting for status display
+// Table formatting for status/verify display. Rows carry gate-level (or, for a
+// pattern gate, per-file) data — the label column is 'Gate', not 'Suite'.
 export interface TableRow {
-  suite: string
+  /** Gate identifier, or `<gateId> › <artifactPath>` for a pattern gate's per-file row. */
+  gate: string
   status: string
   fingerprint: string
   age: string
@@ -95,15 +97,10 @@ export interface TableRow {
 
 export function formatTable(rows: TableRow[]): string {
   // Calculate column widths
-  const headers = ['Suite', 'Status', 'Fingerprint', 'Age']
+  const headers = ['Gate', 'Status', 'Fingerprint', 'Age']
 
   // Helper to get row values in consistent order
-  const getRowValues = (row: TableRow): string[] => [
-    row.suite,
-    row.status,
-    row.fingerprint,
-    row.age,
-  ]
+  const getRowValues = (row: TableRow): string[] => [row.gate, row.status, row.fingerprint, row.age]
 
   const widths = headers.map((h, i) => {
     const columnValues = rows.map((r) => {

--- a/packages/cli/src/utils/pattern-gate.ts
+++ b/packages/cli/src/utils/pattern-gate.ts
@@ -1,0 +1,141 @@
+/**
+ * Pattern-gate (per-file) routing shared across the `seal`, `verify`, `status`,
+ * and `run` commands.
+ *
+ * A gate declared `kind: pattern` fingerprints and seals **each matched file
+ * independently** (see `configuration.md` and issue #130). This module is the
+ * single place the CLI translates a pattern gate into its per-file units so the
+ * four commands stay consistent:
+ *
+ * - each matched file gets its own fingerprint (`computeFingerprintsPerFileSync`),
+ * - each file's seal is read/written as a standalone `.seal` under
+ *   `<gate>/<artifact>/<signer>.seal` via the **low-level** per-file API
+ *   ({@link writeSealFileSync} / {@link listStoredSealsSync}) — never the
+ *   aggregate `writeSeals`, which is one-file-per-gate and would prune the
+ *   sibling per-file seals,
+ * - verification is per-file ({@link verifyPatternArtifactSeal}), so one file
+ *   flipping invalid never touches its siblings.
+ *
+ * @packageDocumentation
+ */
+
+import {
+  computeFingerprintsPerFileSync,
+  listStoredSealsSync,
+  resolveSealsRoot,
+  verifyPatternArtifactSeal,
+  type AttestItConfig,
+  type GateConfig,
+  type Seal,
+  type SealVerificationResult,
+} from '@attest-it/core'
+
+/**
+ * Whether a gate is a per-file **pattern** gate. Absent `kind` (or the explicit
+ * `single`) keeps the pre-existing one-combined-fingerprint behavior.
+ */
+export function isPatternGate(gate: GateConfig): boolean {
+  return gate.kind === 'pattern'
+}
+
+/**
+ * The latest per-file seal for each matched file of a pattern gate, keyed by
+ * artifact path. When several signers sealed the same file the most recent wins
+ * (ties broken by signer slug) — the same deterministic collapse the aggregate
+ * storage and the embeddable API use.
+ *
+ * Reads through the low-level {@link listStoredSealsSync} so per-file pattern
+ * seals (which the aggregate read path deliberately ignores) are visible.
+ */
+export function readPatternSealsByArtifactSync(
+  projectRoot: string,
+  sealsPathOverride: string | undefined,
+  gateId: string,
+): Map<string, Seal> {
+  const root = resolveSealsRoot(projectRoot, sealsPathOverride)
+  const byArtifact = new Map<string, Seal>()
+  for (const { seal } of listStoredSealsSync(root)) {
+    if (seal.gateId !== gateId || seal.artifactPath === undefined) continue
+    const current = byArtifact.get(seal.artifactPath)
+    if (
+      !current ||
+      seal.timestamp > current.timestamp ||
+      (seal.timestamp === current.timestamp && seal.sealedBy > current.sealedBy)
+    ) {
+      byArtifact.set(seal.artifactPath, seal)
+    }
+  }
+  return byArtifact
+}
+
+/**
+ * One matched file of a pattern gate together with its current individual
+ * fingerprint and its verification result.
+ */
+export interface PatternFileState {
+  /** Repo-relative, forward-slash path of the matched file. */
+  path: string
+  /** The file's current individual fingerprint (`sha256:...`). */
+  fingerprint: string
+  /** Per-file verification result (carries `artifactPath`). */
+  result: SealVerificationResult
+}
+
+/**
+ * Compute the current per-file fingerprints for a pattern gate, sorted
+ * lexicographically by path (deterministic ordering for `status`/`verify`).
+ *
+ * A pattern gate whose globs match no file yields an empty list rather than
+ * throwing — there is simply nothing to seal or report for it.
+ */
+export function computePatternFingerprintsSync(
+  gate: GateConfig,
+  projectRoot: string,
+): { path: string; fingerprint: string }[] {
+  try {
+    return computeFingerprintsPerFileSync({
+      paths: gate.fingerprint.paths,
+      ...(gate.fingerprint.exclude && { exclude: gate.fingerprint.exclude }),
+      baseDir: projectRoot,
+    })
+  } catch (error) {
+    // A glob that matches nothing is "no files to attest", not an error. Any
+    // other failure (unreadable path, etc.) is genuinely exceptional.
+    if (error instanceof Error && error.message.includes('matched no files')) {
+      return []
+    }
+    throw error
+  }
+}
+
+/**
+ * Verify a pattern gate: one independent {@link SealVerificationResult} per
+ * matched file, sorted lexicographically by path. A newly-added matching file
+ * with no seal surfaces as `MISSING`; a one-byte change to a sealed file flips
+ * only that file to `FINGERPRINT_MISMATCH` while siblings stay `VALID`.
+ */
+export function verifyPatternGateSync(
+  config: AttestItConfig,
+  gateId: string,
+  gate: GateConfig,
+  projectRoot: string,
+): PatternFileState[] {
+  const perFile = computePatternFingerprintsSync(gate, projectRoot)
+  const sealsByArtifact = readPatternSealsByArtifactSync(
+    projectRoot,
+    config.settings.sealsPath,
+    gateId,
+  )
+  return perFile.map(({ path: filePath, fingerprint }) => ({
+    path: filePath,
+    fingerprint,
+    result: verifyPatternArtifactSeal(
+      config,
+      gateId,
+      filePath,
+      sealsByArtifact.get(filePath),
+      fingerprint,
+      gate.maxAge,
+    ),
+  }))
+}

--- a/packages/cli/test/integration/pattern-gate.integration.test.ts
+++ b/packages/cli/test/integration/pattern-gate.integration.test.ts
@@ -1,0 +1,359 @@
+/**
+ * CLI-layer UAT for **pattern gates** (`kind: pattern`) driven through the real,
+ * built `attest-it` binary as subprocesses (issue #130).
+ *
+ * The core (`@attest-it/core`) has per-file fingerprinting/sealing primitives
+ * with their own unit tests, but before this change the CLI commands
+ * (`seal`/`verify`/`status`/`run`) never called them — a `kind: pattern` gate
+ * silently degraded to single-gate behavior (one combined seal, one row, whole-
+ * gate invalidation). These tests exercise the documented per-file contract at
+ * the CLI boundary, so they FAIL against the pre-fix CLI:
+ *
+ *   - sealing a 2-file pattern gate produces **two** per-file `.seal` files
+ *     (each carrying an `artifactPath`), not one combined aggregate seal;
+ *   - `status --json` / `verify --json` show **one row per matched file**;
+ *   - a newly-added matching file shows UNSEALED (`MISSING`) with no config edit;
+ *   - a one-byte change to one sealed file flips ONLY that file to
+ *     `FINGERPRINT_MISMATCH` while its sibling stays `VALID`.
+ *
+ * A regression case asserts a single (non-pattern) gate still yields exactly one
+ * combined seal and one row.
+ *
+ * @see docs/configuration.md (pattern gates)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawn } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import * as os from 'node:os'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLI_PATH = path.resolve(__dirname, '../../dist/bin/attest-it.js')
+
+const CLI_CALL_TIMEOUT_MS = 15000
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+function runCli(args: string[], cwd: string, env: NodeJS.ProcessEnv = {}): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`CLI call timed out: attest-it ${args.join(' ')}\nstdout:\n${stdout}`))
+    }, CLI_CALL_TIMEOUT_MS)
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ exitCode: code ?? 1, stdout, stderr })
+    })
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+async function runGit(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('git', args, { cwd, stdio: 'ignore' })
+    child.on('close', (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(`git ${args.join(' ')} exited ${String(code)}`))
+    })
+    child.on('error', reject)
+  })
+}
+
+/** Recursively collect every `.seal` file's absolute path under `.attest-it/seals`. */
+function collectSealFiles(projectDir: string): string[] {
+  const root = path.join(projectDir, '.attest-it', 'seals')
+  const out: string[] = []
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.isFile() && entry.name.endsWith('.seal')) out.push(full)
+    }
+  }
+  walk(root)
+  return out.sort()
+}
+
+interface JsonRow {
+  gateId: string
+  artifactPath?: string
+  state: string
+}
+
+function parseRows(stdout: string): JsonRow[] {
+  const parsed: unknown = JSON.parse(stdout)
+  if (!Array.isArray(parsed)) throw new Error(`Expected a JSON array, got: ${stdout}`)
+  return parsed as JsonRow[]
+}
+
+/** Index verification/status rows by their artifact path for per-file assertions. */
+function byArtifact(rows: JsonRow[]): Map<string, JsonRow> {
+  const m = new Map<string, JsonRow>()
+  for (const r of rows) {
+    if (r.artifactPath !== undefined) m.set(r.artifactPath, r)
+  }
+  return m
+}
+
+/**
+ * Run the shared bootstrap: create an identity, `init`, write the given policy
+ * gates + operational suites, join the team over `gateIds`, and commit. Returns
+ * once the working tree is clean and the gate(s) are ready to seal.
+ */
+async function bootstrap(
+  projectDir: string,
+  env: NodeJS.ProcessEnv,
+  gates: Record<string, unknown>,
+  suites: Record<string, unknown>,
+  gateIds: string[],
+): Promise<void> {
+  await fs.promises.writeFile(
+    path.join(projectDir, 'package.json'),
+    JSON.stringify({ dependencies: {} }, null, 2),
+  )
+  await runGit(['init'], projectDir)
+  await runGit(['config', 'user.email', 'test@example.com'], projectDir)
+  await runGit(['config', 'user.name', 'Test User'], projectDir)
+
+  const createResult = await runCli(
+    ['identity', 'create', '--name', 'Test User', '--slug', 'test-user', '--storage', 'file'],
+    projectDir,
+    env,
+  )
+  expect(createResult.exitCode, createResult.stderr).toBe(0)
+
+  const initResult = await runCli(['init'], projectDir, env)
+  expect(initResult.exitCode, initResult.stderr).toBe(0)
+
+  const policyPath = path.join(projectDir, '.attest-it', 'policy.yaml')
+  await fs.promises.writeFile(
+    policyPath,
+    stringifyYaml({ version: 1, settings: { maxAgeDays: 30 }, team: {}, gates }),
+    'utf8',
+  )
+  await fs.promises.writeFile(
+    path.join(projectDir, '.attest-it', 'config.yaml'),
+    stringifyYaml({ version: 1, settings: {}, suites }),
+    'utf8',
+  )
+
+  const joinResult = await runCli(['team', 'join', '--gates', ...gateIds], projectDir, env)
+  expect(joinResult.exitCode, joinResult.stderr).toBe(0)
+
+  await runGit(['add', '.'], projectDir)
+  await runGit(['commit', '-m', 'configure gates'], projectDir)
+}
+
+describe('pattern gates through the real CLI (issue #130)', () => {
+  let projectDir: string
+  let homeDir: string
+  let env: NodeJS.ProcessEnv
+
+  beforeEach(async () => {
+    projectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-pattern-'))
+    homeDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'attest-it-pattern-home-'))
+    // Issue #114: redirect VaultKeeper's file backend to the isolated temp home
+    // so the real ~/.config/vaultkeeper is never touched.
+    env = { ATTEST_IT_HOME: homeDir, VAULTKEEPER_CONFIG_DIR: homeDir }
+  })
+
+  afterEach(async () => {
+    await fs.promises.rm(projectDir, { recursive: true, force: true })
+    await fs.promises.rm(homeDir, { recursive: true, force: true })
+  })
+
+  const patternGates = {
+    tools: {
+      name: 'Tools',
+      description: 'Per-file pattern gate over tools shell scripts',
+      kind: 'pattern',
+      authorizedSigners: ['test-user'],
+      fingerprint: { paths: ['tools/*.sh'] },
+      maxAge: '30d',
+    },
+  }
+
+  async function writeToolFiles(files: Record<string, string>): Promise<void> {
+    await fs.promises.mkdir(path.join(projectDir, 'tools'), { recursive: true })
+    for (const [name, content] of Object.entries(files)) {
+      await fs.promises.writeFile(path.join(projectDir, 'tools', name), content, 'utf8')
+    }
+  }
+
+  it(
+    'seals one per-file seal per matched file; per-file rows; new file unsealed; one-byte flip isolates',
+    async () => {
+      await writeToolFiles({
+        'build.sh': '#!/bin/sh\necho build\n',
+        'deploy.sh': '#!/bin/sh\necho deploy\n',
+      })
+      await bootstrap(
+        projectDir,
+        env,
+        patternGates,
+        { tools: { gate: 'tools', command: 'true' } },
+        ['tools'],
+      )
+
+      // seal → ONE seal file per matched file (two), each carrying an artifactPath.
+      const sealResult = await runCli(['seal', 'tools'], projectDir, env)
+      expect(sealResult.exitCode, sealResult.stderr).toBe(0)
+
+      const sealFiles = collectSealFiles(projectDir)
+      expect(sealFiles).toHaveLength(2)
+      const sealArtifacts = sealFiles
+        .map((p) => parseYaml(fs.readFileSync(p, 'utf8')) as { artifactPath?: string })
+        .map((s) => s.artifactPath)
+        .sort()
+      expect(sealArtifacts).toEqual(['tools/build.sh', 'tools/deploy.sh'])
+
+      // status --json → per-file rows, both VALID.
+      const status1 = await runCli(['status', '--json'], projectDir, env)
+      expect(status1.exitCode, status1.stderr).toBe(0)
+      const rows1 = byArtifact(parseRows(status1.stdout))
+      expect(rows1.get('tools/build.sh')?.state).toBe('VALID')
+      expect(rows1.get('tools/deploy.sh')?.state).toBe('VALID')
+      expect(rows1.size).toBe(2)
+
+      // verify --json → per-file rows, exit 0.
+      const verify1 = await runCli(['verify', '--json'], projectDir, env)
+      expect(verify1.exitCode, verify1.stderr).toBe(0)
+      const vrows1 = byArtifact(parseRows(verify1.stdout))
+      expect(vrows1.get('tools/build.sh')?.state).toBe('VALID')
+      expect(vrows1.get('tools/deploy.sh')?.state).toBe('VALID')
+
+      // Add a THIRD matching file with NO config change → it shows UNSEALED.
+      await writeToolFiles({ 'release.sh': '#!/bin/sh\necho release\n' })
+      const status2 = await runCli(['status', '--json'], projectDir, env)
+      expect(status2.exitCode, status2.stderr).toBe(0)
+      const rows2 = byArtifact(parseRows(status2.stdout))
+      expect(rows2.size).toBe(3)
+      expect(rows2.get('tools/release.sh')?.state).toBe('MISSING')
+      expect(rows2.get('tools/build.sh')?.state).toBe('VALID')
+      expect(rows2.get('tools/deploy.sh')?.state).toBe('VALID')
+
+      // Edit ONE byte of ONE sealed file → only that file flips; sibling unaffected.
+      await fs.promises.writeFile(
+        path.join(projectDir, 'tools', 'build.sh'),
+        '#!/bin/sh\necho BUILD\n',
+        'utf8',
+      )
+      const status3 = await runCli(['status', '--json'], projectDir, env)
+      const rows3 = byArtifact(parseRows(status3.stdout))
+      expect(rows3.get('tools/build.sh')?.state).toBe('FINGERPRINT_MISMATCH')
+      expect(rows3.get('tools/deploy.sh')?.state).toBe('VALID')
+      expect(rows3.get('tools/release.sh')?.state).toBe('MISSING')
+
+      // verify now fails (one file invalid) — but the sibling is still reported VALID.
+      const verify3 = await runCli(['verify', '--json'], projectDir, env)
+      expect(verify3.exitCode).not.toBe(0)
+      const vrows3 = byArtifact(parseRows(verify3.stdout))
+      expect(vrows3.get('tools/build.sh')?.state).toBe('FINGERPRINT_MISMATCH')
+      expect(vrows3.get('tools/deploy.sh')?.state).toBe('VALID')
+    },
+    CLI_CALL_TIMEOUT_MS * 8,
+  )
+
+  it(
+    'run --suite over a pattern gate seals each matched file independently',
+    async () => {
+      await writeToolFiles({
+        'build.sh': '#!/bin/sh\necho build\n',
+        'deploy.sh': '#!/bin/sh\necho deploy\n',
+      })
+      await bootstrap(
+        projectDir,
+        env,
+        patternGates,
+        { tools: { gate: 'tools', command: 'true' } },
+        ['tools'],
+      )
+
+      const runResult = await runCli(['run', '--suite', 'tools', '--yes'], projectDir, env)
+      expect(runResult.exitCode, runResult.stderr).toBe(0)
+
+      // Consistent with `seal`: one per-file seal per matched file.
+      const sealFiles = collectSealFiles(projectDir)
+      expect(sealFiles).toHaveLength(2)
+
+      const verifyResult = await runCli(['verify', '--json'], projectDir, env)
+      expect(verifyResult.exitCode, verifyResult.stderr).toBe(0)
+      const rows = byArtifact(parseRows(verifyResult.stdout))
+      expect(rows.get('tools/build.sh')?.state).toBe('VALID')
+      expect(rows.get('tools/deploy.sh')?.state).toBe('VALID')
+    },
+    CLI_CALL_TIMEOUT_MS * 8,
+  )
+
+  it(
+    'regression: a single (non-pattern) gate still produces one combined seal and one row',
+    async () => {
+      await fs.promises.mkdir(path.join(projectDir, 'src'), { recursive: true })
+      await fs.promises.writeFile(path.join(projectDir, 'src', 'a.ts'), 'export const a = 1\n')
+      await fs.promises.writeFile(path.join(projectDir, 'src', 'b.ts'), 'export const b = 2\n')
+
+      const singleGate = {
+        core: {
+          name: 'Core',
+          description: 'A single combined-fingerprint gate',
+          authorizedSigners: ['test-user'],
+          fingerprint: { paths: ['src'] },
+          maxAge: '30d',
+        },
+      }
+      await bootstrap(projectDir, env, singleGate, { core: { gate: 'core', command: 'true' } }, [
+        'core',
+      ])
+
+      const sealResult = await runCli(['seal', 'core'], projectDir, env)
+      expect(sealResult.exitCode, sealResult.stderr).toBe(0)
+
+      // Exactly ONE combined seal, with NO artifactPath (aggregate one-per-gate).
+      const sealFiles = collectSealFiles(projectDir)
+      expect(sealFiles).toHaveLength(1)
+      const seal = parseYaml(fs.readFileSync(sealFiles[0]!, 'utf8')) as { artifactPath?: string }
+      expect(seal.artifactPath).toBeUndefined()
+
+      // Exactly one status row, keyed by gate (no artifactPath).
+      const statusResult = await runCli(['status', '--json'], projectDir, env)
+      expect(statusResult.exitCode, statusResult.stderr).toBe(0)
+      const rows = parseRows(statusResult.stdout)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.gateId).toBe('core')
+      expect(rows[0]?.artifactPath).toBeUndefined()
+      expect(rows[0]?.state).toBe('VALID')
+    },
+    CLI_CALL_TIMEOUT_MS * 6,
+  )
+})

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -181,13 +181,13 @@ describe('output utilities', () => {
     it('should format table with correct columns and alignment', () => {
       const rows: TableRow[] = [
         {
-          suite: 'auth',
+          gate: 'auth',
           status: 'VALID',
           fingerprint: 'abc123',
           age: '2 days',
         },
         {
-          suite: 'payments',
+          gate: 'payments',
           status: 'EXPIRED',
           fingerprint: 'def456',
           age: '10 days',
@@ -196,8 +196,8 @@ describe('output utilities', () => {
 
       const result = formatTable(rows)
 
-      // Check header
-      expect(result).toContain('Suite')
+      // Check header — the label column reflects gate-level data, not suites.
+      expect(result).toContain('Gate')
       expect(result).toContain('Status')
       expect(result).toContain('Fingerprint')
       expect(result).toContain('Age')
@@ -222,7 +222,7 @@ describe('output utilities', () => {
       const result = formatTable(rows)
 
       // Should still have headers and separator
-      expect(result).toContain('Suite')
+      expect(result).toContain('Gate')
       expect(result).toContain('Status')
       expect(result).toContain('─')
     })
@@ -230,13 +230,13 @@ describe('output utilities', () => {
     it('should align columns correctly with varying lengths', () => {
       const rows: TableRow[] = [
         {
-          suite: 'a',
+          gate: 'a',
           status: 'VALID',
           fingerprint: 'x',
           age: '1d',
         },
         {
-          suite: 'very-long-suite-name',
+          gate: 'very-long-gate-name',
           status: 'SIGNATURE_INVALID',
           fingerprint: 'very-long-fingerprint',
           age: '30 days',

--- a/packages/cli/test/status.test.ts
+++ b/packages/cli/test/status.test.ts
@@ -36,7 +36,7 @@ const mockProcessExit = vi
   .mockImplementation(() => {})
 
 // Import mocked functions
-const { loadSplitConfig, computeFingerprintSync, readSealsSync, verifyAllSeals, verifyGateSeal } =
+const { loadSplitConfig, computeFingerprintSync, readSealsSync, verifyGateSeal } =
   await import('@attest-it/core')
 
 describe('status command', () => {
@@ -121,7 +121,7 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([createMockVerificationResult({ state: 'VALID' })])
+      vi.mocked(verifyGateSeal).mockReturnValue(createMockVerificationResult({ state: 'VALID' }))
 
       await runStatus([], {})
 
@@ -157,10 +157,13 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
-        createMockVerificationResult({ gateId: 'gate1', state: 'MISSING', seal: undefined }),
-        createMockVerificationResult({ gateId: 'gate2', state: 'MISSING', seal: undefined }),
-      ])
+      vi.mocked(verifyGateSeal)
+        .mockReturnValueOnce(
+          createMockVerificationResult({ gateId: 'gate1', state: 'MISSING', seal: undefined }),
+        )
+        .mockReturnValueOnce(
+          createMockVerificationResult({ gateId: 'gate2', state: 'MISSING', seal: undefined }),
+        )
 
       await runStatus([], {})
 
@@ -177,7 +180,7 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([createMockVerificationResult({ state: 'VALID' })])
+      vi.mocked(verifyGateSeal).mockReturnValue(createMockVerificationResult({ state: 'VALID' }))
 
       await runStatus([], { json: true })
 
@@ -196,13 +199,13 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'MISSING',
           seal: undefined,
           message: 'No seal found for gate',
         }),
-      ])
+      )
 
       await runStatus([], { json: true })
 
@@ -219,12 +222,12 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'FINGERPRINT_MISMATCH',
           message: 'Fingerprint changed since seal was created',
         }),
-      ])
+      )
 
       await runStatus([], { json: true })
 
@@ -247,12 +250,12 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'STALE',
           message: 'Seal is 45 days old, exceeds maxAge of 30 days',
         }),
-      ])
+      )
 
       await runStatus([], { json: true })
 
@@ -289,19 +292,22 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
-        createMockVerificationResult({
-          gateId: 'gate1',
-          state: 'STALE',
-          message: 'Seal is 45 days old, exceeds maxAge of 30 days',
-        }),
-        createMockVerificationResult({
-          gateId: 'gate2',
-          state: 'MISSING',
-          seal: undefined,
-          message: 'No seal found',
-        }),
-      ])
+      vi.mocked(verifyGateSeal)
+        .mockReturnValueOnce(
+          createMockVerificationResult({
+            gateId: 'gate1',
+            state: 'STALE',
+            message: 'Seal is 45 days old, exceeds maxAge of 30 days',
+          }),
+        )
+        .mockReturnValueOnce(
+          createMockVerificationResult({
+            gateId: 'gate2',
+            state: 'MISSING',
+            seal: undefined,
+            message: 'No seal found',
+          }),
+        )
 
       await runStatus([], { json: true })
 
@@ -424,7 +430,7 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([createMockVerificationResult({ state: 'VALID' })])
+      vi.mocked(verifyGateSeal).mockReturnValue(createMockVerificationResult({ state: 'VALID' }))
 
       await runStatus([], {}, '/custom/policy.yaml')
 
@@ -471,12 +477,12 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'INVALID_SIGNATURE',
           message: 'Signature verification failed',
         }),
-      ])
+      )
 
       await runStatus([], { json: true })
 
@@ -493,12 +499,12 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'UNKNOWN_SIGNER',
           message: "Signer 'bob' not found in team",
         }),
-      ])
+      )
 
       await runStatus([], { json: true })
 
@@ -533,15 +539,16 @@ describe('status command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
-        createMockVerificationResult({ gateId: 'gate1', state: 'VALID' }),
-        createMockVerificationResult({
-          gateId: 'gate2',
-          state: 'MISSING',
-          seal: undefined,
-          message: 'No seal found',
-        }),
-      ])
+      vi.mocked(verifyGateSeal)
+        .mockReturnValueOnce(createMockVerificationResult({ gateId: 'gate1', state: 'VALID' }))
+        .mockReturnValueOnce(
+          createMockVerificationResult({
+            gateId: 'gate2',
+            state: 'MISSING',
+            seal: undefined,
+            message: 'No seal found',
+          }),
+        )
 
       await runStatus([], {})
 

--- a/packages/cli/test/verify.test.ts
+++ b/packages/cli/test/verify.test.ts
@@ -41,7 +41,6 @@ const {
   loadSplitConfig,
   computeFingerprintSync,
   readSealsSync,
-  verifyAllSeals,
   verifyGateSeal,
 } = await import('@attest-it/core')
 
@@ -145,7 +144,7 @@ describe('verify command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([createMockVerificationResult({ state: 'VALID' })])
+      vi.mocked(verifyGateSeal).mockReturnValue(createMockVerificationResult({ state: 'VALID' }))
 
       await runVerify([], {})
 
@@ -161,13 +160,13 @@ describe('verify command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'MISSING',
           seal: undefined,
           message: 'No seal found for gate',
         }),
-      ])
+      )
 
       await runVerify([], {})
 
@@ -183,12 +182,12 @@ describe('verify command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'FINGERPRINT_MISMATCH',
           message: 'Fingerprint changed since seal was created',
         }),
-      ])
+      )
 
       await runVerify([], {})
 
@@ -204,12 +203,12 @@ describe('verify command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
+      vi.mocked(verifyGateSeal).mockReturnValue(
         createMockVerificationResult({
           state: 'STALE',
           message: 'Seal is 45 days old, exceeds maxAge of 30 days',
         }),
-      ])
+      )
 
       await runVerify([], {})
 
@@ -277,7 +276,7 @@ describe('verify command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue(mockResults)
+      vi.mocked(verifyGateSeal).mockReturnValue(mockResults[0]!)
 
       await runVerify([], { json: true })
 
@@ -391,15 +390,16 @@ describe('verify command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([
-        createMockVerificationResult({ gateId: 'gate1', state: 'VALID' }),
-        createMockVerificationResult({
-          gateId: 'gate2',
-          state: 'MISSING',
-          seal: undefined,
-          message: 'No seal found',
-        }),
-      ])
+      vi.mocked(verifyGateSeal)
+        .mockReturnValueOnce(createMockVerificationResult({ gateId: 'gate1', state: 'VALID' }))
+        .mockReturnValueOnce(
+          createMockVerificationResult({
+            gateId: 'gate2',
+            state: 'MISSING',
+            seal: undefined,
+            message: 'No seal found',
+          }),
+        )
 
       await runVerify([], {})
 
@@ -457,7 +457,7 @@ describe('verify command', () => {
         fileCount: 10,
         files: [],
       })
-      vi.mocked(verifyAllSeals).mockReturnValue([createMockVerificationResult({ state: 'VALID' })])
+      vi.mocked(verifyGateSeal).mockReturnValue(createMockVerificationResult({ state: 'VALID' }))
 
       await runVerify([], {}, '/custom/policy.yaml')
 


### PR DESCRIPTION
## Summary

`kind: pattern` gates were **non-functional via the CLI**. `@attest-it/core` had per-file fingerprinting (`computeFingerprintsPerFile`) and per-file seal storage, but `seal`/`verify`/`status`/`run` only ever called `computeFingerprintSync` (one combined SHA-256) and `verifyGateSeal`/`verifyAllSeals` (single-gate aggregate) — there was **zero** reference to the per-file path. A user who wrote `kind: pattern` and used the CLI silently got `kind: single` behavior: one combined fingerprint, one seal per gate, no per-file rows, no per-file invalidation, no warning.

This wires `kind: pattern` through the full CLI surface. Single (non-pattern) gates behave **exactly** as before — the change is additive.

`Refs #130`. Also addresses the #140 cosmetic nit (retag CLI-internal git-policy helpers `@public` → `@internal`) and **supersedes #126** (which was only about per-file display rows; the deeper problem was the CLI never sealed/verified per-file at all).

## How each command routes a pattern gate

A shared helper, `packages/cli/src/utils/pattern-gate.ts`, translates a pattern gate into its per-file units for all four commands (`isPatternGate`, `computePatternFingerprintsSync`, `readPatternSealsByArtifactSync`, `verifyPatternGateSync`):

- **`seal`** — `processPatternGate` fingerprints each matched file (`computeFingerprintsPerFileSync`) and writes **one seal per file** via the **low-level per-file writer** `writeSealFileSync` at `.attest-it/seals/<gate>/<artifact>/<signer>.seal`. It deliberately does **not** route through the aggregate `writeSeals` (which prunes non-desired-set `.seal` files and would delete the siblings). Path segments reuse #70's collision-safe `slugifySegment` (via `writeSealFileSync`/`resolveSealsRoot` — no new slug fn). A file with a valid per-file seal is skipped unless `--force`.
- **`verify`** / **`status`** — expand a pattern gate into one `verifyPatternArtifactSeal` result **per matched file**, lexicographically ordered, in both the table renderer and `--json`. `verify`'s exit code already aggregates over per-file states, so one invalid file fails the gate while siblings stay valid.
- **`run --suite`** — `sealPatternGateForRun` seals each matched file independently (mirroring `seal`). `getAllSuiteStatuses` (used by `run --all`/interactive) rolls per-file results up into one suite status: `VALID` only when every matched file is valid.

## Per-file seals use the low-level writer + #70 `slugifySegment`

Per-file seals are written with `writeSealFileSync(root, { ...seal, artifactPath })` and read back with `listStoredSealsSync` (via the helper). `writeSealFileSync` composes the path from `slugifySegment(gateId)/slugifySegment(artifactPath)/slugifySegment(signer).seal`, and the aggregate read/write path deliberately ignores/never-prunes seals carrying an `artifactPath`. No aggregate `writeSeals` call is made for pattern gates.

## Column relabel

The `status`/`verify` table's label column carried gate-level (now also per-file) data but was mislabeled `Suite`. Renamed the header to `Gate` and the `TableRow.suite` field to `TableRow.gate`. Pattern per-file rows are labelled `<gateId> › <artifactPath>`.

## #140 nit + api-report

`readPolicyFromRef` / `GitRefPolicyError` / `RefPolicy` in `packages/cli/src/utils/git-policy.ts` retagged `@public` → `@internal` (the CLI ships no library API). The CLI package has **no** api-extractor config / api-report (only `core` and the `attest-it` umbrella do), so there is no CLI api-report to regenerate; `check:api-reports` passes unchanged.

## Acceptance criteria → tests

CLI-layer UAT against the **real built binary** as subprocesses (isolated `ATTEST_IT_HOME` + isolated VaultKeeper dir per #114), in `packages/cli/test/integration/pattern-gate.integration.test.ts`:

- **Criterion 1** (per-file seal/verify/status/run) — covered by *"seals one per-file seal per matched file; per-file rows; new file unsealed; one-byte flip isolates"* and *"run --suite over a pattern gate seals each matched file independently"*: a 2-file `kind: pattern` gate seals to **two** per-file `.seal` files (each carrying `artifactPath`).
- **Criterion 2** (per-file rows; new file unsealed; single-file flip — subsumes #126) — same test: `status --json`/`verify --json` show one row per file; adding a 3rd matching file with **no config change** shows it `MISSING`; a one-byte edit to one sealed file flips **only** that file to `FINGERPRINT_MISMATCH` while the sibling stays `VALID`.
- **Criterion 3** (CLI-layer integration, not just core) — the whole suite drives the real subprocess contract; all pattern assertions **fail against pre-fix code** (which produces one combined seal / one row), verified on a clean `origin/main` checkout.
- **Criterion 4** (`run --suite` consistent with `seal`/`verify`) — the run test asserts two per-file seals and per-file `verify --json` rows.
- **Regression** — *"a single (non-pattern) gate still produces one combined seal and one row"*: exactly one aggregate seal (no `artifactPath`) and one gate-keyed status row.

## Verification

- `pnpm run build` (required target): green across all 4 projects.
- `@attest-it/cli` `check` (eslint + tsc): 0 errors.
- `@attest-it/cli` full suite: **831 passed** (52 files), including the new pattern-gate UAT.
- `check:api-reports` and `check:formatting`: green.
