### PR TITLE
fix(ci): serialize act job execution to fix action-cache race in test-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,24 @@ jobs:
 
       - name: Install act
         run: |
-          curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
+          curl -s https://raw.githubusercontent.com/nektos/act/v0.2.89/install.sh | sudo bash -s v0.2.89
           # The install script puts act in ./bin/act, move it to /usr/local/bin
           sudo mv ./bin/act /usr/local/bin/act
 
       - name: Run action tests with act
         run: |
+          # act runs every job in the workflow file concurrently by default. All three
+          # jobs here need actions/setup-node@v4 and pnpm/action-setup@v4, which act
+          # clones on first use into the shared ~/.cache/act directory. Running them
+          # concurrently races: one job can `docker cp` that cache into its container
+          # while another job is still cloning it, producing spurious
+          # "lstat ...: no such file or directory" failures. --concurrent-jobs 1
+          # serializes job execution so the cache is always fully populated before
+          # it's read.
           act -W packages/github-action/test/act-workflows push \
             -P ubuntu-latest=catthehacker/ubuntu:act-latest \
-            --container-architecture linux/amd64
+            --container-architecture linux/amd64 \
+            --concurrent-jobs 1
 
   # Test CLI in Docker containers
   test-docker:


### PR DESCRIPTION
## Summary

The `test-action` job has failed 3 consecutive times on `main` with a non-deterministic race (confirmed from logs of runs 29654431630 and 29851679067).

The job runs a single `act` invocation covering all jobs in `packages/github-action/test/act-workflows/test-action.yml`:

```
act -W packages/github-action/test/act-workflows push \
  -P ubuntu-latest=catthehacker/ubuntu:act-latest \
  --container-architecture linux/amd64
```

`act` runs every job in that workflow file concurrently by default. All three jobs (`test-split-config-valid`, `test-policy-ref-filesystem`, `test-missing-attestation`) need `actions/setup-node@v4` and `pnpm/action-setup@v4`, which `act` clones on first use into the shared `~/.cache/act` directory. Running the jobs concurrently races: one job's `docker cp` of that cache directory into its container can happen while another job is still cloning it, producing:

```
lstat /home/runner/.cache/act/actions-setup-node@v4/<some file>: no such file or directory
❌ Failure - Main Setup Node.js
```

The specific missing file differs per run (`eslint.config.mjs`, `jest.config.js`), which is the signature of a partially-populated clone being read mid-write.

## Fix

Pass `--concurrent-jobs 1` to serialize job execution, so the shared action cache is always fully populated (clone finished) before the next job reads it via `docker cp`. This is a supported `act` flag (`act --help`), so the fix stays within `act`'s public, documented behavior rather than pre-populating the cache directory by hand.

While in the file, also pinned the `act` install to a specific released version (`v0.2.89`) instead of curling `master`'s unpinned `install.sh`, since an unpinned install can silently change behavior across CI runs.

## Verification

Docker and `act` (v0.2.84) were available locally. With a cold `~/.cache/act`:

- **Without the fix**: log output shows all three jobs' `git clone` and `docker cp` of the shared action cache directories fully interleaved (job A starts cloning while job B is already `docker cp`-ing the same directory).
- **With `--concurrent-jobs 1`**: jobs run strictly one at a time; log output shows a complete run of one job (clone, `docker cp`, exec) before the next job starts anything — no interleaving.

Locally, both runs also hit an unrelated `node: executable file not found in $PATH` failure inside the `setup-node` action — this happens identically with and without `--concurrent-jobs 1`, and is a known consequence of running an amd64 image via QEMU emulation on Apple Silicon locally; it isn't present on GitHub's native amd64 Ubuntu runners, so it's unrelated to this fix. The relevant, load-bearing evidence is the elimination of the interleaved cache access, since that interleaving is the actual race that produces the CI failure.

No changeset included — this only touches a CI workflow file, nothing published.

## Test plan

- [x] Confirmed jobs no longer interleave access to the shared act action cache with `--concurrent-jobs 1`
- [ ] CI `test-action` job passes deterministically on this PR (and on a subsequent run, to rule out flakiness)