### PR TITLE
fix(ci): install native build toolchain in docker test image for node-pty

### DIFF
--- a/packages/cli/test/docker/Dockerfile
+++ b/packages/cli/test/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:20-alpine
 
-# Install git, bash, and pnpm for test scripts
-RUN apk add --no-cache git bash
+# Install git, bash, and pnpm for test scripts, plus the native build toolchain
+# node-gyp needs to compile node-pty (no musl/alpine prebuilds are published for it)
+RUN apk add --no-cache git bash python3 make g++
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 # Create testuser with specific UID/GID for consistency


### PR DESCRIPTION
## Summary

The `test-docker` job has been failing deterministically on `main`. Root cause: #112 added `node-pty@^1.1.0` as a devDependency of `packages/cli`. The docker test image (`packages/cli/test/docker/Dockerfile`) is based on `node:20-alpine`, and node-pty has no musl (alpine) prebuilds, so its install script falls back to `node-gyp rebuild`. That fails immediately with:

```
gyp ERR! find Python
```

because the image had no Python or C/C++ toolchain installed. Every `docker compose` scenario in `packages/cli/test/docker` fails at the image build step (`pnpm install --frozen-lockfile`), before any test scenario even runs.

## Fix

Extend the existing `apk add` layer in `packages/cli/test/docker/Dockerfile` to also install `python3 make g++`, the toolchain `node-gyp` needs to compile native addons on Alpine.

## Verification

Docker was available locally. I rebuilt the image's dependency-install layer directly (up through `RUN pnpm install --frozen-lockfile`, using `--no-cache` to force a real run rather than reuse a cached layer) and confirmed node-pty's install now succeeds:

```
node-pty@1.1.0 install: gyp info find Python using Python version 3.12.13 found at "/usr/bin/python3"
...
node-pty@1.1.0 install:   CXX(target) Release/obj.target/pty/src/unix/pty.o
node-pty@1.1.0 install:   SOLINK_MODULE(target) Release/obj.target/pty.node
node-pty@1.1.0 install: gyp info ok
```

No changeset included — this only touches test infrastructure, nothing published.

## Test plan

- [x] Confirmed the `pnpm install --frozen-lockfile` layer builds successfully with the toolchain installed (previously failed with `gyp ERR! find Python`)
- [ ] CI `test-docker` job passes on this PR