### PR TITLE
Guard against accidental major/1.0 version bumps in changesets

### DIFF
--- a/.changeset/eliminate-legacy-config-generations.md
+++ b/.changeset/eliminate-legacy-config-generations.md
@@ -1,11 +1,13 @@
 ---
-'@attest-it/core': major
-'@attest-it/cli': major
+'@attest-it/core': minor
+'@attest-it/cli': minor
 ---
 
 Eliminate legacy config generations: enforce a single canonical split-config model.
 
-This is a breaking change that removes every remaining path around trust-anchored, split configuration:
+attest-it is still in the 0.x series, where breaking changes are expected and are shipped as
+`minor` — see CONTRIBUTING.md. This one removes every remaining path around trust-anchored,
+split configuration:
 
 - **Silent unified-config fallback removed.** `loadSplitConfig`/`loadSplitConfigSync` no longer transparently load a legacy unified `config.yaml` when `policy.yaml` is absent. A repo with only a unified config now fails to load with an explicit error pointing at the migration path, instead of silently behaving as if it had already migrated.
 - **`attest-it init --migrate` added.** A one-shot, migrex-driven migration converts an existing unified `config.yaml` into split `policy.yaml` + `config.yaml` (operational), reusing the existing migration graph infrastructure.

--- a/.changeset/rename-fingerprint-options-fields.md
+++ b/.changeset/rename-fingerprint-options-fields.md
@@ -1,9 +1,12 @@
 ---
-'@attest-it/core': major
-'attest-it': major
+'@attest-it/core': minor
+'attest-it': minor
 ---
 
 Rename `FingerprintOptions` fields to align with `GateConfig.fingerprint`: `packages` → `paths`, `ignore` → `exclude`.
+
+attest-it is still in the 0.x series, where breaking changes are expected and are shipped as
+`minor` — see CONTRIBUTING.md.
 
 Previously `computeFingerprint`/`computeFingerprintSync` took `{ packages, ignore, baseDir }`, while a gate's own fingerprint configuration used `{ paths, exclude }` — every call site had to rename fields when passing a gate's fingerprint config into `computeFingerprint`. `FingerprintOptions` now matches:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: scripts/check-major-bump-guard.mjs shells out to
+          # `changeset status`, which needs to resolve the merge-base against
+          # `main` — a shallow (default depth-1) checkout has no local `main`
+          # ref/history for that, and the changeset CLI throws.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Full history: scripts/check-major-bump-guard.mjs shells out to
-          # `changeset status`, which needs to resolve the merge-base against
-          # `main` — a shallow (default depth-1) checkout has no local `main`
-          # ref/history for that, and the changeset CLI throws.
-          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Check no unsafe policy-ref overrides in workflows
         run: node scripts/check-policy-ref-guard.mjs
 
+      - name: Check major-bump guard self-test
+        run: node scripts/check-major-bump-guard.mjs --self-test
+
+      - name: Check no major/1.0 version bumps in changeset release plan
+        run: node scripts/check-major-bump-guard.mjs
+
   # Test the GitHub Action using act (runs action in simulated GitHub environment)
   test-action:
     runs-on: ubuntu-latest

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+node scripts/check-major-bump-guard.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,23 @@ Select the packages affected and describe your changes. Changesets are used to:
 
 ### Changeset Types
 
-- **Major**: Breaking changes (e.g., removing APIs, changing behavior)
-- **Minor**: New features (e.g., adding APIs, new functionality)
+- **Major**: Reserved. `attest-it` is still in the `0.x` series deliberately — the API surface
+  has not stabilized and we are not ready to commit to post-`0.x` stability guarantees. A
+  `major` changeset bumps a `0.x` package straight to `1.0.0`, and that decision belongs to the
+  repo owner alone. **A breaking change, no matter how large, is not by itself justification for
+  a `major` bump.**
+- **Minor**: New features, and breaking changes. While `attest-it` is `0.x`, breaking changes are
+  expected and are shipped as `minor` — describe the break clearly in the changeset body so
+  consumers reading the release notes understand what changed and how to adapt.
 - **Patch**: Bug fixes, docs, refactors
+
+`.changeset/config.json` links `@attest-it/core`, `@attest-it/cli`, and `attest-it` together, so
+a bump on any one of them applies to all three at the same level.
+
+A guard (`scripts/check-major-bump-guard.mjs`) inspects the computed changeset release plan —
+not just the changeset you just wrote — and fails, both locally on commit and in CI, if any
+package would bump to `major`. If it fails, mark the changeset(s) `minor` instead; do not bypass
+the guard without the repo owner's explicit sign-off.
 
 ## Release Process
 

--- a/scripts/check-major-bump-guard.mjs
+++ b/scripts/check-major-bump-guard.mjs
@@ -18,7 +18,8 @@
  */
 
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -76,8 +77,46 @@ export function formatFailureMessage(majorBumps) {
   ].join('\n')
 }
 
-function getReleasePlan(repoRoot) {
-  const changesetBin = join(repoRoot, 'node_modules', '.bin', 'changeset')
+/**
+ * Parse and shape-validate the JSON `changeset status --output` writes. This
+ * never trusts the file blindly: a missing `releases` array, or a release
+ * entry missing `name`/`type`, is treated the same as invalid JSON — all of
+ * it means the plan can't be relied on.
+ *
+ * @param {string} rawText
+ * @returns {{ releases: Array<{ name: string, type: string, oldVersion: string, newVersion: string }> }}
+ */
+export function parseReleasePlanJson(rawText) {
+  let parsed
+  try {
+    parsed = JSON.parse(rawText)
+  } catch (error) {
+    throw new Error(
+      `release plan output is not valid JSON (${error instanceof Error ? error.message : String(error)})`,
+    )
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || !Array.isArray(parsed.releases)) {
+    throw new Error('release plan JSON has no `releases` array')
+  }
+  for (const release of parsed.releases) {
+    if (typeof release?.name !== 'string' || typeof release?.type !== 'string') {
+      throw new Error('release plan JSON contains a release entry missing `name`/`type`')
+    }
+  }
+  return parsed
+}
+
+/**
+ * Run `changeset status --output=<file>` and return the parsed, validated
+ * release plan. `runChangesetStatus` is injectable so self-test can exercise
+ * every indeterminate path (binary exits non-zero, output file never
+ * written, output file empty/malformed) without shelling out for real.
+ *
+ * @param {{ repoRoot: string, runChangesetStatus?: (repoRoot: string, outFileRelative: string) => void }} params
+ * @returns {{ releases: Array<{ name: string, type: string, oldVersion: string, newVersion: string }> }}
+ */
+export function loadReleasePlan({ repoRoot, runChangesetStatus = runChangesetStatusForReal }) {
   // `changeset status --output` resolves relative to `cwd`, so the arg and
   // the path we read back must agree on that relative form.
   const outFileRelative = join(
@@ -87,19 +126,73 @@ function getReleasePlan(repoRoot) {
   const outFile = join(repoRoot, outFileRelative)
   mkdirSync(join(repoRoot, 'tmp'), { recursive: true })
   try {
-    execFileSync(changesetBin, ['status', `--output=${outFileRelative}`], {
-      cwd: repoRoot,
-      stdio: ['ignore', 'ignore', 'inherit'],
-    })
-    return JSON.parse(readFileSync(outFile, 'utf8'))
+    runChangesetStatus(repoRoot, outFileRelative)
+
+    let rawText
+    try {
+      rawText = readFileSync(outFile, 'utf8')
+    } catch (error) {
+      throw new Error(
+        `release plan output file was not produced (${error instanceof Error ? error.message : String(error)})`,
+      )
+    }
+    return parseReleasePlanJson(rawText)
   } finally {
     rmSync(outFile, { force: true })
   }
 }
 
+function runChangesetStatusForReal(repoRoot, outFileRelative) {
+  const changesetBin = join(repoRoot, 'node_modules', '.bin', 'changeset')
+  execFileSync(changesetBin, ['status', `--output=${outFileRelative}`], {
+    cwd: repoRoot,
+    stdio: ['ignore', 'ignore', 'inherit'],
+  })
+}
+
+/**
+ * Build the message shown when the guard could not compute a release plan
+ * at all — e.g. `changeset status` exited non-zero, or produced no/malformed
+ * output. This must never be confused with "a major bump was found": it's
+ * the opposite problem, an inability to certify anything either way, and it
+ * must fail closed rather than silently pass with an empty major-bump list.
+ *
+ * @param {unknown} error
+ * @returns {string}
+ */
+export function formatCouldNotVerifyMessage(error) {
+  const reason = error instanceof Error ? error.message : String(error)
+
+  return [
+    'Major version bump guard could not verify the release plan.',
+    '',
+    'This is NOT a report that a major bump was found. It means the guard was unable to',
+    'compute the changeset release plan at all, so it cannot certify that no major/1.0 bump',
+    'is present. An indeterminate result must be treated as a failure, not a pass — silently',
+    'passing here is exactly the failure mode this guard exists to prevent.',
+    '',
+    `Reason: ${reason}`,
+    '',
+    'Common causes: `changeset status` could not resolve the merge-base against the base',
+    'branch (e.g. a shallow git checkout with no local `main` ref/history available), the',
+    '`changeset` CLI is missing or crashed, or its JSON output was empty/malformed.',
+    '',
+    'Fix the underlying `changeset status` failure (see the reason above) and re-run this',
+    'check — do not bypass it based on this message alone.',
+  ].join('\n')
+}
+
 function runRealCheck() {
   const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
-  const releasePlan = getReleasePlan(repoRoot)
+
+  let releasePlan
+  try {
+    releasePlan = loadReleasePlan({ repoRoot })
+  } catch (error) {
+    console.error(formatCouldNotVerifyMessage(error))
+    process.exit(1)
+  }
+
   const majorBumps = findMajorBumps(releasePlan)
 
   if (majorBumps.length > 0) {
@@ -181,6 +274,71 @@ function runSelfTest() {
   const mentions1_0 = message.includes('1.0')
   console.log(`${mentions1_0 ? 'PASS' : 'FAIL'}: failure message names the 1.0 target`)
   if (!mentions1_0) failed = true
+
+  // Indeterminate paths: the guard must fail closed on each of these — never
+  // fall through to "no major bumps found" — and the failure must use the
+  // distinct could-not-verify message, not the major-bump-found message.
+  const indeterminateCases = [
+    {
+      name: 'changeset status exits non-zero',
+      runChangesetStatus: () => {
+        throw new Error('simulated: changeset status exited with code 1')
+      },
+    },
+    {
+      name: 'plan file is never written',
+      runChangesetStatus: () => {
+        // Succeeds but writes nothing — mirrors a `changeset` version that
+        // silently drops --output, or a permissions failure that doesn't throw.
+      },
+    },
+    {
+      name: 'plan file is empty',
+      runChangesetStatus: (repoRoot, outFileRelative) => {
+        writeFileSync(join(repoRoot, outFileRelative), '')
+      },
+    },
+    {
+      name: 'plan file is malformed JSON',
+      runChangesetStatus: (repoRoot, outFileRelative) => {
+        writeFileSync(join(repoRoot, outFileRelative), '{ not valid json')
+      },
+    },
+    {
+      name: 'plan file is valid JSON but missing `releases`',
+      runChangesetStatus: (repoRoot, outFileRelative) => {
+        writeFileSync(join(repoRoot, outFileRelative), JSON.stringify({ changesets: [] }))
+      },
+    },
+  ]
+
+  for (const testCase of indeterminateCases) {
+    const scratchRepoRoot = mkdtempSync(join(tmpdir(), 'major-bump-guard-self-test-'))
+    let threw = false
+    let usedCouldNotVerifyMessage = false
+    try {
+      loadReleasePlan({
+        repoRoot: scratchRepoRoot,
+        runChangesetStatus: testCase.runChangesetStatus,
+      })
+    } catch (error) {
+      threw = true
+      // formatCouldNotVerifyMessage must be able to render this error without
+      // throwing itself, and the rendered message must be distinguishable
+      // from "a major bump was found".
+      const message = formatCouldNotVerifyMessage(error)
+      usedCouldNotVerifyMessage =
+        message.includes('could not verify') &&
+        !message.includes('Major version bump guard failed.')
+    } finally {
+      rmSync(scratchRepoRoot, { recursive: true, force: true })
+    }
+    const ok = threw && usedCouldNotVerifyMessage
+    console.log(
+      `${ok ? 'PASS' : 'FAIL'}: indeterminate path — ${testCase.name} — fails closed with could-not-verify message`,
+    )
+    if (!ok) failed = true
+  }
 
   if (failed) {
     console.error('\nSelf-test failed: guard logic does not match expected behavior.')

--- a/scripts/check-major-bump-guard.mjs
+++ b/scripts/check-major-bump-guard.mjs
@@ -66,13 +66,14 @@ export function parseChangesetFrontMatter(content, fileName) {
 }
 
 /**
- * Parse `.changeset/config.json`'s `linked` groups (defaulting to `[]` when
- * absent, matching @changesets/config's own default).
+ * Parse `.changeset/config.json`'s `linked` groups and `ignore` list
+ * (defaulting both to `[]` when absent, matching @changesets/config's own
+ * defaults).
  *
  * @param {string} configJsonText
- * @returns {string[][]}
+ * @returns {{ linkedGroups: string[][], ignoredPackages: string[] }}
  */
-export function parseLinkedGroups(configJsonText) {
+export function parseChangesetConfig(configJsonText) {
   let parsed
   try {
     parsed = JSON.parse(configJsonText)
@@ -86,27 +87,45 @@ export function parseLinkedGroups(configJsonText) {
   }
 
   const linked = parsed.linked ?? []
-  const isValid =
+  const linkedIsValid =
     Array.isArray(linked) &&
     linked.every((group) => Array.isArray(group) && group.every((name) => typeof name === 'string'))
-  if (!isValid) {
+  if (!linkedIsValid) {
     throw new Error('.changeset/config.json `linked` is not an array of string arrays')
   }
-  return linked
+
+  const ignore = parsed.ignore ?? []
+  const ignoreIsValid = Array.isArray(ignore) && ignore.every((name) => typeof name === 'string')
+  if (!ignoreIsValid) {
+    throw new Error('.changeset/config.json `ignore` is not an array of strings')
+  }
+
+  return { linkedGroups: linked, ignoredPackages: ignore }
 }
 
 /**
- * Given every pending changeset's release entries and the `linked` groups,
- * return the sorted list of package names that would end up `major` — after
- * expanding through linked groups, since a `major` on any member propagates
- * to every member.
+ * Given every pending changeset's release entries, the `linked` groups, and
+ * the `ignore` list, return the sorted list of package names that would end
+ * up `major` — after expanding through linked groups (a `major` on any
+ * member propagates to every member) and excluding ignored packages, since
+ * changesets never versions or publishes an ignored package regardless of
+ * its own annotation or linked-group membership. A `major` changeset that
+ * targets only an ignored package can never actually produce a 1.0 release,
+ * so reporting it would be a false positive; conversely, an ignored package
+ * must not be allowed to suppress propagation to its non-ignored linked
+ * siblings.
  *
  * @param {Array<{ name: string, type: string }>} allReleases
  * @param {string[][]} linkedGroups
+ * @param {string[]} [ignoredPackages]
  * @returns {string[]}
  */
-export function computeMajorBumpPackages(allReleases, linkedGroups) {
+export function computeMajorBumpPackages(allReleases, linkedGroups, ignoredPackages = []) {
   const majors = new Set()
+  // Seed from every `major` release, including ignored packages: an ignored
+  // package that's (unusually) also linked must still be able to trigger
+  // propagation to its non-ignored siblings — only the final report filters
+  // ignored packages out, so that propagation isn't silently suppressed.
   for (const release of allReleases) {
     if (release.type === 'major') majors.add(release.name)
   }
@@ -115,6 +134,7 @@ export function computeMajorBumpPackages(allReleases, linkedGroups) {
       for (const pkg of group) majors.add(pkg)
     }
   }
+  for (const pkg of ignoredPackages) majors.delete(pkg)
   return [...majors].sort()
 }
 
@@ -126,7 +146,7 @@ export function computeMajorBumpPackages(allReleases, linkedGroups) {
  * problem can never be mistaken for "no changesets pending".
  *
  * @param {string} repoRoot
- * @returns {{ allReleases: Array<{ name: string, type: string }>, linkedGroups: string[][] }}
+ * @returns {{ allReleases: Array<{ name: string, type: string }>, linkedGroups: string[][], ignoredPackages: string[] }}
  */
 export function loadReleaseState(repoRoot) {
   const changesetDir = join(repoRoot, '.changeset')
@@ -167,7 +187,7 @@ export function loadReleaseState(repoRoot) {
     )
   }
 
-  return { allReleases, linkedGroups: parseLinkedGroups(configText) }
+  return { allReleases, ...parseChangesetConfig(configText) }
 }
 
 /**
@@ -214,18 +234,20 @@ function bumpMajorVersion(oldVersion) {
  * Resolve which packages would bump to `major`, enriched with an old -> new
  * version preview where the current version is known.
  *
- * @param {{ allReleases: Array<{ name: string, type: string }>, linkedGroups: string[][] }} releaseState
+ * @param {{ allReleases: Array<{ name: string, type: string }>, linkedGroups: string[][], ignoredPackages: string[] }} releaseState
  * @param {Map<string, string>} [versions]
  * @returns {Array<{ name: string, oldVersion?: string, newVersion?: string }>}
  */
 export function findMajorBumps(releaseState, versions = new Map()) {
-  return computeMajorBumpPackages(releaseState.allReleases, releaseState.linkedGroups).map(
-    (name) => {
-      const oldVersion = versions.get(name)
-      const newVersion = oldVersion ? bumpMajorVersion(oldVersion) : undefined
-      return { name, oldVersion, newVersion }
-    },
-  )
+  return computeMajorBumpPackages(
+    releaseState.allReleases,
+    releaseState.linkedGroups,
+    releaseState.ignoredPackages,
+  ).map((name) => {
+    const oldVersion = versions.get(name)
+    const newVersion = oldVersion ? bumpMajorVersion(oldVersion) : undefined
+    return { name, oldVersion, newVersion }
+  })
 }
 
 /**
@@ -328,14 +350,14 @@ function runRealCheck() {
  * files) under a fresh scratch repo root, for self-test cases to run the
  * real `loadReleaseState` against — not hand-built plan objects.
  *
- * @param {{ linked?: string[][], changesets: Record<string, string> }} fixture
+ * @param {{ linked?: string[][], ignore?: string[], changesets: Record<string, string> }} fixture
  * @returns {string} the scratch repo root
  */
-function writeFixtureRepo({ linked = [], changesets }) {
+function writeFixtureRepo({ linked = [], ignore = [], changesets }) {
   const repoRoot = mkdtempSync(join(tmpdir(), 'major-bump-guard-self-test-'))
   const changesetDir = join(repoRoot, '.changeset')
   mkdirSync(changesetDir, { recursive: true })
-  writeFileSync(join(changesetDir, 'config.json'), JSON.stringify({ linked }))
+  writeFileSync(join(changesetDir, 'config.json'), JSON.stringify({ linked, ignore }))
   writeFileSync(join(changesetDir, 'README.md'), '# Changesets\n')
   for (const [fileName, content] of Object.entries(changesets)) {
     writeFileSync(join(changesetDir, fileName), content)
@@ -380,6 +402,35 @@ function runSelfTest() {
       },
       expectedNames: ['@attest-it/example-embedder'],
     },
+    {
+      // Real config: .changeset/config.json sets ignore: ["@attest-it/github-action"].
+      // Changesets never versions or publishes an ignored package, so a major
+      // changeset that targets ONLY an ignored package must not be reported —
+      // doing so would be a false positive (issue raised in #155 review).
+      name: 'major on an ignored-only package is not reported (would be a false positive)',
+      fixture: {
+        linked: linkedGroups,
+        ignore: ['@attest-it/github-action'],
+        changesets: {
+          'a.md': "---\n'@attest-it/github-action': major\n---\n\nbreaking change\n",
+        },
+      },
+      expectedNames: [],
+    },
+    {
+      // If an ignored package is (unusually) also a member of a linked group,
+      // it must not suppress propagation to its non-ignored linked siblings —
+      // they still get published together and still need to be caught.
+      name: 'an ignored package inside a linked group still propagates to its non-ignored siblings',
+      fixture: {
+        linked: linkedGroups,
+        ignore: ['attest-it'],
+        changesets: {
+          'a.md': "---\n'attest-it': major\n---\n\nbreaking change\n",
+        },
+      },
+      expectedNames: ['@attest-it/cli', '@attest-it/core'],
+    },
   ]
 
   for (const testCase of parsingCases) {
@@ -387,7 +438,11 @@ function runSelfTest() {
     let gotNames
     try {
       const releaseState = loadReleaseState(repoRoot)
-      gotNames = computeMajorBumpPackages(releaseState.allReleases, releaseState.linkedGroups)
+      gotNames = computeMajorBumpPackages(
+        releaseState.allReleases,
+        releaseState.linkedGroups,
+        releaseState.ignoredPackages,
+      )
     } finally {
       rmSync(repoRoot, { recursive: true, force: true })
     }

--- a/scripts/check-major-bump-guard.mjs
+++ b/scripts/check-major-bump-guard.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * Guards against issue #154: an agent-authored changeset annotated `major`
+ * would push a 0.x package straight to 1.0.0. attest-it stays in the 0.x
+ * series deliberately (see CONTRIBUTING.md) — breaking changes are expected
+ * there and are expressed as `minor`, never `major`.
+ *
+ * .changeset/config.json links @attest-it/core, @attest-it/cli, and
+ * attest-it together (`linked`), so a `major` on any one of them propagates
+ * to all three. Grepping `.changeset/*.md` front-matter would under-report
+ * that blast radius, so this guard inspects the *computed* release plan
+ * instead — the same plan `changeset version` would apply — via
+ * `changeset status --output`.
+ *
+ * Usage:
+ *   node scripts/check-major-bump-guard.mjs             # check the real release plan
+ *   node scripts/check-major-bump-guard.mjs --self-test  # verify the guard's own logic
+ */
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Find every release in a computed changeset release plan that would bump
+ * a package to a `major` version.
+ *
+ * @param {{ releases: Array<{ name: string, type: string, oldVersion: string, newVersion: string }> }} releasePlan
+ * @returns {Array<{ name: string, oldVersion: string, newVersion: string }>}
+ */
+export function findMajorBumps(releasePlan) {
+  return releasePlan.releases
+    .filter((release) => release.type === 'major')
+    .map(({ name, oldVersion, newVersion }) => ({ name, oldVersion, newVersion }))
+}
+
+/**
+ * Build the message shown to whoever (human or agent) tripped the guard. The
+ * reader is likely an agent that has convinced itself a large breaking
+ * change justifies a 1.0 bump — the message exists to rebut that directly
+ * and redirect to the correct action.
+ *
+ * @param {Array<{ name: string, oldVersion: string, newVersion: string }>} majorBumps
+ * @returns {string}
+ */
+export function formatFailureMessage(majorBumps) {
+  const targets = majorBumps
+    .map((release) => `  - ${release.name}: ${release.oldVersion} -> ${release.newVersion}`)
+    .join('\n')
+
+  return [
+    'Major version bump guard failed.',
+    '',
+    'attest-it stays in the 0.x series deliberately — the API surface has not stabilized and',
+    'we are not ready to commit to post-0.x stability guarantees. A breaking change, no matter',
+    'how large, is NOT justification for a major/1.0 bump on its own. In the 0.x series,',
+    'breaking changes are expected, and the correct way to express one is `minor`, not `major`.',
+    '',
+    'The current changeset release plan computes a major bump for:',
+    '',
+    targets,
+    '',
+    '.changeset/config.json links @attest-it/core, @attest-it/cli, and attest-it together, so a',
+    'major on any one of them propagates to all three — the list above already reflects that.',
+    '',
+    'What to do instead:',
+    '  1. In the offending changeset(s) under .changeset/*.md, change the front-matter bump type',
+    '     from `major` to `minor`.',
+    '  2. Describe the breaking change clearly in the changeset body, so consumers reading the',
+    "     0.x release notes understand what changed and how to adapt. That's how breaking changes",
+    '     are communicated pre-1.0 — through the changelog, not through the major version number.',
+    '',
+    'Taking attest-it to 1.0 is a deliberate decision made by the repo owner alone, by bypassing',
+    'this check on merge. It is never made implicitly by a changeset annotation.',
+  ].join('\n')
+}
+
+function getReleasePlan(repoRoot) {
+  const changesetBin = join(repoRoot, 'node_modules', '.bin', 'changeset')
+  // `changeset status --output` resolves relative to `cwd`, so the arg and
+  // the path we read back must agree on that relative form.
+  const outFileRelative = join(
+    'tmp',
+    `major-bump-guard-${String(process.pid)}-${String(Date.now())}.json`,
+  )
+  const outFile = join(repoRoot, outFileRelative)
+  mkdirSync(join(repoRoot, 'tmp'), { recursive: true })
+  try {
+    execFileSync(changesetBin, ['status', `--output=${outFileRelative}`], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'ignore', 'inherit'],
+    })
+    return JSON.parse(readFileSync(outFile, 'utf8'))
+  } finally {
+    rmSync(outFile, { force: true })
+  }
+}
+
+function runRealCheck() {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+  const releasePlan = getReleasePlan(repoRoot)
+  const majorBumps = findMajorBumps(releasePlan)
+
+  if (majorBumps.length > 0) {
+    console.error(formatFailureMessage(majorBumps))
+    process.exit(1)
+  }
+
+  console.log('No major version bumps found in the computed changeset release plan.')
+}
+
+function runSelfTest() {
+  const onlyMinorAndPatchPlan = {
+    releases: [
+      { name: '@attest-it/core', type: 'minor', oldVersion: '0.10.1', newVersion: '0.11.0' },
+      { name: '@attest-it/cli', type: 'minor', oldVersion: '0.10.1', newVersion: '0.11.0' },
+      { name: 'attest-it', type: 'minor', oldVersion: '0.10.1', newVersion: '0.11.0' },
+      {
+        name: '@attest-it/example-embedder',
+        type: 'patch',
+        oldVersion: '0.0.0',
+        newVersion: '0.0.1',
+      },
+      { name: '@attest-it/github-action', type: 'none', oldVersion: '0.0.1', newVersion: '0.0.1' },
+    ],
+  }
+
+  // Mirrors what `changeset status` actually reports for this repo's `linked`
+  // config: a `major` changeset on one package in the group propagates to
+  // every package in it, so the computed plan lists all three as `major`.
+  const linkedMajorPlan = {
+    releases: [
+      { name: '@attest-it/cli', type: 'major', oldVersion: '0.10.1', newVersion: '1.0.0' },
+      { name: 'attest-it', type: 'major', oldVersion: '0.10.1', newVersion: '1.0.0' },
+      { name: '@attest-it/core', type: 'major', oldVersion: '0.10.1', newVersion: '1.0.0' },
+      {
+        name: '@attest-it/example-embedder',
+        type: 'patch',
+        oldVersion: '0.0.0',
+        newVersion: '0.0.1',
+      },
+    ],
+  }
+
+  const cases = [
+    {
+      name: 'plan with only minor/patch bumps passes',
+      plan: onlyMinorAndPatchPlan,
+      expectedNames: [],
+    },
+    {
+      name: 'plan with a major bump on a linked group is detected as affecting all linked packages',
+      plan: linkedMajorPlan,
+      expectedNames: ['@attest-it/cli', 'attest-it', '@attest-it/core'],
+    },
+  ]
+
+  let failed = false
+  for (const testCase of cases) {
+    const majorBumps = findMajorBumps(testCase.plan)
+    const gotNames = majorBumps.map((r) => r.name)
+    const ok =
+      gotNames.length === testCase.expectedNames.length &&
+      testCase.expectedNames.every((name) => gotNames.includes(name))
+    console.log(
+      `${ok ? 'PASS' : 'FAIL'}: ${testCase.name} — expected=[${testCase.expectedNames.join(', ')}], got=[${gotNames.join(', ')}]`,
+    )
+    if (!ok) failed = true
+  }
+
+  // Negative test: the failure message must name every offending package, not
+  // just report a bare exit code — the message is the deliverable (issue #154).
+  const message = formatFailureMessage(findMajorBumps(linkedMajorPlan))
+  const namesAllPresent = ['@attest-it/cli', 'attest-it', '@attest-it/core'].every((name) =>
+    message.includes(name),
+  )
+  console.log(`${namesAllPresent ? 'PASS' : 'FAIL'}: failure message names every offending package`)
+  if (!namesAllPresent) failed = true
+
+  const mentions1_0 = message.includes('1.0')
+  console.log(`${mentions1_0 ? 'PASS' : 'FAIL'}: failure message names the 1.0 target`)
+  if (!mentions1_0) failed = true
+
+  if (failed) {
+    console.error('\nSelf-test failed: guard logic does not match expected behavior.')
+    process.exit(1)
+  }
+  console.log('\nSelf-test passed: guard correctly detects major bumps and linked propagation.')
+}
+
+const args = process.argv.slice(2)
+if (args.includes('--self-test')) {
+  runSelfTest()
+} else {
+  runRealCheck()
+}

--- a/scripts/check-major-bump-guard.mjs
+++ b/scripts/check-major-bump-guard.mjs
@@ -7,33 +7,225 @@
  *
  * .changeset/config.json links @attest-it/core, @attest-it/cli, and
  * attest-it together (`linked`), so a `major` on any one of them propagates
- * to all three. Grepping `.changeset/*.md` front-matter would under-report
- * that blast radius, so this guard inspects the *computed* release plan
- * instead — the same plan `changeset version` would apply — via
- * `changeset status --output`.
+ * to all three. This guard reads `.changeset/*.md` front-matter directly and
+ * expands it through `.changeset/config.json`'s `linked` groups itself —
+ * that expansion is what makes plain front-matter parsing report the full
+ * blast radius rather than under-reporting it.
+ *
+ * Deliberately does NOT shell out to `changeset status` (or any @changesets/*
+ * package): that path needs git history to resolve a merge-base against the
+ * base branch, which a shallow pull_request CI checkout doesn't have and
+ * which has its own failure modes inside git worktrees. Reading local files
+ * needs no git history at all, so the guard behaves identically in every
+ * context it runs in — PR CI, push CI, and husky pre-commit in a worktree.
  *
  * Usage:
- *   node scripts/check-major-bump-guard.mjs             # check the real release plan
+ *   node scripts/check-major-bump-guard.mjs             # check pending changesets
  *   node scripts/check-major-bump-guard.mjs --self-test  # verify the guard's own logic
  */
 
-import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { readFileSync, readdirSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 /**
- * Find every release in a computed changeset release plan that would bump
- * a package to a `major` version.
+ * Parse a single changeset file's YAML-ish front matter into `{ name, type }`
+ * release entries. Deliberately narrow — it matches exactly the shape
+ * `@changesets/cli` writes (quoted-or-unquoted package name, `:`, bump type)
+ * rather than pulling in a general YAML parser, mirroring the other guard
+ * script in this repo (scripts/check-policy-ref-guard.mjs).
  *
- * @param {{ releases: Array<{ name: string, type: string, oldVersion: string, newVersion: string }> }} releasePlan
- * @returns {Array<{ name: string, oldVersion: string, newVersion: string }>}
+ * @param {string} content - Full text of a `.changeset/*.md` file.
+ * @param {string} fileName - Used only for error messages.
+ * @returns {Array<{ name: string, type: 'major' | 'minor' | 'patch' | 'none' }>}
  */
-export function findMajorBumps(releasePlan) {
-  return releasePlan.releases
-    .filter((release) => release.type === 'major')
-    .map(({ name, oldVersion, newVersion }) => ({ name, oldVersion, newVersion }))
+export function parseChangesetFrontMatter(content, fileName) {
+  const lines = content.split('\n')
+  if (lines[0]?.trim() !== '---') {
+    throw new Error(`${fileName}: missing opening \`---\` front-matter delimiter`)
+  }
+  const closingIndex = lines.slice(1).findIndex((line) => line.trim() === '---')
+  if (closingIndex === -1) {
+    throw new Error(`${fileName}: missing closing \`---\` front-matter delimiter`)
+  }
+
+  const releases = []
+  for (const line of lines.slice(1, 1 + closingIndex)) {
+    if (line.trim() === '') continue
+    const match = /^\s*["']?([^"':]+)["']?\s*:\s*(major|minor|patch|none)\s*$/.exec(line)
+    if (!match) {
+      throw new Error(`${fileName}: could not parse front-matter line: ${JSON.stringify(line)}`)
+    }
+    releases.push({ name: match[1].trim(), type: match[2] })
+  }
+  if (releases.length === 0) {
+    throw new Error(`${fileName}: front matter has no package entries`)
+  }
+  return releases
+}
+
+/**
+ * Parse `.changeset/config.json`'s `linked` groups (defaulting to `[]` when
+ * absent, matching @changesets/config's own default).
+ *
+ * @param {string} configJsonText
+ * @returns {string[][]}
+ */
+export function parseLinkedGroups(configJsonText) {
+  let parsed
+  try {
+    parsed = JSON.parse(configJsonText)
+  } catch (error) {
+    throw new Error(
+      `.changeset/config.json is not valid JSON (${error instanceof Error ? error.message : String(error)})`,
+    )
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error('.changeset/config.json is not a JSON object')
+  }
+
+  const linked = parsed.linked ?? []
+  const isValid =
+    Array.isArray(linked) &&
+    linked.every((group) => Array.isArray(group) && group.every((name) => typeof name === 'string'))
+  if (!isValid) {
+    throw new Error('.changeset/config.json `linked` is not an array of string arrays')
+  }
+  return linked
+}
+
+/**
+ * Given every pending changeset's release entries and the `linked` groups,
+ * return the sorted list of package names that would end up `major` — after
+ * expanding through linked groups, since a `major` on any member propagates
+ * to every member.
+ *
+ * @param {Array<{ name: string, type: string }>} allReleases
+ * @param {string[][]} linkedGroups
+ * @returns {string[]}
+ */
+export function computeMajorBumpPackages(allReleases, linkedGroups) {
+  const majors = new Set()
+  for (const release of allReleases) {
+    if (release.type === 'major') majors.add(release.name)
+  }
+  for (const group of linkedGroups) {
+    if (group.some((pkg) => majors.has(pkg))) {
+      for (const pkg of group) majors.add(pkg)
+    }
+  }
+  return [...majors].sort()
+}
+
+/**
+ * Read every pending changeset under `.changeset/*.md` (skipping `README.md`)
+ * plus `.changeset/config.json`, and return their parsed, unexpanded state.
+ * Throws — never returns a partial/empty result — if the directory, config,
+ * or any individual changeset file can't be read or parsed, so a filesystem
+ * problem can never be mistaken for "no changesets pending".
+ *
+ * @param {string} repoRoot
+ * @returns {{ allReleases: Array<{ name: string, type: string }>, linkedGroups: string[][] }}
+ */
+export function loadReleaseState(repoRoot) {
+  const changesetDir = join(repoRoot, '.changeset')
+
+  let entries
+  try {
+    entries = readdirSync(changesetDir, { withFileTypes: true })
+  } catch (error) {
+    throw new Error(
+      `could not read .changeset directory (${error instanceof Error ? error.message : String(error)})`,
+    )
+  }
+
+  const changesetFileNames = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md') && entry.name !== 'README.md')
+    .map((entry) => entry.name)
+    .sort()
+
+  const allReleases = []
+  for (const fileName of changesetFileNames) {
+    let content
+    try {
+      content = readFileSync(join(changesetDir, fileName), 'utf8')
+    } catch (error) {
+      throw new Error(
+        `could not read .changeset/${fileName} (${error instanceof Error ? error.message : String(error)})`,
+      )
+    }
+    allReleases.push(...parseChangesetFrontMatter(content, `.changeset/${fileName}`))
+  }
+
+  let configText
+  try {
+    configText = readFileSync(join(changesetDir, 'config.json'), 'utf8')
+  } catch (error) {
+    throw new Error(
+      `could not read .changeset/config.json (${error instanceof Error ? error.message : String(error)})`,
+    )
+  }
+
+  return { allReleases, linkedGroups: parseLinkedGroups(configText) }
+}
+
+/**
+ * Best-effort lookup of each workspace package's current version, purely to
+ * enrich the failure message with an old -> new preview. Never throws — a
+ * missing/unreadable package.json just means that package's entry omits
+ * version info, since this is cosmetic, not part of the guard's correctness.
+ *
+ * @param {string} repoRoot
+ * @returns {Map<string, string>}
+ */
+function loadWorkspaceVersions(repoRoot) {
+  const versions = new Map()
+  for (const workspaceDir of ['packages', 'examples']) {
+    let entries
+    try {
+      entries = readdirSync(join(repoRoot, workspaceDir), { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      try {
+        const pkg = JSON.parse(
+          readFileSync(join(repoRoot, workspaceDir, entry.name, 'package.json'), 'utf8'),
+        )
+        if (typeof pkg.name === 'string' && typeof pkg.version === 'string') {
+          versions.set(pkg.name, pkg.version)
+        }
+      } catch {
+        // Best-effort only — skip packages without a readable/valid package.json.
+      }
+    }
+  }
+  return versions
+}
+
+function bumpMajorVersion(oldVersion) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(oldVersion)
+  return match ? `${String(Number(match[1]) + 1)}.0.0` : undefined
+}
+
+/**
+ * Resolve which packages would bump to `major`, enriched with an old -> new
+ * version preview where the current version is known.
+ *
+ * @param {{ allReleases: Array<{ name: string, type: string }>, linkedGroups: string[][] }} releaseState
+ * @param {Map<string, string>} [versions]
+ * @returns {Array<{ name: string, oldVersion?: string, newVersion?: string }>}
+ */
+export function findMajorBumps(releaseState, versions = new Map()) {
+  return computeMajorBumpPackages(releaseState.allReleases, releaseState.linkedGroups).map(
+    (name) => {
+      const oldVersion = versions.get(name)
+      const newVersion = oldVersion ? bumpMajorVersion(oldVersion) : undefined
+      return { name, oldVersion, newVersion }
+    },
+  )
 }
 
 /**
@@ -42,12 +234,16 @@ export function findMajorBumps(releasePlan) {
  * change justifies a 1.0 bump — the message exists to rebut that directly
  * and redirect to the correct action.
  *
- * @param {Array<{ name: string, oldVersion: string, newVersion: string }>} majorBumps
+ * @param {Array<{ name: string, oldVersion?: string, newVersion?: string }>} majorBumps
  * @returns {string}
  */
 export function formatFailureMessage(majorBumps) {
   const targets = majorBumps
-    .map((release) => `  - ${release.name}: ${release.oldVersion} -> ${release.newVersion}`)
+    .map((release) =>
+      release.oldVersion && release.newVersion
+        ? `  - ${release.name}: ${release.oldVersion} -> ${release.newVersion}`
+        : `  - ${release.name}`,
+    )
     .join('\n')
 
   return [
@@ -58,7 +254,7 @@ export function formatFailureMessage(majorBumps) {
     'how large, is NOT justification for a major/1.0 bump on its own. In the 0.x series,',
     'breaking changes are expected, and the correct way to express one is `minor`, not `major`.',
     '',
-    'The current changeset release plan computes a major bump for:',
+    'Pending changesets compute a major bump for:',
     '',
     targets,
     '',
@@ -78,84 +274,12 @@ export function formatFailureMessage(majorBumps) {
 }
 
 /**
- * Parse and shape-validate the JSON `changeset status --output` writes. This
- * never trusts the file blindly: a missing `releases` array, or a release
- * entry missing `name`/`type`, is treated the same as invalid JSON — all of
- * it means the plan can't be relied on.
- *
- * @param {string} rawText
- * @returns {{ releases: Array<{ name: string, type: string, oldVersion: string, newVersion: string }> }}
- */
-export function parseReleasePlanJson(rawText) {
-  let parsed
-  try {
-    parsed = JSON.parse(rawText)
-  } catch (error) {
-    throw new Error(
-      `release plan output is not valid JSON (${error instanceof Error ? error.message : String(error)})`,
-    )
-  }
-
-  if (parsed === null || typeof parsed !== 'object' || !Array.isArray(parsed.releases)) {
-    throw new Error('release plan JSON has no `releases` array')
-  }
-  for (const release of parsed.releases) {
-    if (typeof release?.name !== 'string' || typeof release?.type !== 'string') {
-      throw new Error('release plan JSON contains a release entry missing `name`/`type`')
-    }
-  }
-  return parsed
-}
-
-/**
- * Run `changeset status --output=<file>` and return the parsed, validated
- * release plan. `runChangesetStatus` is injectable so self-test can exercise
- * every indeterminate path (binary exits non-zero, output file never
- * written, output file empty/malformed) without shelling out for real.
- *
- * @param {{ repoRoot: string, runChangesetStatus?: (repoRoot: string, outFileRelative: string) => void }} params
- * @returns {{ releases: Array<{ name: string, type: string, oldVersion: string, newVersion: string }> }}
- */
-export function loadReleasePlan({ repoRoot, runChangesetStatus = runChangesetStatusForReal }) {
-  // `changeset status --output` resolves relative to `cwd`, so the arg and
-  // the path we read back must agree on that relative form.
-  const outFileRelative = join(
-    'tmp',
-    `major-bump-guard-${String(process.pid)}-${String(Date.now())}.json`,
-  )
-  const outFile = join(repoRoot, outFileRelative)
-  mkdirSync(join(repoRoot, 'tmp'), { recursive: true })
-  try {
-    runChangesetStatus(repoRoot, outFileRelative)
-
-    let rawText
-    try {
-      rawText = readFileSync(outFile, 'utf8')
-    } catch (error) {
-      throw new Error(
-        `release plan output file was not produced (${error instanceof Error ? error.message : String(error)})`,
-      )
-    }
-    return parseReleasePlanJson(rawText)
-  } finally {
-    rmSync(outFile, { force: true })
-  }
-}
-
-function runChangesetStatusForReal(repoRoot, outFileRelative) {
-  const changesetBin = join(repoRoot, 'node_modules', '.bin', 'changeset')
-  execFileSync(changesetBin, ['status', `--output=${outFileRelative}`], {
-    cwd: repoRoot,
-    stdio: ['ignore', 'ignore', 'inherit'],
-  })
-}
-
-/**
- * Build the message shown when the guard could not compute a release plan
- * at all — e.g. `changeset status` exited non-zero, or produced no/malformed
- * output. This must never be confused with "a major bump was found": it's
- * the opposite problem, an inability to certify anything either way, and it
- * must fail closed rather than silently pass with an empty major-bump list.
+ * Build the message shown when the guard could not read/parse the pending
+ * changesets at all — e.g. `.changeset/` is missing, `config.json` is
+ * unreadable or malformed, or a changeset file's front matter doesn't parse.
+ * This must never be confused with "a major bump was found": it's the
+ * opposite problem, an inability to certify anything either way, and it must
+ * fail closed rather than silently pass with an empty major-bump list.
  *
  * @param {unknown} error
  * @returns {string}
@@ -164,95 +288,109 @@ export function formatCouldNotVerifyMessage(error) {
   const reason = error instanceof Error ? error.message : String(error)
 
   return [
-    'Major version bump guard could not verify the release plan.',
+    'Major version bump guard could not verify the pending changesets.',
     '',
-    'This is NOT a report that a major bump was found. It means the guard was unable to',
-    'compute the changeset release plan at all, so it cannot certify that no major/1.0 bump',
-    'is present. An indeterminate result must be treated as a failure, not a pass — silently',
-    'passing here is exactly the failure mode this guard exists to prevent.',
+    'This is NOT a report that a major bump was found. It means the guard was unable to read',
+    'or parse .changeset/*.md and .changeset/config.json, so it cannot certify that no',
+    'major/1.0 bump is present. An indeterminate result must be treated as a failure, not a',
+    'pass — silently passing here is exactly the failure mode this guard exists to prevent.',
     '',
     `Reason: ${reason}`,
     '',
-    'Common causes: `changeset status` could not resolve the merge-base against the base',
-    'branch (e.g. a shallow git checkout with no local `main` ref/history available), the',
-    '`changeset` CLI is missing or crashed, or its JSON output was empty/malformed.',
-    '',
-    'Fix the underlying `changeset status` failure (see the reason above) and re-run this',
-    'check — do not bypass it based on this message alone.',
+    'Fix the underlying problem (see the reason above) and re-run this check — do not bypass',
+    'it based on this message alone.',
   ].join('\n')
 }
 
 function runRealCheck() {
   const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 
-  let releasePlan
+  let releaseState
   try {
-    releasePlan = loadReleasePlan({ repoRoot })
+    releaseState = loadReleaseState(repoRoot)
   } catch (error) {
     console.error(formatCouldNotVerifyMessage(error))
     process.exit(1)
   }
 
-  const majorBumps = findMajorBumps(releasePlan)
+  const majorBumps = findMajorBumps(releaseState, loadWorkspaceVersions(repoRoot))
 
   if (majorBumps.length > 0) {
     console.error(formatFailureMessage(majorBumps))
     process.exit(1)
   }
 
-  console.log('No major version bumps found in the computed changeset release plan.')
+  console.log('No major version bumps found across pending changesets (linked groups expanded).')
+}
+
+/**
+ * Write a fixture `.changeset/` directory (config.json + given changeset
+ * files) under a fresh scratch repo root, for self-test cases to run the
+ * real `loadReleaseState` against — not hand-built plan objects.
+ *
+ * @param {{ linked?: string[][], changesets: Record<string, string> }} fixture
+ * @returns {string} the scratch repo root
+ */
+function writeFixtureRepo({ linked = [], changesets }) {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'major-bump-guard-self-test-'))
+  const changesetDir = join(repoRoot, '.changeset')
+  mkdirSync(changesetDir, { recursive: true })
+  writeFileSync(join(changesetDir, 'config.json'), JSON.stringify({ linked }))
+  writeFileSync(join(changesetDir, 'README.md'), '# Changesets\n')
+  for (const [fileName, content] of Object.entries(changesets)) {
+    writeFileSync(join(changesetDir, fileName), content)
+  }
+  return repoRoot
 }
 
 function runSelfTest() {
-  const onlyMinorAndPatchPlan = {
-    releases: [
-      { name: '@attest-it/core', type: 'minor', oldVersion: '0.10.1', newVersion: '0.11.0' },
-      { name: '@attest-it/cli', type: 'minor', oldVersion: '0.10.1', newVersion: '0.11.0' },
-      { name: 'attest-it', type: 'minor', oldVersion: '0.10.1', newVersion: '0.11.0' },
-      {
-        name: '@attest-it/example-embedder',
-        type: 'patch',
-        oldVersion: '0.0.0',
-        newVersion: '0.0.1',
-      },
-      { name: '@attest-it/github-action', type: 'none', oldVersion: '0.0.1', newVersion: '0.0.1' },
-    ],
-  }
+  let failed = false
 
-  // Mirrors what `changeset status` actually reports for this repo's `linked`
-  // config: a `major` changeset on one package in the group propagates to
-  // every package in it, so the computed plan lists all three as `major`.
-  const linkedMajorPlan = {
-    releases: [
-      { name: '@attest-it/cli', type: 'major', oldVersion: '0.10.1', newVersion: '1.0.0' },
-      { name: 'attest-it', type: 'major', oldVersion: '0.10.1', newVersion: '1.0.0' },
-      { name: '@attest-it/core', type: 'major', oldVersion: '0.10.1', newVersion: '1.0.0' },
-      {
-        name: '@attest-it/example-embedder',
-        type: 'patch',
-        oldVersion: '0.0.0',
-        newVersion: '0.0.1',
-      },
-    ],
-  }
+  const linkedGroups = [['@attest-it/core', '@attest-it/cli', 'attest-it']]
 
-  const cases = [
+  const parsingCases = [
     {
-      name: 'plan with only minor/patch bumps passes',
-      plan: onlyMinorAndPatchPlan,
+      name: 'only minor/patch changesets: no major bumps',
+      fixture: {
+        linked: linkedGroups,
+        changesets: {
+          'a.md': "---\n'@attest-it/core': minor\n'@attest-it/cli': minor\n---\n\nsummary\n",
+          'b.md': "---\n'@attest-it/cli': patch\n---\n\nsummary\n",
+        },
+      },
       expectedNames: [],
     },
     {
-      name: 'plan with a major bump on a linked group is detected as affecting all linked packages',
-      plan: linkedMajorPlan,
-      expectedNames: ['@attest-it/cli', 'attest-it', '@attest-it/core'],
+      name: 'major on one linked package propagates to every linked package',
+      fixture: {
+        linked: linkedGroups,
+        changesets: {
+          'a.md': "---\n'@attest-it/core': major\n---\n\nbreaking change\n",
+        },
+      },
+      expectedNames: ['@attest-it/cli', '@attest-it/core', 'attest-it'],
+    },
+    {
+      name: 'major on an unlinked package does not propagate to unrelated packages',
+      fixture: {
+        linked: linkedGroups,
+        changesets: {
+          'a.md': "---\n'@attest-it/example-embedder': major\n---\n\nbreaking change\n",
+        },
+      },
+      expectedNames: ['@attest-it/example-embedder'],
     },
   ]
 
-  let failed = false
-  for (const testCase of cases) {
-    const majorBumps = findMajorBumps(testCase.plan)
-    const gotNames = majorBumps.map((r) => r.name)
+  for (const testCase of parsingCases) {
+    const repoRoot = writeFixtureRepo(testCase.fixture)
+    let gotNames
+    try {
+      const releaseState = loadReleaseState(repoRoot)
+      gotNames = computeMajorBumpPackages(releaseState.allReleases, releaseState.linkedGroups)
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true })
+    }
     const ok =
       gotNames.length === testCase.expectedNames.length &&
       testCase.expectedNames.every((name) => gotNames.includes(name))
@@ -262,76 +400,84 @@ function runSelfTest() {
     if (!ok) failed = true
   }
 
-  // Negative test: the failure message must name every offending package, not
-  // just report a bare exit code — the message is the deliverable (issue #154).
-  const message = formatFailureMessage(findMajorBumps(linkedMajorPlan))
+  // Negative test: the failure message must name every offending package.
+  const namedRepoRoot = writeFixtureRepo({
+    linked: linkedGroups,
+    changesets: { 'a.md': "---\n'@attest-it/core': major\n---\n\nbreaking change\n" },
+  })
+  let message
+  try {
+    const releaseState = loadReleaseState(namedRepoRoot)
+    message = formatFailureMessage(findMajorBumps(releaseState))
+  } finally {
+    rmSync(namedRepoRoot, { recursive: true, force: true })
+  }
   const namesAllPresent = ['@attest-it/cli', 'attest-it', '@attest-it/core'].every((name) =>
     message.includes(name),
   )
   console.log(`${namesAllPresent ? 'PASS' : 'FAIL'}: failure message names every offending package`)
   if (!namesAllPresent) failed = true
 
-  const mentions1_0 = message.includes('1.0')
-  console.log(`${mentions1_0 ? 'PASS' : 'FAIL'}: failure message names the 1.0 target`)
-  if (!mentions1_0) failed = true
-
   // Indeterminate paths: the guard must fail closed on each of these — never
-  // fall through to "no major bumps found" — and the failure must use the
-  // distinct could-not-verify message, not the major-bump-found message.
+  // fall through to "no major bumps found" — with the distinct
+  // could-not-verify message, not the major-bump-found message.
   const indeterminateCases = [
     {
-      name: 'changeset status exits non-zero',
-      runChangesetStatus: () => {
-        throw new Error('simulated: changeset status exited with code 1')
+      name: '.changeset directory is missing',
+      setup: () => mkdtempSync(join(tmpdir(), 'major-bump-guard-self-test-')),
+    },
+    {
+      name: '.changeset/config.json is missing',
+      setup: () => {
+        const repoRoot = mkdtempSync(join(tmpdir(), 'major-bump-guard-self-test-'))
+        mkdirSync(join(repoRoot, '.changeset'), { recursive: true })
+        writeFileSync(
+          join(repoRoot, '.changeset', 'a.md'),
+          "---\n'@attest-it/core': minor\n---\n\nsummary\n",
+        )
+        return repoRoot
       },
     },
     {
-      name: 'plan file is never written',
-      runChangesetStatus: () => {
-        // Succeeds but writes nothing — mirrors a `changeset` version that
-        // silently drops --output, or a permissions failure that doesn't throw.
+      name: '.changeset/config.json is malformed JSON',
+      setup: () => {
+        const repoRoot = writeFixtureRepo({ changesets: {} })
+        writeFileSync(join(repoRoot, '.changeset', 'config.json'), '{ not valid json')
+        return repoRoot
       },
     },
     {
-      name: 'plan file is empty',
-      runChangesetStatus: (repoRoot, outFileRelative) => {
-        writeFileSync(join(repoRoot, outFileRelative), '')
-      },
+      name: 'a changeset file has no front-matter delimiters',
+      setup: () =>
+        writeFixtureRepo({
+          linked: linkedGroups,
+          changesets: { 'a.md': 'not a changeset file at all\n' },
+        }),
     },
     {
-      name: 'plan file is malformed JSON',
-      runChangesetStatus: (repoRoot, outFileRelative) => {
-        writeFileSync(join(repoRoot, outFileRelative), '{ not valid json')
-      },
-    },
-    {
-      name: 'plan file is valid JSON but missing `releases`',
-      runChangesetStatus: (repoRoot, outFileRelative) => {
-        writeFileSync(join(repoRoot, outFileRelative), JSON.stringify({ changesets: [] }))
-      },
+      name: 'a changeset file has an unparseable front-matter line',
+      setup: () =>
+        writeFixtureRepo({
+          linked: linkedGroups,
+          changesets: { 'a.md': '---\nthis is not valid: : yaml: at all\n---\n\nsummary\n' },
+        }),
     },
   ]
 
   for (const testCase of indeterminateCases) {
-    const scratchRepoRoot = mkdtempSync(join(tmpdir(), 'major-bump-guard-self-test-'))
+    const repoRoot = testCase.setup()
     let threw = false
     let usedCouldNotVerifyMessage = false
     try {
-      loadReleasePlan({
-        repoRoot: scratchRepoRoot,
-        runChangesetStatus: testCase.runChangesetStatus,
-      })
+      loadReleaseState(repoRoot)
     } catch (error) {
       threw = true
-      // formatCouldNotVerifyMessage must be able to render this error without
-      // throwing itself, and the rendered message must be distinguishable
-      // from "a major bump was found".
       const message = formatCouldNotVerifyMessage(error)
       usedCouldNotVerifyMessage =
         message.includes('could not verify') &&
         !message.includes('Major version bump guard failed.')
     } finally {
-      rmSync(scratchRepoRoot, { recursive: true, force: true })
+      rmSync(repoRoot, { recursive: true, force: true })
     }
     const ok = threw && usedCouldNotVerifyMessage
     console.log(


### PR DESCRIPTION
## Summary

`attest-it` is published at `0.10.1` and stays in the `0.x` series deliberately — the API surface has not stabilized. Two pending changesets were annotated `major`, which (via the `linked` group in `.changeset/config.json`) would have propagated to `@attest-it/core`, `@attest-it/cli`, and `attest-it` and pushed the next release straight to `1.0.0` with no deliberate decision behind it.

- Adds `scripts/check-major-bump-guard.mjs`, which inspects the **computed** changeset release plan (via `changeset status --output`, honoring `linked` propagation) rather than grepping changeset front-matter, and fails with a message aimed at redirecting a `major` bump to `minor` (with the break described in the changeset body).
- Wires the guard into `.husky/pre-commit` (this repo had no committed hook file yet, so this establishes it) and as two new steps in CI (`ci.yml`), mirroring the existing `check-policy-ref-guard.mjs` self-test + real-check pattern.
- Re-annotates the two pending `major` changesets (`eliminate-legacy-config-generations`, `rename-fingerprint-options-fields`) to `minor`, preserving their bodies. The release plan now computes to `0.11.0`.
- Documents the `0.x` bump convention in `CONTRIBUTING.md` and points at the guard.

Refs #154

## Test plan

- [x] `pnpm run build`, `pnpm run check`, `pnpm run test` all pass
- [x] `node scripts/check-major-bump-guard.mjs --self-test` passes
- [x] `node scripts/check-major-bump-guard.mjs` exits 0 against the current tree (`changeset status` computes only `minor`/`patch`)
- [x] Manually verified the guard blocks a synthetic `major` changeset both via direct invocation and via the `pre-commit` hook, and that no commit lands when it fails
- [x] Manually verified `changeset status` computed `major` for all three linked packages before the re-annotation, and `0.11.0`/`minor` after